### PR TITLE
fix: add removal policy for API Lambda

### DIFF
--- a/packages/infra/lib/stack.ts
+++ b/packages/infra/lib/stack.ts
@@ -50,5 +50,9 @@ export class SkylarkReferenceAppStack extends cdk.Stack {
     const defaultLambda = nextJsApp.defaultNextLambda.node
       .defaultChild as cdk.CfnResource;
     defaultLambda.applyRemovalPolicy(cdk.RemovalPolicy.RETAIN);
+    const apiLambda = nextJsApp.nextApiLambda?.node.defaultChild as
+      | cdk.CfnResource
+      | undefined;
+    apiLambda?.applyRemovalPolicy(cdk.RemovalPolicy.RETAIN);
   }
 }


### PR DESCRIPTION
<!-- Enter a very brief description of change -->
<!-- Add any optional commentary which may help the code reviewer. -->
Deletion fails because the API Lambda is a replicated function.
Related to https://github.com/ostmodern/skylark-reference-apps/pull/10

<!-- Please tick all relevant change types this PR commits -->
<!-- Delete non-relevant lines -->
* [x] Bugfix
