### PR TITLE
bugfix: Set Accept Language to en-gb

### DIFF
--- a/apps/media/hooks/useBrandWithSeasonBySlug.tsx
+++ b/apps/media/hooks/useBrandWithSeasonBySlug.tsx
@@ -92,7 +92,9 @@ export const brandWithSeasonFetcher = ([slug, deviceType]: [
     deviceTypes: [deviceType],
   });
 
-  return fetch(`${SKYLARK_API}/api/brands/?slug=${slug}&${apiQuery}`)
+  return fetch(`${SKYLARK_API}/api/brands/?slug=${slug}&${apiQuery}`, {
+    headers: { "Accept-Language": "en-gb" },
+  })
     .then((r) => r.json())
     .then(({ objects }: ApiMultipleEntertainmentObjects) => {
       if (!objects || objects.length === 0) {

--- a/apps/media/hooks/useHomepageSet.tsx
+++ b/apps/media/hooks/useHomepageSet.tsx
@@ -78,7 +78,8 @@ export const homepageSetFetcher = (
   });
 
   return fetch(
-    `${SKYLARK_API}/api/sets/?slug=${homepageSlug}&set_type_slug=homepage&${apiQuery}`
+    `${SKYLARK_API}/api/sets/?slug=${homepageSlug}&set_type_slug=homepage&${apiQuery}`,
+    { headers: { "Accept-Language": "en-gb" } }
   )
     .then((r) => r.json())
     .then(({ objects: [homepage] }: ApiMultipleEntertainmentObjects) =>

--- a/apps/media/hooks/useMoviesSet.tsx
+++ b/apps/media/hooks/useMoviesSet.tsx
@@ -34,7 +34,9 @@ export const moviesSetFetcher = (endpoint: string) => {
     fields,
   });
 
-  return fetch(`${SKYLARK_API}/api/${endpoint}/?${apiQuery}`)
+  return fetch(`${SKYLARK_API}/api/${endpoint}/?${apiQuery}`, {
+    headers: { "Accept-Language": "en-gb" },
+  })
     .then((r) => r.json())
     .then(({ objects: movies }: ApiMultipleEntertainmentObjects) =>
       movies.map((movie) => parseSkylarkObject(movie))

--- a/apps/media/hooks/useSingleObjectBySlug.tsx
+++ b/apps/media/hooks/useSingleObjectBySlug.tsx
@@ -86,7 +86,9 @@ const singleObjectFetcher = ([endpoint, slug]: [
   endpoint: string,
   slug: string
 ]) =>
-  fetch(`${SKYLARK_API}/api/${endpoint}/?slug=${slug}&${apiQuery}`)
+  fetch(`${SKYLARK_API}/api/${endpoint}/?slug=${slug}&${apiQuery}`, {
+    headers: { "Accept-Language": "en-gb" },
+  })
     .then((r) => r.json())
     .then(({ objects: [object] }: ApiMultipleEntertainmentObjects) =>
       parseSkylarkObject(object)


### PR DESCRIPTION
<!-- Enter a very brief description of change -->
<!-- Add any optional commentary which may help the code reviewer. -->
Some browsers are setting the `Accept-Language` request header, we need it to be hardcoded to `en-gb` as that is all we have content for at the moment.

<!-- Please tick all relevant change types this PR commits -->
<!-- Delete non-relevant lines -->
* [x] Bugfix

