### PR TITLE
[SL-2227] bugfix: Use object self as URL for updating external assets

### DIFF
--- a/packages/ingestor/src/lib/skylark/create.test.ts
+++ b/packages/ingestor/src/lib/skylark/create.test.ts
@@ -1568,7 +1568,7 @@ describe("skylark.create", () => {
             {
               id: `PATCH-${externalAssetDataSourceId}-${episode.self}`,
               method: "PATCH",
-              url: `/api/assets/versions/data-source/${externalAssetDataSourceId}/`,
+              url: `/api/asset/asset-1`,
               data: JSON.stringify({
                 parent_url: episode.self,
                 schedule_urls: [metadata.schedules.always.self],

--- a/packages/ingestor/src/lib/skylark/create.ts
+++ b/packages/ingestor/src/lib/skylark/create.ts
@@ -785,7 +785,7 @@ export const connectExternallyCreatedAssetToMediaObject = async (
       return {
         id: `PATCH-${assetDataSourceId}-${assetParent.self}`,
         method: "PATCH",
-        url: `/api/assets/versions/data-source/${assetDataSourceId}/`,
+        url: asset.self,
         data: JSON.stringify(data),
       };
 


### PR DESCRIPTION
<!-- Enter a very brief description of change -->
<!-- Add any optional commentary which may help the code reviewer. -->
When adding a `parent_url` to externally created assets, we should use the asset `self` URL to update as the data source `PUT` clears the `ovps` array (removing links to the asset video) and `relationships` removing the image URLs.

Note: Tested on the countryline-prod environment

<!-- Please tick all relevant change types this PR commits -->
<!-- Delete non-relevant lines -->
* [x] Bugfix

#### Jira
<!-- Line separated list of relevant Jira ticket links -->
https://ostmodern.atlassian.net/browse/SL-2227


