### PR TITLE
feat: Ability to connect Media Objects in Airtable to Workflow Service Assets

### DIFF
--- a/packages/ingestor/src/lib/skylark/create.ts
+++ b/packages/ingestor/src/lib/skylark/create.ts
@@ -769,9 +769,9 @@ export const connectExternallyCreatedAssetToMediaObject = async (
       );
       const assetParent = createdMediaObjects.find(
         ({ data_source_id }) => data_source_id === assetParentAirtableRecord?.id
-      ) as ApiEntertainmentObjectWithAirtableId;
+      );
 
-      if (asset?.parent_url === assetParent.self) {
+      if (!assetParent || asset?.parent_url === assetParent.self) {
         return {};
       }
 

--- a/packages/ingestor/src/lib/skylark/get.test.ts
+++ b/packages/ingestor/src/lib/skylark/get.test.ts
@@ -251,13 +251,13 @@ describe("skylark.get", () => {
   });
 
   describe("getSetItems", () => {
-    it("calls /api/sets/?set_type_slug=", async () => {
+    it("calls /api/cms-sets/?set_type_slug=", async () => {
       axiosRequest.mockResolvedValue({ data: {} });
       await getSetItems("set-1");
 
       expect(axiosRequest).toBeCalledWith(
         expect.objectContaining({
-          url: "https://skylarkplatform.io/api/sets/set-1/items/",
+          url: "https://skylarkplatform.io/api/cms-sets/set-1/items/",
         })
       );
     });

--- a/packages/ingestor/src/lib/skylark/get.ts
+++ b/packages/ingestor/src/lib/skylark/get.ts
@@ -114,11 +114,12 @@ export const getSetBySlug = async (
 
 /**
  * getSetItems - Gets the items for a set using its ID
+ * Uses the cms-sets endpoint so that dynamic objects are not expanded
  * @param setUid - Set ID
  * @returns set items
  */
 export const getSetItems = async (setUid: string) => {
-  const url = `/api/sets/${setUid}/items/`;
+  const url = `/api/cms-sets/${setUid}/items/`;
   const res = await authenticatedSkylarkRequest<{ objects?: ApiSetItem[] }>(
     url,
     {

--- a/packages/ingestor/src/lib/skylark/sets.test.ts
+++ b/packages/ingestor/src/lib/skylark/sets.test.ts
@@ -423,7 +423,7 @@ describe("skylark.sets", () => {
       expect(axiosRequest).toBeCalledTimes(5);
       expect(axiosRequest).toBeCalledWith(
         expect.objectContaining({
-          url: "https://skylarkplatform.io/api/sets/set_1/items/",
+          url: "https://skylarkplatform.io/api/cms-sets/set_1/items/",
           method: "GET",
         })
       );
@@ -462,7 +462,8 @@ describe("skylark.sets", () => {
 
       // Assert.
       expect(axiosRequest).toBeCalledTimes(5);
-      expect(axiosRequest).toBeCalledWith(
+      expect(axiosRequest).toHaveBeenNthCalledWith(
+        5,
         expect.objectContaining({
           url: "https://skylarkplatform.io/api/sets/set_1/items/",
           method: "POST",
@@ -488,7 +489,7 @@ describe("skylark.sets", () => {
             };
           }
 
-          if (url?.includes("/api/sets/set_1/items/")) {
+          if (url?.includes("/api/cms-sets/set_1/items/")) {
             return {
               data: {
                 objects: [
@@ -513,7 +514,8 @@ describe("skylark.sets", () => {
 
       // Assert.
       expect(axiosRequest).toBeCalledTimes(5);
-      expect(axiosRequest).toBeCalledWith(
+      expect(axiosRequest).toHaveBeenNthCalledWith(
+        5,
         expect.objectContaining({
           url: "https://skylarkplatform.io/api/sets/set_1/items/set_item_1/",
           method: "PUT",

--- a/packages/ingestor/src/main.ts
+++ b/packages/ingestor/src/main.ts
@@ -21,6 +21,7 @@ import {
   getResources,
   createOrUpdateAirtableObjectsInSkylarkWithParentsInSameTable,
   createTranslationsForObjects,
+  connectExternallyCreatedAssetToMediaObject,
 } from "./lib/skylark";
 import { getAllTables } from "./lib/airtable";
 import {
@@ -148,6 +149,18 @@ const createMediaObjects = async (airtable: Airtables, metadata: Metadata) => {
       metadata
     );
 
+  // eslint-disable-next-line no-console
+  console.log("Media objects created");
+
+  await connectExternallyCreatedAssetToMediaObject(
+    airtable.mediaObjects,
+    mediaObjects,
+    metadata
+  );
+
+  // eslint-disable-next-line no-console
+  console.log("Media objects linked to external assets");
+
   await createTranslationsForObjects(
     mediaObjects,
     airtable.translations.mediaObjects,
@@ -155,7 +168,7 @@ const createMediaObjects = async (airtable: Airtables, metadata: Metadata) => {
   );
 
   // eslint-disable-next-line no-console
-  console.log("Media objects created");
+  console.log("Media objects translated");
 
   return mediaObjects;
 };
@@ -210,6 +223,8 @@ const createAdditionalObjects = async (metadata: Metadata) => {
 
 const main = async () => {
   // eslint-disable-next-line no-console
+  console.time("Completed in:");
+  // eslint-disable-next-line no-console
   console.log(`Starting ingest to ${SKYLARK_API}`);
 
   const shouldCreateAdditionalObjects = process.env.CREATE_SETS === "true";
@@ -236,6 +251,8 @@ const main = async () => {
 
   await createAndUploadAssets(airtable.mediaObjects, mediaObjects);
 
+  // eslint-disable-next-line no-console
+  console.timeEnd("Completed in:");
   // eslint-disable-next-line no-console
   console.log("great success");
 };


### PR DESCRIPTION
<!-- Enter a very brief description of change -->
<!-- Add any optional commentary which may help the code reviewer. -->
- Adds functionality to the ingestor to use a `external_asset_data_source_id` field in the Media Objects Airtable to connect existing assets (that could have been added by the workflow-service) to objects created in Airtable using the asset's `data_source_id`.
- Fixes a bug in the ingestor concerned with adding Dynamic Objects to sets by using the `cms-sets` API.

<!-- Please tick all relevant change types this PR commits -->
<!-- Delete non-relevant lines -->
* [x] Bugfix
* [x] Feature

#### Jira
<!-- Line separated list of relevant Jira ticket links -->
https://ostmodern.atlassian.net/browse/SL-2227

