### PR TITLE
fix: don't add branch name to domain name on main

### DIFF
--- a/packages/infra/bin/infra.ts
+++ b/packages/infra/bin/infra.ts
@@ -29,7 +29,12 @@ const main = async () => {
     process.env.STACK_NAME ||
     strFromArr(["sl-ref-apps", app, sanitzedGitBranch], "-");
   const primaryDomain = strFromArr(
-    [app, sanitzedGitBranch, "apps", baseDomain],
+    [
+      app,
+      sanitzedGitBranch !== "main" && sanitzedGitBranch,
+      "apps",
+      baseDomain,
+    ],
     "."
   );
   const description = `${app} Skylark Reference App deployed via CDK`;


### PR DESCRIPTION
<!-- Enter a very brief description of change -->
<!-- Add any optional commentary which may help the code reviewer. -->
Fixes the main branch being deployed to `https://media.main.apps.skylark-dev.skylarkplatform.io/` (should be `https://media.apps.skylark-dev.skylarkplatform.io/`)

<!-- Please tick all relevant change types this PR commits -->
<!-- Delete non-relevant lines -->
* [x] Bugfix

