### PR TITLE
feat: Fetch single object relationships separately to speed up time to load

### DIFF
--- a/apps/saas/hooks/useSingleObject.tsx
+++ b/apps/saas/hooks/useSingleObject.tsx
@@ -86,6 +86,7 @@ export const useSingleObject = <T extends GraphQLObjectTypes>(
     fetcher
   );
 
+  // Fetch simple metadata and relationships in separate requests to speed up time to interactive
   const { data: relationships, isError: relationshipsError } =
     useSingleObjectRelationships<T>(type, lookupValue);
 

--- a/apps/saas/hooks/useSingleObjectRelationships.tsx
+++ b/apps/saas/hooks/useSingleObjectRelationships.tsx
@@ -1,0 +1,168 @@
+import useSWR from "swr";
+import { jsonToGraphQLQuery } from "json-to-graphql-query";
+import {
+  graphQLClient,
+  Dimensions,
+  GraphQLObjectTypes,
+} from "@skylark-reference-apps/lib";
+import { useDimensions } from "@skylark-reference-apps/react";
+import { Brand, Episode, Movie, Season, Set } from "../types/gql";
+import { createGraphQLQueryDimensions } from "../lib/utils";
+
+type ObjectType<T> = T extends "Episode"
+  ? Episode
+  : T extends "Movie"
+  ? Movie
+  : T extends "Brand"
+  ? Brand
+  : T extends "Season"
+  ? Season
+  : T extends "Set"
+  ? Set
+  : never;
+
+const createGraphQLQuery = (
+  type: GraphQLObjectTypes,
+  lookupValue: string,
+  dimensions: Dimensions
+) => {
+  // Helper to use the external_id when an airtable record ID is given
+  const lookupField = lookupValue.startsWith("rec") ? "external_id" : "uid";
+
+  const fieldsToFetch: { [key: string]: boolean | object } = {};
+
+  if (["Episode", "Movie"].includes(type)) {
+    fieldsToFetch.credits = {
+      objects: {
+        character: true,
+        people: {
+          objects: {
+            name: true,
+          },
+        },
+        roles: {
+          objects: {
+            title: true,
+          },
+        },
+      },
+    };
+    fieldsToFetch.themes = {
+      objects: {
+        name: true,
+      },
+    };
+    fieldsToFetch.genres = {
+      objects: {
+        name: true,
+      },
+    };
+    fieldsToFetch.ratings = {
+      objects: {
+        value: true,
+      },
+    };
+  }
+
+  if (type === "Episode") {
+    fieldsToFetch.seasons = {
+      objects: {
+        season_number: true,
+        brands: {
+          objects: {
+            title_short: true,
+            title_medium: true,
+            title_long: true,
+          },
+        },
+      },
+    };
+  }
+
+  if (type === "Movie") {
+    fieldsToFetch.brands = {
+      objects: {
+        title_short: true,
+        title_medium: true,
+        title_long: true,
+      },
+    };
+  }
+
+  if (type === "Brand") {
+    fieldsToFetch.tags = {
+      objects: {
+        name: true,
+      },
+    };
+    fieldsToFetch.ratings = {
+      objects: {
+        value: true,
+      },
+    };
+    fieldsToFetch.seasons = {
+      objects: {
+        title_short: true,
+        title_medium: true,
+        title_long: true,
+        season_number: true,
+        number_of_episodes: true,
+        episodes: {
+          objects: {
+            uid: true,
+            episode_number: true,
+          },
+        },
+      },
+    };
+  }
+
+  const method = `get${type}`;
+
+  const queryAsJson = {
+    query: {
+      __name: method,
+      [method]: {
+        __args: {
+          [lookupField]: lookupValue,
+          ...createGraphQLQueryDimensions(dimensions),
+        },
+        ...fieldsToFetch,
+      },
+    },
+  };
+
+  const query = jsonToGraphQLQuery(queryAsJson);
+
+  return { query, method };
+};
+
+const fetcher = <T extends GraphQLObjectTypes>([
+  ,
+  type,
+  lookupValue,
+  dimensions,
+]: [key: string, type: T, lookupValue: string, dimensions: Dimensions]) => {
+  const { query, method } = createGraphQLQuery(type, lookupValue, dimensions);
+  return graphQLClient
+    .request<{ [key: string]: ObjectType<T> }>(query)
+    .then(({ [method]: data }): ObjectType<T> => data);
+};
+
+export const useSingleObjectRelationships = <T extends GraphQLObjectTypes>(
+  type: T,
+  lookupValue: string
+) => {
+  const { dimensions } = useDimensions();
+
+  const { data, error } = useSWR<ObjectType<T>, Error>(
+    [`${type}Relationships`, type, lookupValue, dimensions],
+    fetcher
+  );
+
+  return {
+    data,
+    isLoading: !error && !data,
+    isError: error,
+  };
+};

--- a/apps/saas/interfaces.ts
+++ b/apps/saas/interfaces.ts
@@ -1,0 +1,13 @@
+import { Brand, Episode, Movie, Season, Set } from "./types/gql";
+
+export type SingleObjectType<T> = T extends "Episode"
+  ? Episode
+  : T extends "Movie"
+  ? Movie
+  : T extends "Brand"
+  ? Brand
+  : T extends "Season"
+  ? Season
+  : T extends "Set"
+  ? Set
+  : never;

--- a/apps/saas/tests/hooks/useSingleObjectRelationships.test.tsx
+++ b/apps/saas/tests/hooks/useSingleObjectRelationships.test.tsx
@@ -5,7 +5,7 @@ import {
 import { renderHook, act } from "@testing-library/react-hooks";
 import { useSWRConfig } from "swr";
 
-import { useSingleObject } from "../../hooks/useSingleObject";
+import { useSingleObjectRelationships } from "../../hooks/useSingleObjectRelationships";
 
 jest.spyOn(graphQLClient, "request");
 
@@ -36,15 +36,13 @@ describe("useSingleObject", () => {
       graphQlRequest.mockResolvedValueOnce({ [method]: {} });
 
       const { waitForNextUpdate } = renderHook(() =>
-        useSingleObject(type as GraphQLMediaObjectTypes, "uid")
+        useSingleObjectRelationships(type as GraphQLMediaObjectTypes, "uid")
       );
 
       await waitForNextUpdate();
 
       expect(graphQlRequest).toBeCalledWith(
-        expect.stringContaining(`query ${method} { ${method} (uid: "uid"`),
-        {},
-        {}
+        expect.stringContaining(`query ${method} { ${method} (uid: "uid"`)
       );
     });
 
@@ -53,35 +51,13 @@ describe("useSingleObject", () => {
       graphQlRequest.mockResolvedValueOnce({ [method]: {} });
 
       const { waitForNextUpdate } = renderHook(() =>
-        useSingleObject(type as GraphQLMediaObjectTypes, "uid")
+        useSingleObjectRelationships(type as GraphQLMediaObjectTypes, "uid")
       );
 
       await waitForNextUpdate();
 
-      expect(graphQlRequest).toHaveBeenNthCalledWith(
-        1,
-        expect.stringContaining(
-          "{ __typename uid title slug title_short title_medium title_long synopsis_short synopsis_medium synopsis_long release_date"
-        ),
-        {},
-        {}
-      );
-    });
-
-    it(`makes a second request to fetch relationships when the type is ${type}`, async () => {
-      const method = `get${type}`;
-      graphQlRequest.mockResolvedValueOnce({ [method]: {} });
-
-      const { waitForNextUpdate } = renderHook(() =>
-        useSingleObject(type as GraphQLMediaObjectTypes, "uid")
-      );
-
-      await waitForNextUpdate();
-
-      expect(graphQlRequest).toHaveBeenCalledTimes(2);
-      expect(graphQlRequest).toHaveBeenNthCalledWith(
-        2,
-        expect.stringContaining("images { objects { title type url }")
+      expect(graphQlRequest).toBeCalledWith(
+        expect.stringContaining("{ images { objects { title type url } }")
       );
     });
   });
@@ -90,7 +66,7 @@ describe("useSingleObject", () => {
     graphQlRequest.mockResolvedValueOnce({ getEpisode: {} });
 
     const { waitForNextUpdate } = renderHook(() =>
-      useSingleObject("Episode", "reclskjdf")
+      useSingleObjectRelationships("Episode", "reclskjdf")
     );
 
     await waitForNextUpdate();
@@ -98,9 +74,7 @@ describe("useSingleObject", () => {
     expect(graphQlRequest).toBeCalledWith(
       expect.stringContaining(
         `query getEpisode { getEpisode (external_id: "reclskjdf"`
-      ),
-      {},
-      {}
+      )
     );
   });
 
@@ -108,7 +82,7 @@ describe("useSingleObject", () => {
     graphQlRequest.mockResolvedValueOnce({ getEpisode: {} });
 
     const { waitForNextUpdate } = renderHook(() =>
-      useSingleObject("Episode", "uid")
+      useSingleObjectRelationships("Episode", "uid")
     );
 
     await waitForNextUpdate();
@@ -116,36 +90,21 @@ describe("useSingleObject", () => {
     expect(graphQlRequest).toBeCalledWith(
       expect.stringContaining(
         "credits { objects { character people { objects { name } } roles { objects { title } } } }"
-      ),
-      {},
-      {}
+      )
     );
     expect(graphQlRequest).toBeCalledWith(
-      expect.stringContaining("themes { objects { name } }"),
-      {},
-      {}
+      expect.stringContaining("themes { objects { name } }")
     );
     expect(graphQlRequest).toBeCalledWith(
-      expect.stringContaining("genres { objects { name } }"),
-      {},
-      {}
+      expect.stringContaining("genres { objects { name } }")
     );
     expect(graphQlRequest).toBeCalledWith(
-      expect.stringContaining("ratings { objects { value } }"),
-      {},
-      {}
-    );
-    expect(graphQlRequest).toBeCalledWith(
-      expect.stringContaining("episode_number"),
-      {},
-      {}
+      expect.stringContaining("ratings { objects { value } }")
     );
     expect(graphQlRequest).toBeCalledWith(
       expect.stringContaining(
         "seasons { objects { season_number brands { objects { title_short title_medium title_long } } } }"
-      ),
-      {},
-      {}
+      )
     );
   });
 
@@ -153,7 +112,7 @@ describe("useSingleObject", () => {
     graphQlRequest.mockResolvedValueOnce({ getMovie: {} });
 
     const { waitForNextUpdate } = renderHook(() =>
-      useSingleObject("Movie", "uid")
+      useSingleObjectRelationships("Movie", "uid")
     );
 
     await waitForNextUpdate();
@@ -161,31 +120,21 @@ describe("useSingleObject", () => {
     expect(graphQlRequest).toBeCalledWith(
       expect.stringContaining(
         "credits { objects { character people { objects { name } } roles { objects { title } } } }"
-      ),
-      {},
-      {}
+      )
     );
     expect(graphQlRequest).toBeCalledWith(
-      expect.stringContaining("themes { objects { name } }"),
-      {},
-      {}
+      expect.stringContaining("themes { objects { name } }")
     );
     expect(graphQlRequest).toBeCalledWith(
-      expect.stringContaining("genres { objects { name } }"),
-      {},
-      {}
+      expect.stringContaining("genres { objects { name } }")
     );
     expect(graphQlRequest).toBeCalledWith(
-      expect.stringContaining("ratings { objects { value } }"),
-      {},
-      {}
+      expect.stringContaining("ratings { objects { value } }")
     );
     expect(graphQlRequest).toBeCalledWith(
       expect.stringContaining(
         "brands { objects { title_short title_medium title_long } }"
-      ),
-      {},
-      {}
+      )
     );
   });
 
@@ -193,22 +142,18 @@ describe("useSingleObject", () => {
     graphQlRequest.mockResolvedValueOnce({ getBrand: {} });
 
     const { waitForNextUpdate } = renderHook(() =>
-      useSingleObject("Brand", "uid")
+      useSingleObjectRelationships("Brand", "uid")
     );
 
     await waitForNextUpdate();
 
     expect(graphQlRequest).toBeCalledWith(
-      expect.stringContaining("tags { objects { name } }"),
-      {},
-      {}
+      expect.stringContaining("tags { objects { name } }")
     );
     expect(graphQlRequest).toBeCalledWith(
       expect.stringContaining(
         "seasons { objects { title_short title_medium title_long season_number number_of_episodes episodes { objects { uid episode_number } } } }"
-      ),
-      {},
-      {}
+      )
     );
   });
 
@@ -217,25 +162,11 @@ describe("useSingleObject", () => {
     graphQlRequest.mockRejectedValueOnce(err);
 
     const { result, waitForNextUpdate } = renderHook(() =>
-      useSingleObject("Episode", "123")
+      useSingleObjectRelationships("Episode", "123")
     );
 
     await waitForNextUpdate();
 
-    expect(result.current.isError).toBe(err);
-  });
-
-  it("sets isNotFound to true when the error contains not found", async () => {
-    const err = new Error("error not found");
-    graphQlRequest.mockRejectedValueOnce(err);
-
-    const { result, waitForNextUpdate } = renderHook(() =>
-      useSingleObject("Episode", "123")
-    );
-
-    await waitForNextUpdate();
-
-    expect(result.current.isNotFound).toBe(true);
     expect(result.current.isError).toBe(err);
   });
 });

--- a/apps/saas/types/gql.ts
+++ b/apps/saas/types/gql.ts
@@ -3,15 +3,9 @@
 /* eslint-disable */
 export type Maybe<T> = T | null;
 export type InputMaybe<T> = Maybe<T>;
-export type Exact<T extends { [key: string]: unknown }> = {
-  [K in keyof T]: T[K];
-};
-export type MakeOptional<T, K extends keyof T> = Omit<T, K> & {
-  [SubKey in K]?: Maybe<T[SubKey]>;
-};
-export type MakeMaybe<T, K extends keyof T> = Omit<T, K> & {
-  [SubKey in K]: Maybe<T[SubKey]>;
-};
+export type Exact<T extends { [key: string]: unknown }> = { [K in keyof T]: T[K] };
+export type MakeOptional<T, K extends keyof T> = Omit<T, K> & { [SubKey in K]?: Maybe<T[SubKey]> };
+export type MakeMaybe<T, K extends keyof T> = Omit<T, K> & { [SubKey in K]: Maybe<T[SubKey]> };
 /** All built-in and custom scalars, mapped to their actual values */
 export type Scalars = {
   ID: string;
@@ -23,72 +17,77 @@ export type Scalars = {
 };
 
 export type Asset = Metadata & {
-  __typename?: "Asset";
+  __typename?: 'Asset';
   _meta?: Maybe<_AssetMeta>;
   availability?: Maybe<AvailabilityListing>;
-  external_id?: Maybe<Scalars["String"]>;
+  external_id?: Maybe<Scalars['String']>;
   images?: Maybe<ImageListing>;
   parental_guidance?: Maybe<ParentalGuidanceListing>;
   parents?: Maybe<EntertainmentListing>;
-  slug?: Maybe<Scalars["String"]>;
-  title?: Maybe<Scalars["String"]>;
-  type: Scalars["String"];
-  uid: Scalars["String"];
-  url?: Maybe<Scalars["String"]>;
+  slug?: Maybe<Scalars['String']>;
+  title?: Maybe<Scalars['String']>;
+  type: Scalars['String'];
+  uid: Scalars['String'];
+  url?: Maybe<Scalars['String']>;
 };
+
 
 export type Asset_MetaArgs = {
-  global_version?: InputMaybe<Scalars["Int"]>;
-  language?: InputMaybe<Scalars["String"]>;
-  language_version?: InputMaybe<Scalars["Int"]>;
+  global_version?: InputMaybe<Scalars['Int']>;
+  language?: InputMaybe<Scalars['String']>;
+  language_version?: InputMaybe<Scalars['Int']>;
 };
+
 
 export type AssetAvailabilityArgs = {
-  limit?: InputMaybe<Scalars["Int"]>;
-  next_token?: InputMaybe<Scalars["String"]>;
+  limit?: InputMaybe<Scalars['Int']>;
+  next_token?: InputMaybe<Scalars['String']>;
 };
+
 
 export type AssetImagesArgs = {
-  language?: InputMaybe<Scalars["String"]>;
-  limit?: InputMaybe<Scalars["Int"]>;
-  next_token?: InputMaybe<Scalars["String"]>;
+  language?: InputMaybe<Scalars['String']>;
+  limit?: InputMaybe<Scalars['Int']>;
+  next_token?: InputMaybe<Scalars['String']>;
 };
+
 
 export type AssetParental_GuidanceArgs = {
-  language?: InputMaybe<Scalars["String"]>;
-  limit?: InputMaybe<Scalars["Int"]>;
-  next_token?: InputMaybe<Scalars["String"]>;
+  language?: InputMaybe<Scalars['String']>;
+  limit?: InputMaybe<Scalars['Int']>;
+  next_token?: InputMaybe<Scalars['String']>;
 };
 
+
 export type AssetParentsArgs = {
-  language?: InputMaybe<Scalars["String"]>;
-  limit?: InputMaybe<Scalars["Int"]>;
-  next_token?: InputMaybe<Scalars["String"]>;
+  language?: InputMaybe<Scalars['String']>;
+  limit?: InputMaybe<Scalars['Int']>;
+  next_token?: InputMaybe<Scalars['String']>;
 };
 
 export type AssetInput = {
   availability?: InputMaybe<AssignAvailabilityInput>;
-  data_source_fields?: InputMaybe<Array<InputMaybe<Scalars["String"]>>>;
-  data_source_id?: InputMaybe<Scalars["String"]>;
-  external_id?: InputMaybe<Scalars["String"]>;
+  data_source_fields?: InputMaybe<Array<InputMaybe<Scalars['String']>>>;
+  data_source_id?: InputMaybe<Scalars['String']>;
+  external_id?: InputMaybe<Scalars['String']>;
   relationships?: InputMaybe<AssetRelationships>;
-  slug?: InputMaybe<Scalars["String"]>;
-  title?: InputMaybe<Scalars["String"]>;
+  slug?: InputMaybe<Scalars['String']>;
+  title?: InputMaybe<Scalars['String']>;
   type?: InputMaybe<AssetType>;
-  url?: InputMaybe<Scalars["String"]>;
+  url?: InputMaybe<Scalars['String']>;
 };
 
 export type AssetListing = Listing & {
-  __typename?: "AssetListing";
-  count?: Maybe<Scalars["Int"]>;
-  next_token?: Maybe<Scalars["String"]>;
+  __typename?: 'AssetListing';
+  count?: Maybe<Scalars['Int']>;
+  next_token?: Maybe<Scalars['String']>;
   objects?: Maybe<Array<Maybe<Asset>>>;
 };
 
 export type AssetRelationshipInput = {
   create?: InputMaybe<Array<InputMaybe<AssetInput>>>;
-  link?: InputMaybe<Array<InputMaybe<Scalars["String"]>>>;
-  unlink?: InputMaybe<Array<InputMaybe<Scalars["String"]>>>;
+  link?: InputMaybe<Array<InputMaybe<Scalars['String']>>>;
+  unlink?: InputMaybe<Array<InputMaybe<Scalars['String']>>>;
 };
 
 export type AssetRelationships = {
@@ -97,182 +96,194 @@ export type AssetRelationships = {
 };
 
 export enum AssetType {
-  Main = "MAIN",
-  Trailer = "TRAILER",
+  Main = 'MAIN',
+  Trailer = 'TRAILER'
 }
 
 export type AssignAvailabilityInput = {
   create?: InputMaybe<Array<InputMaybe<AvailabilityInput>>>;
-  link?: InputMaybe<Array<InputMaybe<Scalars["String"]>>>;
-  unlink?: InputMaybe<Array<InputMaybe<Scalars["String"]>>>;
+  link?: InputMaybe<Array<InputMaybe<Scalars['String']>>>;
+  unlink?: InputMaybe<Array<InputMaybe<Scalars['String']>>>;
 };
 
 export type AssignDimensionInput = {
-  dimension_slug?: InputMaybe<Scalars["String"]>;
-  value_slugs?: InputMaybe<Array<InputMaybe<Scalars["String"]>>>;
+  dimension_slug?: InputMaybe<Scalars['String']>;
+  value_slugs?: InputMaybe<Array<InputMaybe<Scalars['String']>>>;
 };
 
 export type Availability = {
-  __typename?: "Availability";
+  __typename?: 'Availability';
   _meta?: Maybe<_AvailabilityMeta>;
   dimensions?: Maybe<Array<Maybe<DimensionAssigned>>>;
-  end?: Maybe<Scalars["AWSDateTime"]>;
-  external_id?: Maybe<Scalars["String"]>;
-  slug?: Maybe<Scalars["String"]>;
-  start?: Maybe<Scalars["AWSDateTime"]>;
-  title?: Maybe<Scalars["String"]>;
-  uid?: Maybe<Scalars["String"]>;
+  end?: Maybe<Scalars['AWSDateTime']>;
+  external_id?: Maybe<Scalars['String']>;
+  slug?: Maybe<Scalars['String']>;
+  start?: Maybe<Scalars['AWSDateTime']>;
+  title?: Maybe<Scalars['String']>;
+  uid?: Maybe<Scalars['String']>;
 };
 
 export type AvailabilityInput = {
   dimensions?: InputMaybe<Array<InputMaybe<AssignDimensionInput>>>;
-  end?: InputMaybe<Scalars["AWSDateTime"]>;
-  external_id?: InputMaybe<Scalars["String"]>;
-  slug?: InputMaybe<Scalars["String"]>;
-  start?: InputMaybe<Scalars["AWSDateTime"]>;
-  title?: InputMaybe<Scalars["String"]>;
+  end?: InputMaybe<Scalars['AWSDateTime']>;
+  external_id?: InputMaybe<Scalars['String']>;
+  slug?: InputMaybe<Scalars['String']>;
+  start?: InputMaybe<Scalars['AWSDateTime']>;
+  title?: InputMaybe<Scalars['String']>;
 };
 
 export type AvailabilityListing = {
-  __typename?: "AvailabilityListing";
-  count?: Maybe<Scalars["Int"]>;
-  next_token?: Maybe<Scalars["String"]>;
+  __typename?: 'AvailabilityListing';
+  count?: Maybe<Scalars['Int']>;
+  next_token?: Maybe<Scalars['String']>;
   objects?: Maybe<Array<Maybe<Availability>>>;
 };
 
-export type Brand = CurationMetadata &
-  Entertainment & {
-    __typename?: "Brand";
-    _meta?: Maybe<_BrandMeta>;
-    assets?: Maybe<AssetListing>;
-    availability?: Maybe<AvailabilityListing>;
-    credits?: Maybe<CreditListing>;
-    episodes?: Maybe<EpisodeListing>;
-    external_id?: Maybe<Scalars["String"]>;
-    genres?: Maybe<GenreListing>;
-    images?: Maybe<ImageListing>;
-    movies?: Maybe<MovieListing>;
-    ratings?: Maybe<RatingListing>;
-    release_date?: Maybe<Scalars["String"]>;
-    seasons?: Maybe<SeasonListing>;
-    sets?: Maybe<SetListing>;
-    slug?: Maybe<Scalars["String"]>;
-    synopsis_long?: Maybe<Scalars["String"]>;
-    synopsis_medium?: Maybe<Scalars["String"]>;
-    synopsis_short?: Maybe<Scalars["String"]>;
-    tags?: Maybe<TagListing>;
-    themes?: Maybe<ThemeListing>;
-    title?: Maybe<Scalars["String"]>;
-    title_long?: Maybe<Scalars["String"]>;
-    title_medium?: Maybe<Scalars["String"]>;
-    title_short?: Maybe<Scalars["String"]>;
-    uid: Scalars["String"];
-  };
+export type Brand = CurationMetadata & Entertainment & {
+  __typename?: 'Brand';
+  _meta?: Maybe<_BrandMeta>;
+  assets?: Maybe<AssetListing>;
+  availability?: Maybe<AvailabilityListing>;
+  credits?: Maybe<CreditListing>;
+  episodes?: Maybe<EpisodeListing>;
+  external_id?: Maybe<Scalars['String']>;
+  genres?: Maybe<GenreListing>;
+  images?: Maybe<ImageListing>;
+  movies?: Maybe<MovieListing>;
+  ratings?: Maybe<RatingListing>;
+  release_date?: Maybe<Scalars['String']>;
+  seasons?: Maybe<SeasonListing>;
+  sets?: Maybe<SetListing>;
+  slug?: Maybe<Scalars['String']>;
+  synopsis_long?: Maybe<Scalars['String']>;
+  synopsis_medium?: Maybe<Scalars['String']>;
+  synopsis_short?: Maybe<Scalars['String']>;
+  tags?: Maybe<TagListing>;
+  themes?: Maybe<ThemeListing>;
+  title?: Maybe<Scalars['String']>;
+  title_long?: Maybe<Scalars['String']>;
+  title_medium?: Maybe<Scalars['String']>;
+  title_short?: Maybe<Scalars['String']>;
+  uid: Scalars['String'];
+};
+
 
 export type Brand_MetaArgs = {
-  global_version?: InputMaybe<Scalars["Int"]>;
-  language?: InputMaybe<Scalars["String"]>;
-  language_version?: InputMaybe<Scalars["Int"]>;
+  global_version?: InputMaybe<Scalars['Int']>;
+  language?: InputMaybe<Scalars['String']>;
+  language_version?: InputMaybe<Scalars['Int']>;
 };
+
 
 export type BrandAssetsArgs = {
-  language?: InputMaybe<Scalars["String"]>;
-  limit?: InputMaybe<Scalars["Int"]>;
-  next_token?: InputMaybe<Scalars["String"]>;
+  language?: InputMaybe<Scalars['String']>;
+  limit?: InputMaybe<Scalars['Int']>;
+  next_token?: InputMaybe<Scalars['String']>;
 };
+
 
 export type BrandAvailabilityArgs = {
-  limit?: InputMaybe<Scalars["Int"]>;
-  next_token?: InputMaybe<Scalars["String"]>;
+  limit?: InputMaybe<Scalars['Int']>;
+  next_token?: InputMaybe<Scalars['String']>;
 };
+
 
 export type BrandCreditsArgs = {
-  language?: InputMaybe<Scalars["String"]>;
-  limit?: InputMaybe<Scalars["Int"]>;
-  next_token?: InputMaybe<Scalars["String"]>;
+  language?: InputMaybe<Scalars['String']>;
+  limit?: InputMaybe<Scalars['Int']>;
+  next_token?: InputMaybe<Scalars['String']>;
 };
+
 
 export type BrandEpisodesArgs = {
-  language?: InputMaybe<Scalars["String"]>;
-  limit?: InputMaybe<Scalars["Int"]>;
-  next_token?: InputMaybe<Scalars["String"]>;
+  language?: InputMaybe<Scalars['String']>;
+  limit?: InputMaybe<Scalars['Int']>;
+  next_token?: InputMaybe<Scalars['String']>;
 };
+
 
 export type BrandGenresArgs = {
-  language?: InputMaybe<Scalars["String"]>;
-  limit?: InputMaybe<Scalars["Int"]>;
-  next_token?: InputMaybe<Scalars["String"]>;
+  language?: InputMaybe<Scalars['String']>;
+  limit?: InputMaybe<Scalars['Int']>;
+  next_token?: InputMaybe<Scalars['String']>;
 };
+
 
 export type BrandImagesArgs = {
-  language?: InputMaybe<Scalars["String"]>;
-  limit?: InputMaybe<Scalars["Int"]>;
-  next_token?: InputMaybe<Scalars["String"]>;
+  language?: InputMaybe<Scalars['String']>;
+  limit?: InputMaybe<Scalars['Int']>;
+  next_token?: InputMaybe<Scalars['String']>;
 };
+
 
 export type BrandMoviesArgs = {
-  language?: InputMaybe<Scalars["String"]>;
-  limit?: InputMaybe<Scalars["Int"]>;
-  next_token?: InputMaybe<Scalars["String"]>;
+  language?: InputMaybe<Scalars['String']>;
+  limit?: InputMaybe<Scalars['Int']>;
+  next_token?: InputMaybe<Scalars['String']>;
 };
+
 
 export type BrandRatingsArgs = {
-  language?: InputMaybe<Scalars["String"]>;
-  limit?: InputMaybe<Scalars["Int"]>;
-  next_token?: InputMaybe<Scalars["String"]>;
+  language?: InputMaybe<Scalars['String']>;
+  limit?: InputMaybe<Scalars['Int']>;
+  next_token?: InputMaybe<Scalars['String']>;
 };
+
 
 export type BrandSeasonsArgs = {
-  language?: InputMaybe<Scalars["String"]>;
-  limit?: InputMaybe<Scalars["Int"]>;
-  next_token?: InputMaybe<Scalars["String"]>;
+  language?: InputMaybe<Scalars['String']>;
+  limit?: InputMaybe<Scalars['Int']>;
+  next_token?: InputMaybe<Scalars['String']>;
 };
+
 
 export type BrandSetsArgs = {
-  limit?: InputMaybe<Scalars["Int"]>;
-  next_token?: InputMaybe<Scalars["String"]>;
+  limit?: InputMaybe<Scalars['Int']>;
+  next_token?: InputMaybe<Scalars['String']>;
 };
+
 
 export type BrandTagsArgs = {
-  language?: InputMaybe<Scalars["String"]>;
-  limit?: InputMaybe<Scalars["Int"]>;
-  next_token?: InputMaybe<Scalars["String"]>;
+  language?: InputMaybe<Scalars['String']>;
+  limit?: InputMaybe<Scalars['Int']>;
+  next_token?: InputMaybe<Scalars['String']>;
 };
 
+
 export type BrandThemesArgs = {
-  language?: InputMaybe<Scalars["String"]>;
-  limit?: InputMaybe<Scalars["Int"]>;
-  next_token?: InputMaybe<Scalars["String"]>;
+  language?: InputMaybe<Scalars['String']>;
+  limit?: InputMaybe<Scalars['Int']>;
+  next_token?: InputMaybe<Scalars['String']>;
 };
 
 export type BrandInput = {
   availability?: InputMaybe<AssignAvailabilityInput>;
-  data_source_fields?: InputMaybe<Array<InputMaybe<Scalars["String"]>>>;
-  data_source_id?: InputMaybe<Scalars["String"]>;
-  external_id?: InputMaybe<Scalars["String"]>;
+  data_source_fields?: InputMaybe<Array<InputMaybe<Scalars['String']>>>;
+  data_source_id?: InputMaybe<Scalars['String']>;
+  external_id?: InputMaybe<Scalars['String']>;
   relationships?: InputMaybe<BrandRelationships>;
-  release_date?: InputMaybe<Scalars["String"]>;
-  slug?: InputMaybe<Scalars["String"]>;
-  synopsis_long?: InputMaybe<Scalars["String"]>;
-  synopsis_medium?: InputMaybe<Scalars["String"]>;
-  synopsis_short?: InputMaybe<Scalars["String"]>;
-  title?: InputMaybe<Scalars["String"]>;
-  title_long?: InputMaybe<Scalars["String"]>;
-  title_medium?: InputMaybe<Scalars["String"]>;
-  title_short?: InputMaybe<Scalars["String"]>;
+  release_date?: InputMaybe<Scalars['String']>;
+  slug?: InputMaybe<Scalars['String']>;
+  synopsis_long?: InputMaybe<Scalars['String']>;
+  synopsis_medium?: InputMaybe<Scalars['String']>;
+  synopsis_short?: InputMaybe<Scalars['String']>;
+  title?: InputMaybe<Scalars['String']>;
+  title_long?: InputMaybe<Scalars['String']>;
+  title_medium?: InputMaybe<Scalars['String']>;
+  title_short?: InputMaybe<Scalars['String']>;
 };
 
 export type BrandListing = Listing & {
-  __typename?: "BrandListing";
-  count?: Maybe<Scalars["Int"]>;
-  next_token?: Maybe<Scalars["String"]>;
+  __typename?: 'BrandListing';
+  count?: Maybe<Scalars['Int']>;
+  next_token?: Maybe<Scalars['String']>;
   objects?: Maybe<Array<Maybe<Brand>>>;
 };
 
 export type BrandRelationshipInput = {
   create?: InputMaybe<Array<InputMaybe<BrandInput>>>;
-  link?: InputMaybe<Array<InputMaybe<Scalars["String"]>>>;
-  unlink?: InputMaybe<Array<InputMaybe<Scalars["String"]>>>;
+  link?: InputMaybe<Array<InputMaybe<Scalars['String']>>>;
+  unlink?: InputMaybe<Array<InputMaybe<Scalars['String']>>>;
 };
 
 export type BrandRelationships = {
@@ -291,79 +302,83 @@ export type BrandRelationships = {
 
 export type BrandSetCreate = {
   object?: InputMaybe<BrandInput>;
-  position: Scalars["Int"];
+  position: Scalars['Int'];
 };
 
 export type BrandSetInput = {
   create?: InputMaybe<Array<InputMaybe<BrandSetCreate>>>;
   link?: InputMaybe<Array<InputMaybe<SetLink>>>;
   reposition?: InputMaybe<Array<InputMaybe<SetLink>>>;
-  unlink?: InputMaybe<Array<InputMaybe<Scalars["String"]>>>;
+  unlink?: InputMaybe<Array<InputMaybe<Scalars['String']>>>;
 };
 
 export type CountResponse = {
-  __typename?: "CountResponse";
-  count?: Maybe<Scalars["Int"]>;
+  __typename?: 'CountResponse';
+  count?: Maybe<Scalars['Int']>;
 };
 
 export type Credit = Metadata & {
-  __typename?: "Credit";
+  __typename?: 'Credit';
   _meta?: Maybe<_CreditMeta>;
   availability?: Maybe<AvailabilityListing>;
-  character?: Maybe<Scalars["String"]>;
-  external_id?: Maybe<Scalars["String"]>;
+  character?: Maybe<Scalars['String']>;
+  external_id?: Maybe<Scalars['String']>;
   people?: Maybe<PersonListing>;
-  position?: Maybe<Scalars["Int"]>;
+  position?: Maybe<Scalars['Int']>;
   roles?: Maybe<RoleListing>;
-  slug?: Maybe<Scalars["String"]>;
-  uid: Scalars["String"];
+  slug?: Maybe<Scalars['String']>;
+  uid: Scalars['String'];
 };
+
 
 export type Credit_MetaArgs = {
-  global_version?: InputMaybe<Scalars["Int"]>;
-  language?: InputMaybe<Scalars["String"]>;
-  language_version?: InputMaybe<Scalars["Int"]>;
+  global_version?: InputMaybe<Scalars['Int']>;
+  language?: InputMaybe<Scalars['String']>;
+  language_version?: InputMaybe<Scalars['Int']>;
 };
+
 
 export type CreditAvailabilityArgs = {
-  limit?: InputMaybe<Scalars["Int"]>;
-  next_token?: InputMaybe<Scalars["String"]>;
+  limit?: InputMaybe<Scalars['Int']>;
+  next_token?: InputMaybe<Scalars['String']>;
 };
+
 
 export type CreditPeopleArgs = {
-  language?: InputMaybe<Scalars["String"]>;
-  limit?: InputMaybe<Scalars["Int"]>;
-  next_token?: InputMaybe<Scalars["String"]>;
+  language?: InputMaybe<Scalars['String']>;
+  limit?: InputMaybe<Scalars['Int']>;
+  next_token?: InputMaybe<Scalars['String']>;
 };
 
+
 export type CreditRolesArgs = {
-  language?: InputMaybe<Scalars["String"]>;
-  limit?: InputMaybe<Scalars["Int"]>;
-  next_token?: InputMaybe<Scalars["String"]>;
+  language?: InputMaybe<Scalars['String']>;
+  limit?: InputMaybe<Scalars['Int']>;
+  next_token?: InputMaybe<Scalars['String']>;
 };
 
 export type CreditInput = {
   availability?: InputMaybe<AssignAvailabilityInput>;
-  character?: InputMaybe<Scalars["String"]>;
-  data_source_fields?: InputMaybe<Array<InputMaybe<Scalars["String"]>>>;
-  data_source_id?: InputMaybe<Scalars["String"]>;
-  external_id?: InputMaybe<Scalars["String"]>;
-  position?: InputMaybe<Scalars["Int"]>;
+  character?: InputMaybe<Scalars['String']>;
+  data_source_fields?: InputMaybe<Array<InputMaybe<Scalars['String']>>>;
+  data_source_id?: InputMaybe<Scalars['String']>;
+  external_id?: InputMaybe<Scalars['String']>;
+  position?: InputMaybe<Scalars['Int']>;
   relationships?: InputMaybe<CreditRelationships>;
-  slug?: InputMaybe<Scalars["String"]>;
+  slug?: InputMaybe<Scalars['String']>;
 };
 
 export type CreditListing = Listing & {
-  __typename?: "CreditListing";
-  count?: Maybe<Scalars["Int"]>;
-  next_token?: Maybe<Scalars["String"]>;
+  __typename?: 'CreditListing';
+  count?: Maybe<Scalars['Int']>;
+  next_token?: Maybe<Scalars['String']>;
   objects?: Maybe<Array<Maybe<Credit>>>;
 };
 
 export type CreditRelationshipInput = {
   create?: InputMaybe<Array<InputMaybe<CreditInput>>>;
-  link?: InputMaybe<Array<InputMaybe<Scalars["String"]>>>;
-  unlink?: InputMaybe<Array<InputMaybe<Scalars["String"]>>>;
+  link?: InputMaybe<Array<InputMaybe<Scalars['String']>>>;
+  unlink?: InputMaybe<Array<InputMaybe<Scalars['String']>>>;
 };
 
 export type CreditRelationships = {
@@ -372,60 +387,62 @@ export type CreditRelationships = {
 };
 
 export type CurationMetadata = {
-  external_id?: Maybe<Scalars["String"]>;
+  external_id?: Maybe<Scalars['String']>;
   sets?: Maybe<SetListing>;
-  slug?: Maybe<Scalars["String"]>;
-  uid: Scalars["String"];
+  slug?: Maybe<Scalars['String']>;
+  uid: Scalars['String'];
 };
 
+
 export type CurationMetadataSetsArgs = {
-  limit?: InputMaybe<Scalars["Int"]>;
-  next_token?: InputMaybe<Scalars["String"]>;
+  limit?: InputMaybe<Scalars['Int']>;
+  next_token?: InputMaybe<Scalars['String']>;
 };
 
 export type CurationMetadataListing = Listing & {
-  __typename?: "CurationMetadataListing";
-  count?: Maybe<Scalars["Int"]>;
-  next_token?: Maybe<Scalars["String"]>;
+  __typename?: 'CurationMetadataListing';
+  count?: Maybe<Scalars['Int']>;
+  next_token?: Maybe<Scalars['String']>;
   objects?: Maybe<Array<Maybe<SetContent>>>;
 };
 
 export type Dimension = {
-  __typename?: "Dimension";
+  __typename?: 'Dimension';
   _meta?: Maybe<_DimensionMeta>;
-  description?: Maybe<Scalars["String"]>;
-  external_id?: Maybe<Scalars["String"]>;
-  slug: Scalars["String"];
-  title?: Maybe<Scalars["String"]>;
-  uid: Scalars["String"];
+  description?: Maybe<Scalars['String']>;
+  external_id?: Maybe<Scalars['String']>;
+  slug: Scalars['String'];
+  title?: Maybe<Scalars['String']>;
+  uid: Scalars['String'];
 };
 
+
 export type Dimension_MetaArgs = {
-  value_external_id?: InputMaybe<Scalars["String"]>;
-  value_id?: InputMaybe<Scalars["String"]>;
+  value_external_id?: InputMaybe<Scalars['String']>;
+  value_id?: InputMaybe<Scalars['String']>;
 };
 
 export type DimensionAssigned = {
-  __typename?: "DimensionAssigned";
-  dimension_slug?: Maybe<Scalars["String"]>;
-  value_slugs?: Maybe<Array<Maybe<Scalars["String"]>>>;
+  __typename?: 'DimensionAssigned';
+  dimension_slug?: Maybe<Scalars['String']>;
+  value_slugs?: Maybe<Array<Maybe<Scalars['String']>>>;
 };
 
 export type DimensionInput = {
-  description?: InputMaybe<Scalars["String"]>;
-  external_id?: InputMaybe<Scalars["String"]>;
-  slug: Scalars["String"];
-  title?: InputMaybe<Scalars["String"]>;
+  description?: InputMaybe<Scalars['String']>;
+  external_id?: InputMaybe<Scalars['String']>;
+  slug: Scalars['String'];
+  title?: InputMaybe<Scalars['String']>;
 };
 
 export type DimensionValue = {
-  __typename?: "DimensionValue";
+  __typename?: 'DimensionValue';
   _meta?: Maybe<_DimensionValueMeta>;
-  description?: Maybe<Scalars["String"]>;
-  external_id?: Maybe<Scalars["String"]>;
-  slug: Scalars["String"];
-  title?: Maybe<Scalars["String"]>;
-  uid: Scalars["String"];
+  description?: Maybe<Scalars['String']>;
+  external_id?: Maybe<Scalars['String']>;
+  slug: Scalars['String'];
+  title?: Maybe<Scalars['String']>;
+  uid: Scalars['String'];
 };
 
 export type Entertainment = {
@@ -435,200 +452,219 @@ export type Entertainment = {
   genres?: Maybe<GenreListing>;
   images?: Maybe<ImageListing>;
   ratings?: Maybe<RatingListing>;
-  release_date?: Maybe<Scalars["String"]>;
-  synopsis_long?: Maybe<Scalars["String"]>;
-  synopsis_medium?: Maybe<Scalars["String"]>;
-  synopsis_short?: Maybe<Scalars["String"]>;
+  release_date?: Maybe<Scalars['String']>;
+  synopsis_long?: Maybe<Scalars['String']>;
+  synopsis_medium?: Maybe<Scalars['String']>;
+  synopsis_short?: Maybe<Scalars['String']>;
   tags?: Maybe<TagListing>;
   themes?: Maybe<ThemeListing>;
-  title?: Maybe<Scalars["String"]>;
-  title_long?: Maybe<Scalars["String"]>;
-  title_medium?: Maybe<Scalars["String"]>;
-  title_short?: Maybe<Scalars["String"]>;
+  title?: Maybe<Scalars['String']>;
+  title_long?: Maybe<Scalars['String']>;
+  title_medium?: Maybe<Scalars['String']>;
+  title_short?: Maybe<Scalars['String']>;
 };
+
 
 export type EntertainmentAssetsArgs = {
-  language?: InputMaybe<Scalars["String"]>;
-  limit?: InputMaybe<Scalars["Int"]>;
-  next_token?: InputMaybe<Scalars["String"]>;
+  language?: InputMaybe<Scalars['String']>;
+  limit?: InputMaybe<Scalars['Int']>;
+  next_token?: InputMaybe<Scalars['String']>;
 };
+
 
 export type EntertainmentAvailabilityArgs = {
-  limit?: InputMaybe<Scalars["Int"]>;
-  next_token?: InputMaybe<Scalars["String"]>;
+  limit?: InputMaybe<Scalars['Int']>;
+  next_token?: InputMaybe<Scalars['String']>;
 };
+
 
 export type EntertainmentCreditsArgs = {
-  language?: InputMaybe<Scalars["String"]>;
-  limit?: InputMaybe<Scalars["Int"]>;
-  next_token?: InputMaybe<Scalars["String"]>;
+  language?: InputMaybe<Scalars['String']>;
+  limit?: InputMaybe<Scalars['Int']>;
+  next_token?: InputMaybe<Scalars['String']>;
 };
+
 
 export type EntertainmentGenresArgs = {
-  language?: InputMaybe<Scalars["String"]>;
-  limit?: InputMaybe<Scalars["Int"]>;
-  next_token?: InputMaybe<Scalars["String"]>;
+  language?: InputMaybe<Scalars['String']>;
+  limit?: InputMaybe<Scalars['Int']>;
+  next_token?: InputMaybe<Scalars['String']>;
 };
+
 
 export type EntertainmentImagesArgs = {
-  language?: InputMaybe<Scalars["String"]>;
-  limit?: InputMaybe<Scalars["Int"]>;
-  next_token?: InputMaybe<Scalars["String"]>;
+  language?: InputMaybe<Scalars['String']>;
+  limit?: InputMaybe<Scalars['Int']>;
+  next_token?: InputMaybe<Scalars['String']>;
 };
+
 
 export type EntertainmentRatingsArgs = {
-  language?: InputMaybe<Scalars["String"]>;
-  limit?: InputMaybe<Scalars["Int"]>;
-  next_token?: InputMaybe<Scalars["String"]>;
+  language?: InputMaybe<Scalars['String']>;
+  limit?: InputMaybe<Scalars['Int']>;
+  next_token?: InputMaybe<Scalars['String']>;
 };
+
 
 export type EntertainmentTagsArgs = {
-  language?: InputMaybe<Scalars["String"]>;
-  limit?: InputMaybe<Scalars["Int"]>;
-  next_token?: InputMaybe<Scalars["String"]>;
+  language?: InputMaybe<Scalars['String']>;
+  limit?: InputMaybe<Scalars['Int']>;
+  next_token?: InputMaybe<Scalars['String']>;
 };
 
+
 export type EntertainmentThemesArgs = {
-  language?: InputMaybe<Scalars["String"]>;
-  limit?: InputMaybe<Scalars["Int"]>;
-  next_token?: InputMaybe<Scalars["String"]>;
+  language?: InputMaybe<Scalars['String']>;
+  limit?: InputMaybe<Scalars['Int']>;
+  next_token?: InputMaybe<Scalars['String']>;
 };
 
 export type EntertainmentListing = {
-  __typename?: "EntertainmentListing";
-  count?: Maybe<Scalars["Int"]>;
-  next_token?: Maybe<Scalars["String"]>;
+  __typename?: 'EntertainmentListing';
+  count?: Maybe<Scalars['Int']>;
+  next_token?: Maybe<Scalars['String']>;
   objects?: Maybe<Array<Maybe<Entertainment>>>;
 };
 
-export type Episode = CurationMetadata &
-  Entertainment & {
-    __typename?: "Episode";
-    _meta?: Maybe<_EpisodeMeta>;
-    assets?: Maybe<AssetListing>;
-    availability?: Maybe<AvailabilityListing>;
-    brands?: Maybe<BrandListing>;
-    credits?: Maybe<CreditListing>;
-    episode_number?: Maybe<Scalars["Int"]>;
-    external_id?: Maybe<Scalars["String"]>;
-    genres?: Maybe<GenreListing>;
-    images?: Maybe<ImageListing>;
-    ratings?: Maybe<RatingListing>;
-    release_date?: Maybe<Scalars["String"]>;
-    seasons?: Maybe<SeasonListing>;
-    sets?: Maybe<SetListing>;
-    slug?: Maybe<Scalars["String"]>;
-    synopsis_long?: Maybe<Scalars["String"]>;
-    synopsis_medium?: Maybe<Scalars["String"]>;
-    synopsis_short?: Maybe<Scalars["String"]>;
-    tags?: Maybe<TagListing>;
-    themes?: Maybe<ThemeListing>;
-    title?: Maybe<Scalars["String"]>;
-    title_long?: Maybe<Scalars["String"]>;
-    title_medium?: Maybe<Scalars["String"]>;
-    title_short?: Maybe<Scalars["String"]>;
-    uid: Scalars["String"];
-  };
+export type Episode = CurationMetadata & Entertainment & {
+  __typename?: 'Episode';
+  _meta?: Maybe<_EpisodeMeta>;
+  assets?: Maybe<AssetListing>;
+  availability?: Maybe<AvailabilityListing>;
+  brands?: Maybe<BrandListing>;
+  credits?: Maybe<CreditListing>;
+  episode_number?: Maybe<Scalars['Int']>;
+  external_id?: Maybe<Scalars['String']>;
+  genres?: Maybe<GenreListing>;
+  images?: Maybe<ImageListing>;
+  ratings?: Maybe<RatingListing>;
+  release_date?: Maybe<Scalars['String']>;
+  seasons?: Maybe<SeasonListing>;
+  sets?: Maybe<SetListing>;
+  slug?: Maybe<Scalars['String']>;
+  synopsis_long?: Maybe<Scalars['String']>;
+  synopsis_medium?: Maybe<Scalars['String']>;
+  synopsis_short?: Maybe<Scalars['String']>;
+  tags?: Maybe<TagListing>;
+  themes?: Maybe<ThemeListing>;
+  title?: Maybe<Scalars['String']>;
+  title_long?: Maybe<Scalars['String']>;
+  title_medium?: Maybe<Scalars['String']>;
+  title_short?: Maybe<Scalars['String']>;
+  uid: Scalars['String'];
+};
+
 
 export type Episode_MetaArgs = {
-  global_version?: InputMaybe<Scalars["Int"]>;
-  language?: InputMaybe<Scalars["String"]>;
-  language_version?: InputMaybe<Scalars["Int"]>;
+  global_version?: InputMaybe<Scalars['Int']>;
+  language?: InputMaybe<Scalars['String']>;
+  language_version?: InputMaybe<Scalars['Int']>;
 };
+
 
 export type EpisodeAssetsArgs = {
-  language?: InputMaybe<Scalars["String"]>;
-  limit?: InputMaybe<Scalars["Int"]>;
-  next_token?: InputMaybe<Scalars["String"]>;
+  language?: InputMaybe<Scalars['String']>;
+  limit?: InputMaybe<Scalars['Int']>;
+  next_token?: InputMaybe<Scalars['String']>;
 };
+
 
 export type EpisodeAvailabilityArgs = {
-  limit?: InputMaybe<Scalars["Int"]>;
-  next_token?: InputMaybe<Scalars["String"]>;
+  limit?: InputMaybe<Scalars['Int']>;
+  next_token?: InputMaybe<Scalars['String']>;
 };
+
 
 export type EpisodeBrandsArgs = {
-  language?: InputMaybe<Scalars["String"]>;
-  limit?: InputMaybe<Scalars["Int"]>;
-  next_token?: InputMaybe<Scalars["String"]>;
+  language?: InputMaybe<Scalars['String']>;
+  limit?: InputMaybe<Scalars['Int']>;
+  next_token?: InputMaybe<Scalars['String']>;
 };
+
 
 export type EpisodeCreditsArgs = {
-  language?: InputMaybe<Scalars["String"]>;
-  limit?: InputMaybe<Scalars["Int"]>;
-  next_token?: InputMaybe<Scalars["String"]>;
+  language?: InputMaybe<Scalars['String']>;
+  limit?: InputMaybe<Scalars['Int']>;
+  next_token?: InputMaybe<Scalars['String']>;
 };
+
 
 export type EpisodeGenresArgs = {
-  language?: InputMaybe<Scalars["String"]>;
-  limit?: InputMaybe<Scalars["Int"]>;
-  next_token?: InputMaybe<Scalars["String"]>;
+  language?: InputMaybe<Scalars['String']>;
+  limit?: InputMaybe<Scalars['Int']>;
+  next_token?: InputMaybe<Scalars['String']>;
 };
+
 
 export type EpisodeImagesArgs = {
-  language?: InputMaybe<Scalars["String"]>;
-  limit?: InputMaybe<Scalars["Int"]>;
-  next_token?: InputMaybe<Scalars["String"]>;
+  language?: InputMaybe<Scalars['String']>;
+  limit?: InputMaybe<Scalars['Int']>;
+  next_token?: InputMaybe<Scalars['String']>;
 };
+
 
 export type EpisodeRatingsArgs = {
-  language?: InputMaybe<Scalars["String"]>;
-  limit?: InputMaybe<Scalars["Int"]>;
-  next_token?: InputMaybe<Scalars["String"]>;
+  language?: InputMaybe<Scalars['String']>;
+  limit?: InputMaybe<Scalars['Int']>;
+  next_token?: InputMaybe<Scalars['String']>;
 };
+
 
 export type EpisodeSeasonsArgs = {
-  language?: InputMaybe<Scalars["String"]>;
-  limit?: InputMaybe<Scalars["Int"]>;
-  next_token?: InputMaybe<Scalars["String"]>;
+  language?: InputMaybe<Scalars['String']>;
+  limit?: InputMaybe<Scalars['Int']>;
+  next_token?: InputMaybe<Scalars['String']>;
 };
+
 
 export type EpisodeSetsArgs = {
-  limit?: InputMaybe<Scalars["Int"]>;
-  next_token?: InputMaybe<Scalars["String"]>;
+  limit?: InputMaybe<Scalars['Int']>;
+  next_token?: InputMaybe<Scalars['String']>;
 };
+
 
 export type EpisodeTagsArgs = {
-  language?: InputMaybe<Scalars["String"]>;
-  limit?: InputMaybe<Scalars["Int"]>;
-  next_token?: InputMaybe<Scalars["String"]>;
+  language?: InputMaybe<Scalars['String']>;
+  limit?: InputMaybe<Scalars['Int']>;
+  next_token?: InputMaybe<Scalars['String']>;
 };
 
+
 export type EpisodeThemesArgs = {
-  language?: InputMaybe<Scalars["String"]>;
-  limit?: InputMaybe<Scalars["Int"]>;
-  next_token?: InputMaybe<Scalars["String"]>;
+  language?: InputMaybe<Scalars['String']>;
+  limit?: InputMaybe<Scalars['Int']>;
+  next_token?: InputMaybe<Scalars['String']>;
 };
 
 export type EpisodeInput = {
   availability?: InputMaybe<AssignAvailabilityInput>;
-  data_source_fields?: InputMaybe<Array<InputMaybe<Scalars["String"]>>>;
-  data_source_id?: InputMaybe<Scalars["String"]>;
-  episode_number?: InputMaybe<Scalars["Int"]>;
-  external_id?: InputMaybe<Scalars["String"]>;
+  data_source_fields?: InputMaybe<Array<InputMaybe<Scalars['String']>>>;
+  data_source_id?: InputMaybe<Scalars['String']>;
+  episode_number?: InputMaybe<Scalars['Int']>;
+  external_id?: InputMaybe<Scalars['String']>;
   relationships?: InputMaybe<EpisodeRelationships>;
-  release_date?: InputMaybe<Scalars["String"]>;
-  slug?: InputMaybe<Scalars["String"]>;
-  synopsis_long?: InputMaybe<Scalars["String"]>;
-  synopsis_medium?: InputMaybe<Scalars["String"]>;
-  synopsis_short?: InputMaybe<Scalars["String"]>;
-  title?: InputMaybe<Scalars["String"]>;
-  title_long?: InputMaybe<Scalars["String"]>;
-  title_medium?: InputMaybe<Scalars["String"]>;
-  title_short?: InputMaybe<Scalars["String"]>;
+  release_date?: InputMaybe<Scalars['String']>;
+  slug?: InputMaybe<Scalars['String']>;
+  synopsis_long?: InputMaybe<Scalars['String']>;
+  synopsis_medium?: InputMaybe<Scalars['String']>;
+  synopsis_short?: InputMaybe<Scalars['String']>;
+  title?: InputMaybe<Scalars['String']>;
+  title_long?: InputMaybe<Scalars['String']>;
+  title_medium?: InputMaybe<Scalars['String']>;
+  title_short?: InputMaybe<Scalars['String']>;
 };
 
 export type EpisodeListing = Listing & {
-  __typename?: "EpisodeListing";
-  count?: Maybe<Scalars["Int"]>;
-  next_token?: Maybe<Scalars["String"]>;
+  __typename?: 'EpisodeListing';
+  count?: Maybe<Scalars['Int']>;
+  next_token?: Maybe<Scalars['String']>;
   objects?: Maybe<Array<Maybe<Episode>>>;
 };
 
 export type EpisodeRelationshipInput = {
   create?: InputMaybe<Array<InputMaybe<EpisodeInput>>>;
-  link?: InputMaybe<Array<InputMaybe<Scalars["String"]>>>;
-  unlink?: InputMaybe<Array<InputMaybe<Scalars["String"]>>>;
+  link?: InputMaybe<Array<InputMaybe<Scalars['String']>>>;
+  unlink?: InputMaybe<Array<InputMaybe<Scalars['String']>>>;
 };
 
 export type EpisodeRelationships = {
@@ -645,300 +681,317 @@ export type EpisodeRelationships = {
 
 export type EpisodeSetCreate = {
   object?: InputMaybe<EpisodeInput>;
-  position: Scalars["Int"];
+  position: Scalars['Int'];
 };
 
 export type EpisodeSetInput = {
   create?: InputMaybe<Array<InputMaybe<EpisodeSetCreate>>>;
   link?: InputMaybe<Array<InputMaybe<SetLink>>>;
   reposition?: InputMaybe<Array<InputMaybe<SetLink>>>;
-  unlink?: InputMaybe<Array<InputMaybe<Scalars["String"]>>>;
+  unlink?: InputMaybe<Array<InputMaybe<Scalars['String']>>>;
 };
 
 export type Genre = CurationMetadata & {
-  __typename?: "Genre";
+  __typename?: 'Genre';
   _meta?: Maybe<_GenreMeta>;
   availability?: Maybe<AvailabilityListing>;
-  external_id?: Maybe<Scalars["String"]>;
-  metadata_source?: Maybe<Scalars["String"]>;
+  external_id?: Maybe<Scalars['String']>;
+  metadata_source?: Maybe<Scalars['String']>;
   movies?: Maybe<MovieListing>;
-  name?: Maybe<Scalars["String"]>;
+  name?: Maybe<Scalars['String']>;
   parents?: Maybe<EntertainmentListing>;
   sets?: Maybe<SetListing>;
-  slug?: Maybe<Scalars["String"]>;
-  uid: Scalars["String"];
+  slug?: Maybe<Scalars['String']>;
+  uid: Scalars['String'];
 };
+
 
 export type Genre_MetaArgs = {
-  global_version?: InputMaybe<Scalars["Int"]>;
-  language?: InputMaybe<Scalars["String"]>;
-  language_version?: InputMaybe<Scalars["Int"]>;
+  global_version?: InputMaybe<Scalars['Int']>;
+  language?: InputMaybe<Scalars['String']>;
+  language_version?: InputMaybe<Scalars['Int']>;
 };
+
 
 export type GenreAvailabilityArgs = {
-  limit?: InputMaybe<Scalars["Int"]>;
-  next_token?: InputMaybe<Scalars["String"]>;
+  limit?: InputMaybe<Scalars['Int']>;
+  next_token?: InputMaybe<Scalars['String']>;
 };
+
 
 export type GenreMoviesArgs = {
-  language?: InputMaybe<Scalars["String"]>;
-  limit?: InputMaybe<Scalars["Int"]>;
-  next_token?: InputMaybe<Scalars["String"]>;
+  language?: InputMaybe<Scalars['String']>;
+  limit?: InputMaybe<Scalars['Int']>;
+  next_token?: InputMaybe<Scalars['String']>;
 };
+
 
 export type GenreParentsArgs = {
-  language?: InputMaybe<Scalars["String"]>;
-  limit?: InputMaybe<Scalars["Int"]>;
-  next_token?: InputMaybe<Scalars["String"]>;
+  language?: InputMaybe<Scalars['String']>;
+  limit?: InputMaybe<Scalars['Int']>;
+  next_token?: InputMaybe<Scalars['String']>;
 };
 
+
 export type GenreSetsArgs = {
-  limit?: InputMaybe<Scalars["Int"]>;
-  next_token?: InputMaybe<Scalars["String"]>;
+  limit?: InputMaybe<Scalars['Int']>;
+  next_token?: InputMaybe<Scalars['String']>;
 };
 
 export type GenreInput = {
   availability?: InputMaybe<AssignAvailabilityInput>;
-  data_source_fields?: InputMaybe<Array<InputMaybe<Scalars["String"]>>>;
-  data_source_id?: InputMaybe<Scalars["String"]>;
-  external_id?: InputMaybe<Scalars["String"]>;
-  metadata_source?: InputMaybe<Scalars["String"]>;
-  name?: InputMaybe<Scalars["String"]>;
-  slug?: InputMaybe<Scalars["String"]>;
+  data_source_fields?: InputMaybe<Array<InputMaybe<Scalars['String']>>>;
+  data_source_id?: InputMaybe<Scalars['String']>;
+  external_id?: InputMaybe<Scalars['String']>;
+  metadata_source?: InputMaybe<Scalars['String']>;
+  name?: InputMaybe<Scalars['String']>;
+  slug?: InputMaybe<Scalars['String']>;
 };
 
 export type GenreListing = Listing & {
-  __typename?: "GenreListing";
-  count?: Maybe<Scalars["Int"]>;
-  next_token?: Maybe<Scalars["String"]>;
+  __typename?: 'GenreListing';
+  count?: Maybe<Scalars['Int']>;
+  next_token?: Maybe<Scalars['String']>;
   objects?: Maybe<Array<Maybe<Genre>>>;
 };
 
 export type GenreRelationshipInput = {
   create?: InputMaybe<Array<InputMaybe<GenreInput>>>;
-  link?: InputMaybe<Array<InputMaybe<Scalars["String"]>>>;
-  unlink?: InputMaybe<Array<InputMaybe<Scalars["String"]>>>;
+  link?: InputMaybe<Array<InputMaybe<Scalars['String']>>>;
+  unlink?: InputMaybe<Array<InputMaybe<Scalars['String']>>>;
 };
 
 export type GenreSetCreate = {
   object?: InputMaybe<GenreInput>;
-  position: Scalars["Int"];
+  position: Scalars['Int'];
 };
 
 export type GenreSetInput = {
   create?: InputMaybe<Array<InputMaybe<GenreSetCreate>>>;
   link?: InputMaybe<Array<InputMaybe<SetLink>>>;
   reposition?: InputMaybe<Array<InputMaybe<SetLink>>>;
-  unlink?: InputMaybe<Array<InputMaybe<Scalars["String"]>>>;
+  unlink?: InputMaybe<Array<InputMaybe<Scalars['String']>>>;
 };
 
 export type Image = Metadata & {
-  __typename?: "Image";
+  __typename?: 'Image';
   _meta?: Maybe<_ImageMeta>;
   availability?: Maybe<AvailabilityListing>;
-  description?: Maybe<Scalars["String"]>;
-  external_id?: Maybe<Scalars["String"]>;
+  description?: Maybe<Scalars['String']>;
+  external_id?: Maybe<Scalars['String']>;
   parents?: Maybe<EntertainmentListing>;
-  slug?: Maybe<Scalars["String"]>;
-  title?: Maybe<Scalars["String"]>;
-  type?: Maybe<Scalars["String"]>;
-  uid: Scalars["String"];
-  url?: Maybe<Scalars["String"]>;
+  slug?: Maybe<Scalars['String']>;
+  title?: Maybe<Scalars['String']>;
+  type?: Maybe<Scalars['String']>;
+  uid: Scalars['String'];
+  url?: Maybe<Scalars['String']>;
 };
+
 
 export type Image_MetaArgs = {
-  global_version?: InputMaybe<Scalars["Int"]>;
-  language?: InputMaybe<Scalars["String"]>;
-  language_version?: InputMaybe<Scalars["Int"]>;
+  global_version?: InputMaybe<Scalars['Int']>;
+  language?: InputMaybe<Scalars['String']>;
+  language_version?: InputMaybe<Scalars['Int']>;
 };
 
+
 export type ImageAvailabilityArgs = {
-  limit?: InputMaybe<Scalars["Int"]>;
-  next_token?: InputMaybe<Scalars["String"]>;
+  limit?: InputMaybe<Scalars['Int']>;
+  next_token?: InputMaybe<Scalars['String']>;
 };
 
 export type ImageInput = {
   availability?: InputMaybe<AssignAvailabilityInput>;
-  data_source_fields?: InputMaybe<Array<InputMaybe<Scalars["String"]>>>;
-  data_source_id?: InputMaybe<Scalars["String"]>;
-  description?: InputMaybe<Scalars["String"]>;
-  external_id?: InputMaybe<Scalars["String"]>;
-  title?: InputMaybe<Scalars["String"]>;
+  data_source_fields?: InputMaybe<Array<InputMaybe<Scalars['String']>>>;
+  data_source_id?: InputMaybe<Scalars['String']>;
+  description?: InputMaybe<Scalars['String']>;
+  external_id?: InputMaybe<Scalars['String']>;
+  title?: InputMaybe<Scalars['String']>;
   type?: InputMaybe<ImageType>;
-  url?: InputMaybe<Scalars["String"]>;
+  url?: InputMaybe<Scalars['String']>;
 };
 
 export type ImageListing = Listing & {
-  __typename?: "ImageListing";
-  count?: Maybe<Scalars["Int"]>;
-  next_token?: Maybe<Scalars["String"]>;
+  __typename?: 'ImageListing';
+  count?: Maybe<Scalars['Int']>;
+  next_token?: Maybe<Scalars['String']>;
   objects?: Maybe<Array<Maybe<Image>>>;
 };
 
 export type ImageRelationshipInput = {
   create?: InputMaybe<Array<InputMaybe<ImageInput>>>;
-  link?: InputMaybe<Array<InputMaybe<Scalars["String"]>>>;
-  unlink?: InputMaybe<Array<InputMaybe<Scalars["String"]>>>;
+  link?: InputMaybe<Array<InputMaybe<Scalars['String']>>>;
+  unlink?: InputMaybe<Array<InputMaybe<Scalars['String']>>>;
 };
 
 export type ImageSetCreate = {
   object?: InputMaybe<ImageInput>;
-  position: Scalars["Int"];
+  position: Scalars['Int'];
 };
 
 export type ImageSetInput = {
   create?: InputMaybe<Array<InputMaybe<ImageSetCreate>>>;
   link?: InputMaybe<Array<InputMaybe<SetLink>>>;
   reposition?: InputMaybe<Array<InputMaybe<SetLink>>>;
-  unlink?: InputMaybe<Array<InputMaybe<Scalars["String"]>>>;
+  unlink?: InputMaybe<Array<InputMaybe<Scalars['String']>>>;
 };
 
 export enum ImageType {
-  Background = "BACKGROUND",
-  Feature = "FEATURE",
-  Footer = "FOOTER",
-  Header = "HEADER",
-  Landscape = "LANDSCAPE",
-  Main = "MAIN",
-  Poster = "POSTER",
-  PostLive = "POST_LIVE",
-  Preview = "PREVIEW",
-  PreLive = "PRE_LIVE",
-  Thumbnail = "THUMBNAIL",
+  Background = 'BACKGROUND',
+  Feature = 'FEATURE',
+  Footer = 'FOOTER',
+  Header = 'HEADER',
+  Landscape = 'LANDSCAPE',
+  Main = 'MAIN',
+  Poster = 'POSTER',
+  PostLive = 'POST_LIVE',
+  Preview = 'PREVIEW',
+  PreLive = 'PRE_LIVE',
+  Thumbnail = 'THUMBNAIL'
 }
 
 export type Listing = {
-  count?: Maybe<Scalars["Int"]>;
-  next_token?: Maybe<Scalars["String"]>;
+  count?: Maybe<Scalars['Int']>;
+  next_token?: Maybe<Scalars['String']>;
 };
 
 export type Metadata = {
-  external_id?: Maybe<Scalars["String"]>;
-  slug?: Maybe<Scalars["String"]>;
-  uid: Scalars["String"];
+  external_id?: Maybe<Scalars['String']>;
+  slug?: Maybe<Scalars['String']>;
+  uid: Scalars['String'];
 };
 
-export type Movie = CurationMetadata &
-  Entertainment & {
-    __typename?: "Movie";
-    _meta?: Maybe<_MovieMeta>;
-    assets?: Maybe<AssetListing>;
-    availability?: Maybe<AvailabilityListing>;
-    brands?: Maybe<BrandListing>;
-    credits?: Maybe<CreditListing>;
-    external_id?: Maybe<Scalars["String"]>;
-    genres?: Maybe<GenreListing>;
-    images?: Maybe<ImageListing>;
-    ratings?: Maybe<RatingListing>;
-    release_date?: Maybe<Scalars["String"]>;
-    sets?: Maybe<SetListing>;
-    slug?: Maybe<Scalars["String"]>;
-    synopsis_long?: Maybe<Scalars["String"]>;
-    synopsis_medium?: Maybe<Scalars["String"]>;
-    synopsis_short?: Maybe<Scalars["String"]>;
-    tags?: Maybe<TagListing>;
-    themes?: Maybe<ThemeListing>;
-    title?: Maybe<Scalars["String"]>;
-    title_long?: Maybe<Scalars["String"]>;
-    title_medium?: Maybe<Scalars["String"]>;
-    title_short?: Maybe<Scalars["String"]>;
-    uid: Scalars["String"];
-    year_of_release?: Maybe<Scalars["Int"]>;
-  };
+export type Movie = CurationMetadata & Entertainment & {
+  __typename?: 'Movie';
+  _meta?: Maybe<_MovieMeta>;
+  assets?: Maybe<AssetListing>;
+  availability?: Maybe<AvailabilityListing>;
+  brands?: Maybe<BrandListing>;
+  credits?: Maybe<CreditListing>;
+  external_id?: Maybe<Scalars['String']>;
+  genres?: Maybe<GenreListing>;
+  images?: Maybe<ImageListing>;
+  ratings?: Maybe<RatingListing>;
+  release_date?: Maybe<Scalars['String']>;
+  sets?: Maybe<SetListing>;
+  slug?: Maybe<Scalars['String']>;
+  synopsis_long?: Maybe<Scalars['String']>;
+  synopsis_medium?: Maybe<Scalars['String']>;
+  synopsis_short?: Maybe<Scalars['String']>;
+  tags?: Maybe<TagListing>;
+  themes?: Maybe<ThemeListing>;
+  title?: Maybe<Scalars['String']>;
+  title_long?: Maybe<Scalars['String']>;
+  title_medium?: Maybe<Scalars['String']>;
+  title_short?: Maybe<Scalars['String']>;
+  uid: Scalars['String'];
+  year_of_release?: Maybe<Scalars['Int']>;
+};
+
 
 export type Movie_MetaArgs = {
-  global_version?: InputMaybe<Scalars["Int"]>;
-  language?: InputMaybe<Scalars["String"]>;
-  language_version?: InputMaybe<Scalars["Int"]>;
+  global_version?: InputMaybe<Scalars['Int']>;
+  language?: InputMaybe<Scalars['String']>;
+  language_version?: InputMaybe<Scalars['Int']>;
 };
+
 
 export type MovieAssetsArgs = {
-  language?: InputMaybe<Scalars["String"]>;
-  limit?: InputMaybe<Scalars["Int"]>;
-  next_token?: InputMaybe<Scalars["String"]>;
+  language?: InputMaybe<Scalars['String']>;
+  limit?: InputMaybe<Scalars['Int']>;
+  next_token?: InputMaybe<Scalars['String']>;
 };
+
 
 export type MovieAvailabilityArgs = {
-  limit?: InputMaybe<Scalars["Int"]>;
-  next_token?: InputMaybe<Scalars["String"]>;
+  limit?: InputMaybe<Scalars['Int']>;
+  next_token?: InputMaybe<Scalars['String']>;
 };
+
 
 export type MovieBrandsArgs = {
-  language?: InputMaybe<Scalars["String"]>;
-  limit?: InputMaybe<Scalars["Int"]>;
-  next_token?: InputMaybe<Scalars["String"]>;
+  language?: InputMaybe<Scalars['String']>;
+  limit?: InputMaybe<Scalars['Int']>;
+  next_token?: InputMaybe<Scalars['String']>;
 };
+
 
 export type MovieCreditsArgs = {
-  language?: InputMaybe<Scalars["String"]>;
-  limit?: InputMaybe<Scalars["Int"]>;
-  next_token?: InputMaybe<Scalars["String"]>;
+  language?: InputMaybe<Scalars['String']>;
+  limit?: InputMaybe<Scalars['Int']>;
+  next_token?: InputMaybe<Scalars['String']>;
 };
+
 
 export type MovieGenresArgs = {
-  language?: InputMaybe<Scalars["String"]>;
-  limit?: InputMaybe<Scalars["Int"]>;
-  next_token?: InputMaybe<Scalars["String"]>;
+  language?: InputMaybe<Scalars['String']>;
+  limit?: InputMaybe<Scalars['Int']>;
+  next_token?: InputMaybe<Scalars['String']>;
 };
+
 
 export type MovieImagesArgs = {
-  language?: InputMaybe<Scalars["String"]>;
-  limit?: InputMaybe<Scalars["Int"]>;
-  next_token?: InputMaybe<Scalars["String"]>;
+  language?: InputMaybe<Scalars['String']>;
+  limit?: InputMaybe<Scalars['Int']>;
+  next_token?: InputMaybe<Scalars['String']>;
 };
+
 
 export type MovieRatingsArgs = {
-  language?: InputMaybe<Scalars["String"]>;
-  limit?: InputMaybe<Scalars["Int"]>;
-  next_token?: InputMaybe<Scalars["String"]>;
+  language?: InputMaybe<Scalars['String']>;
+  limit?: InputMaybe<Scalars['Int']>;
+  next_token?: InputMaybe<Scalars['String']>;
 };
+
 
 export type MovieSetsArgs = {
-  limit?: InputMaybe<Scalars["Int"]>;
-  next_token?: InputMaybe<Scalars["String"]>;
+  limit?: InputMaybe<Scalars['Int']>;
+  next_token?: InputMaybe<Scalars['String']>;
 };
+
 
 export type MovieTagsArgs = {
-  language?: InputMaybe<Scalars["String"]>;
-  limit?: InputMaybe<Scalars["Int"]>;
-  next_token?: InputMaybe<Scalars["String"]>;
+  language?: InputMaybe<Scalars['String']>;
+  limit?: InputMaybe<Scalars['Int']>;
+  next_token?: InputMaybe<Scalars['String']>;
 };
 
+
 export type MovieThemesArgs = {
-  language?: InputMaybe<Scalars["String"]>;
-  limit?: InputMaybe<Scalars["Int"]>;
-  next_token?: InputMaybe<Scalars["String"]>;
+  language?: InputMaybe<Scalars['String']>;
+  limit?: InputMaybe<Scalars['Int']>;
+  next_token?: InputMaybe<Scalars['String']>;
 };
 
 export type MovieInput = {
   availability?: InputMaybe<AssignAvailabilityInput>;
-  data_source_fields?: InputMaybe<Array<InputMaybe<Scalars["String"]>>>;
-  data_source_id?: InputMaybe<Scalars["String"]>;
-  external_id?: InputMaybe<Scalars["String"]>;
+  data_source_fields?: InputMaybe<Array<InputMaybe<Scalars['String']>>>;
+  data_source_id?: InputMaybe<Scalars['String']>;
+  external_id?: InputMaybe<Scalars['String']>;
   relationships?: InputMaybe<MovieRelationships>;
-  release_date?: InputMaybe<Scalars["String"]>;
-  slug?: InputMaybe<Scalars["String"]>;
-  synopsis_long?: InputMaybe<Scalars["String"]>;
-  synopsis_medium?: InputMaybe<Scalars["String"]>;
-  synopsis_short?: InputMaybe<Scalars["String"]>;
-  title?: InputMaybe<Scalars["String"]>;
-  title_long?: InputMaybe<Scalars["String"]>;
-  title_medium?: InputMaybe<Scalars["String"]>;
-  title_short?: InputMaybe<Scalars["String"]>;
-  year_of_release?: InputMaybe<Scalars["Int"]>;
+  release_date?: InputMaybe<Scalars['String']>;
+  slug?: InputMaybe<Scalars['String']>;
+  synopsis_long?: InputMaybe<Scalars['String']>;
+  synopsis_medium?: InputMaybe<Scalars['String']>;
+  synopsis_short?: InputMaybe<Scalars['String']>;
+  title?: InputMaybe<Scalars['String']>;
+  title_long?: InputMaybe<Scalars['String']>;
+  title_medium?: InputMaybe<Scalars['String']>;
+  title_short?: InputMaybe<Scalars['String']>;
+  year_of_release?: InputMaybe<Scalars['Int']>;
 };
 
 export type MovieListing = Listing & {
-  __typename?: "MovieListing";
-  count?: Maybe<Scalars["Int"]>;
-  next_token?: Maybe<Scalars["String"]>;
+  __typename?: 'MovieListing';
+  count?: Maybe<Scalars['Int']>;
+  next_token?: Maybe<Scalars['String']>;
   objects?: Maybe<Array<Maybe<Movie>>>;
 };
 
 export type MovieRelationshipInput = {
   create?: InputMaybe<Array<InputMaybe<MovieInput>>>;
-  link?: InputMaybe<Array<InputMaybe<Scalars["String"]>>>;
-  unlink?: InputMaybe<Array<InputMaybe<Scalars["String"]>>>;
+  link?: InputMaybe<Array<InputMaybe<Scalars['String']>>>;
+  unlink?: InputMaybe<Array<InputMaybe<Scalars['String']>>>;
 };
 
 export type MovieRelationships = {
@@ -954,18 +1007,18 @@ export type MovieRelationships = {
 
 export type MovieSetCreate = {
   object?: InputMaybe<MovieInput>;
-  position: Scalars["Int"];
+  position: Scalars['Int'];
 };
 
 export type MovieSetInput = {
   create?: InputMaybe<Array<InputMaybe<MovieSetCreate>>>;
   link?: InputMaybe<Array<InputMaybe<SetLink>>>;
   reposition?: InputMaybe<Array<InputMaybe<SetLink>>>;
-  unlink?: InputMaybe<Array<InputMaybe<Scalars["String"]>>>;
+  unlink?: InputMaybe<Array<InputMaybe<Scalars['String']>>>;
 };
 
 export type Mutation = {
-  __typename?: "Mutation";
+  __typename?: 'Mutation';
   createAsset?: Maybe<Asset>;
   createAvailability?: Maybe<Availability>;
   createBrand?: Maybe<Brand>;
@@ -985,11 +1038,11 @@ export type Mutation = {
   createTag?: Maybe<Tag>;
   createTheme?: Maybe<Theme>;
   deleteAsset?: Maybe<Array<Maybe<ObjectDeleteResponse>>>;
-  deleteAvailability?: Maybe<Scalars["String"]>;
+  deleteAvailability?: Maybe<Scalars['String']>;
   deleteBrand?: Maybe<Array<Maybe<ObjectDeleteResponse>>>;
   deleteCredit?: Maybe<Array<Maybe<ObjectDeleteResponse>>>;
-  deleteDimension?: Maybe<Scalars["String"]>;
-  deleteDimensionValue?: Maybe<Scalars["String"]>;
+  deleteDimension?: Maybe<Scalars['String']>;
+  deleteDimensionValue?: Maybe<Scalars['String']>;
   deleteEpisode?: Maybe<Array<Maybe<ObjectDeleteResponse>>>;
   deleteGenre?: Maybe<Array<Maybe<ObjectDeleteResponse>>>;
   deleteImage?: Maybe<Array<Maybe<ObjectDeleteResponse>>>;
@@ -1022,458 +1075,516 @@ export type Mutation = {
   updateTheme?: Maybe<Theme>;
 };
 
+
 export type MutationCreateAssetArgs = {
   asset?: InputMaybe<AssetInput>;
-  language?: InputMaybe<Scalars["String"]>;
+  language?: InputMaybe<Scalars['String']>;
 };
+
 
 export type MutationCreateAvailabilityArgs = {
   availability: AvailabilityInput;
 };
 
+
 export type MutationCreateBrandArgs = {
   brand?: InputMaybe<BrandInput>;
-  language?: InputMaybe<Scalars["String"]>;
+  language?: InputMaybe<Scalars['String']>;
 };
+
 
 export type MutationCreateCreditArgs = {
   credit?: InputMaybe<CreditInput>;
-  language?: InputMaybe<Scalars["String"]>;
+  language?: InputMaybe<Scalars['String']>;
 };
+
 
 export type MutationCreateDimensionArgs = {
   dimension: DimensionInput;
 };
 
+
 export type MutationCreateDimensionValueArgs = {
-  dimension_id?: InputMaybe<Scalars["String"]>;
+  dimension_id?: InputMaybe<Scalars['String']>;
   dimension_value: DimensionInput;
-  external_id?: InputMaybe<Scalars["String"]>;
+  external_id?: InputMaybe<Scalars['String']>;
 };
+
 
 export type MutationCreateEpisodeArgs = {
   episode?: InputMaybe<EpisodeInput>;
-  language?: InputMaybe<Scalars["String"]>;
+  language?: InputMaybe<Scalars['String']>;
 };
+
 
 export type MutationCreateGenreArgs = {
   genre?: InputMaybe<GenreInput>;
-  language?: InputMaybe<Scalars["String"]>;
+  language?: InputMaybe<Scalars['String']>;
 };
+
 
 export type MutationCreateImageArgs = {
   image?: InputMaybe<ImageInput>;
-  language?: InputMaybe<Scalars["String"]>;
+  language?: InputMaybe<Scalars['String']>;
 };
 
+
 export type MutationCreateMovieArgs = {
-  language?: InputMaybe<Scalars["String"]>;
+  language?: InputMaybe<Scalars['String']>;
   movie?: InputMaybe<MovieInput>;
 };
 
+
 export type MutationCreateParentalGuidanceArgs = {
-  language?: InputMaybe<Scalars["String"]>;
+  language?: InputMaybe<Scalars['String']>;
   parental_guidance?: InputMaybe<ParentalGuidanceInput>;
 };
 
+
 export type MutationCreatePersonArgs = {
-  language?: InputMaybe<Scalars["String"]>;
+  language?: InputMaybe<Scalars['String']>;
   person?: InputMaybe<PersonInput>;
 };
 
+
 export type MutationCreateRatingArgs = {
-  language?: InputMaybe<Scalars["String"]>;
+  language?: InputMaybe<Scalars['String']>;
   rating?: InputMaybe<RatingInput>;
 };
 
+
 export type MutationCreateRoleArgs = {
-  language?: InputMaybe<Scalars["String"]>;
+  language?: InputMaybe<Scalars['String']>;
   role?: InputMaybe<RoleInput>;
 };
 
+
 export type MutationCreateSeasonArgs = {
-  language?: InputMaybe<Scalars["String"]>;
+  language?: InputMaybe<Scalars['String']>;
   season?: InputMaybe<SeasonInput>;
 };
 
+
 export type MutationCreateSetArgs = {
-  language?: InputMaybe<Scalars["String"]>;
+  language?: InputMaybe<Scalars['String']>;
   set?: InputMaybe<SetInput>;
 };
 
+
 export type MutationCreateTagArgs = {
-  language?: InputMaybe<Scalars["String"]>;
+  language?: InputMaybe<Scalars['String']>;
   tag?: InputMaybe<TagInput>;
 };
 
+
 export type MutationCreateThemeArgs = {
-  language?: InputMaybe<Scalars["String"]>;
+  language?: InputMaybe<Scalars['String']>;
   theme?: InputMaybe<ThemeInput>;
 };
 
+
 export type MutationDeleteAssetArgs = {
-  external_id?: InputMaybe<Scalars["String"]>;
-  global_version?: InputMaybe<Scalars["Int"]>;
-  language?: InputMaybe<Scalars["String"]>;
-  language_version?: InputMaybe<Scalars["Int"]>;
-  uid: Scalars["String"];
+  external_id?: InputMaybe<Scalars['String']>;
+  global_version?: InputMaybe<Scalars['Int']>;
+  language?: InputMaybe<Scalars['String']>;
+  language_version?: InputMaybe<Scalars['Int']>;
+  uid: Scalars['String'];
 };
+
 
 export type MutationDeleteAvailabilityArgs = {
-  external_id?: InputMaybe<Scalars["String"]>;
-  uid?: InputMaybe<Scalars["String"]>;
+  external_id?: InputMaybe<Scalars['String']>;
+  uid?: InputMaybe<Scalars['String']>;
 };
+
 
 export type MutationDeleteBrandArgs = {
-  external_id?: InputMaybe<Scalars["String"]>;
-  global_version?: InputMaybe<Scalars["Int"]>;
-  language?: InputMaybe<Scalars["String"]>;
-  language_version?: InputMaybe<Scalars["Int"]>;
-  uid: Scalars["String"];
+  external_id?: InputMaybe<Scalars['String']>;
+  global_version?: InputMaybe<Scalars['Int']>;
+  language?: InputMaybe<Scalars['String']>;
+  language_version?: InputMaybe<Scalars['Int']>;
+  uid: Scalars['String'];
 };
+
 
 export type MutationDeleteCreditArgs = {
-  external_id?: InputMaybe<Scalars["String"]>;
-  global_version?: InputMaybe<Scalars["Int"]>;
-  language?: InputMaybe<Scalars["String"]>;
-  language_version?: InputMaybe<Scalars["Int"]>;
-  uid: Scalars["String"];
+  external_id?: InputMaybe<Scalars['String']>;
+  global_version?: InputMaybe<Scalars['Int']>;
+  language?: InputMaybe<Scalars['String']>;
+  language_version?: InputMaybe<Scalars['Int']>;
+  uid: Scalars['String'];
 };
+
 
 export type MutationDeleteDimensionArgs = {
-  dimension_id?: InputMaybe<Scalars["String"]>;
-  external_id?: InputMaybe<Scalars["String"]>;
+  dimension_id?: InputMaybe<Scalars['String']>;
+  external_id?: InputMaybe<Scalars['String']>;
 };
+
 
 export type MutationDeleteDimensionValueArgs = {
-  dimension_id?: InputMaybe<Scalars["String"]>;
-  external_id?: InputMaybe<Scalars["String"]>;
-  value_external_id?: InputMaybe<Scalars["String"]>;
-  value_id?: InputMaybe<Scalars["String"]>;
+  dimension_id?: InputMaybe<Scalars['String']>;
+  external_id?: InputMaybe<Scalars['String']>;
+  value_external_id?: InputMaybe<Scalars['String']>;
+  value_id?: InputMaybe<Scalars['String']>;
 };
+
 
 export type MutationDeleteEpisodeArgs = {
-  external_id?: InputMaybe<Scalars["String"]>;
-  global_version?: InputMaybe<Scalars["Int"]>;
-  language?: InputMaybe<Scalars["String"]>;
-  language_version?: InputMaybe<Scalars["Int"]>;
-  uid: Scalars["String"];
+  external_id?: InputMaybe<Scalars['String']>;
+  global_version?: InputMaybe<Scalars['Int']>;
+  language?: InputMaybe<Scalars['String']>;
+  language_version?: InputMaybe<Scalars['Int']>;
+  uid: Scalars['String'];
 };
+
 
 export type MutationDeleteGenreArgs = {
-  external_id?: InputMaybe<Scalars["String"]>;
-  global_version?: InputMaybe<Scalars["Int"]>;
-  language?: InputMaybe<Scalars["String"]>;
-  language_version?: InputMaybe<Scalars["Int"]>;
-  uid: Scalars["String"];
+  external_id?: InputMaybe<Scalars['String']>;
+  global_version?: InputMaybe<Scalars['Int']>;
+  language?: InputMaybe<Scalars['String']>;
+  language_version?: InputMaybe<Scalars['Int']>;
+  uid: Scalars['String'];
 };
+
 
 export type MutationDeleteImageArgs = {
-  external_id?: InputMaybe<Scalars["String"]>;
-  global_version?: InputMaybe<Scalars["Int"]>;
-  language?: InputMaybe<Scalars["String"]>;
-  language_version?: InputMaybe<Scalars["Int"]>;
-  uid: Scalars["String"];
+  external_id?: InputMaybe<Scalars['String']>;
+  global_version?: InputMaybe<Scalars['Int']>;
+  language?: InputMaybe<Scalars['String']>;
+  language_version?: InputMaybe<Scalars['Int']>;
+  uid: Scalars['String'];
 };
+
 
 export type MutationDeleteMovieArgs = {
-  external_id?: InputMaybe<Scalars["String"]>;
-  global_version?: InputMaybe<Scalars["Int"]>;
-  language?: InputMaybe<Scalars["String"]>;
-  language_version?: InputMaybe<Scalars["Int"]>;
-  uid: Scalars["String"];
+  external_id?: InputMaybe<Scalars['String']>;
+  global_version?: InputMaybe<Scalars['Int']>;
+  language?: InputMaybe<Scalars['String']>;
+  language_version?: InputMaybe<Scalars['Int']>;
+  uid: Scalars['String'];
 };
+
 
 export type MutationDeleteParentalGuidanceArgs = {
-  external_id?: InputMaybe<Scalars["String"]>;
-  global_version?: InputMaybe<Scalars["Int"]>;
-  language?: InputMaybe<Scalars["String"]>;
-  language_version?: InputMaybe<Scalars["Int"]>;
-  uid: Scalars["String"];
+  external_id?: InputMaybe<Scalars['String']>;
+  global_version?: InputMaybe<Scalars['Int']>;
+  language?: InputMaybe<Scalars['String']>;
+  language_version?: InputMaybe<Scalars['Int']>;
+  uid: Scalars['String'];
 };
+
 
 export type MutationDeletePersonArgs = {
-  external_id?: InputMaybe<Scalars["String"]>;
-  global_version?: InputMaybe<Scalars["Int"]>;
-  language?: InputMaybe<Scalars["String"]>;
-  language_version?: InputMaybe<Scalars["Int"]>;
-  uid: Scalars["String"];
+  external_id?: InputMaybe<Scalars['String']>;
+  global_version?: InputMaybe<Scalars['Int']>;
+  language?: InputMaybe<Scalars['String']>;
+  language_version?: InputMaybe<Scalars['Int']>;
+  uid: Scalars['String'];
 };
+
 
 export type MutationDeleteRatingArgs = {
-  external_id?: InputMaybe<Scalars["String"]>;
-  global_version?: InputMaybe<Scalars["Int"]>;
-  language?: InputMaybe<Scalars["String"]>;
-  language_version?: InputMaybe<Scalars["Int"]>;
-  uid: Scalars["String"];
+  external_id?: InputMaybe<Scalars['String']>;
+  global_version?: InputMaybe<Scalars['Int']>;
+  language?: InputMaybe<Scalars['String']>;
+  language_version?: InputMaybe<Scalars['Int']>;
+  uid: Scalars['String'];
 };
+
 
 export type MutationDeleteRoleArgs = {
-  external_id?: InputMaybe<Scalars["String"]>;
-  global_version?: InputMaybe<Scalars["Int"]>;
-  language?: InputMaybe<Scalars["String"]>;
-  language_version?: InputMaybe<Scalars["Int"]>;
-  uid: Scalars["String"];
+  external_id?: InputMaybe<Scalars['String']>;
+  global_version?: InputMaybe<Scalars['Int']>;
+  language?: InputMaybe<Scalars['String']>;
+  language_version?: InputMaybe<Scalars['Int']>;
+  uid: Scalars['String'];
 };
+
 
 export type MutationDeleteSeasonArgs = {
-  external_id?: InputMaybe<Scalars["String"]>;
-  global_version?: InputMaybe<Scalars["Int"]>;
-  language?: InputMaybe<Scalars["String"]>;
-  language_version?: InputMaybe<Scalars["Int"]>;
-  uid: Scalars["String"];
+  external_id?: InputMaybe<Scalars['String']>;
+  global_version?: InputMaybe<Scalars['Int']>;
+  language?: InputMaybe<Scalars['String']>;
+  language_version?: InputMaybe<Scalars['Int']>;
+  uid: Scalars['String'];
 };
+
 
 export type MutationDeleteSetArgs = {
-  external_id?: InputMaybe<Scalars["String"]>;
-  global_version?: InputMaybe<Scalars["Int"]>;
-  language?: InputMaybe<Scalars["String"]>;
-  language_version?: InputMaybe<Scalars["Int"]>;
-  uid?: InputMaybe<Scalars["String"]>;
+  external_id?: InputMaybe<Scalars['String']>;
+  global_version?: InputMaybe<Scalars['Int']>;
+  language?: InputMaybe<Scalars['String']>;
+  language_version?: InputMaybe<Scalars['Int']>;
+  uid?: InputMaybe<Scalars['String']>;
 };
+
 
 export type MutationDeleteTagArgs = {
-  external_id?: InputMaybe<Scalars["String"]>;
-  global_version?: InputMaybe<Scalars["Int"]>;
-  language?: InputMaybe<Scalars["String"]>;
-  language_version?: InputMaybe<Scalars["Int"]>;
-  uid: Scalars["String"];
+  external_id?: InputMaybe<Scalars['String']>;
+  global_version?: InputMaybe<Scalars['Int']>;
+  language?: InputMaybe<Scalars['String']>;
+  language_version?: InputMaybe<Scalars['Int']>;
+  uid: Scalars['String'];
 };
 
+
 export type MutationDeleteThemeArgs = {
-  external_id?: InputMaybe<Scalars["String"]>;
-  global_version?: InputMaybe<Scalars["Int"]>;
-  language?: InputMaybe<Scalars["String"]>;
-  language_version?: InputMaybe<Scalars["Int"]>;
-  uid: Scalars["String"];
+  external_id?: InputMaybe<Scalars['String']>;
+  global_version?: InputMaybe<Scalars['Int']>;
+  language?: InputMaybe<Scalars['String']>;
+  language_version?: InputMaybe<Scalars['Int']>;
+  uid: Scalars['String'];
 };
+
 
 export type MutationUpdateAssetArgs = {
   asset?: InputMaybe<AssetInput>;
-  external_id?: InputMaybe<Scalars["String"]>;
-  global_version?: InputMaybe<Scalars["Int"]>;
-  language?: InputMaybe<Scalars["String"]>;
-  language_version?: InputMaybe<Scalars["Int"]>;
-  uid?: InputMaybe<Scalars["String"]>;
+  external_id?: InputMaybe<Scalars['String']>;
+  global_version?: InputMaybe<Scalars['Int']>;
+  language?: InputMaybe<Scalars['String']>;
+  language_version?: InputMaybe<Scalars['Int']>;
+  uid?: InputMaybe<Scalars['String']>;
 };
+
 
 export type MutationUpdateAvailabilityArgs = {
   availability: AvailabilityInput;
-  external_id?: InputMaybe<Scalars["String"]>;
-  uid?: InputMaybe<Scalars["String"]>;
+  external_id?: InputMaybe<Scalars['String']>;
+  uid?: InputMaybe<Scalars['String']>;
 };
+
 
 export type MutationUpdateBrandArgs = {
   brand?: InputMaybe<BrandInput>;
-  external_id?: InputMaybe<Scalars["String"]>;
-  global_version?: InputMaybe<Scalars["Int"]>;
-  language?: InputMaybe<Scalars["String"]>;
-  language_version?: InputMaybe<Scalars["Int"]>;
-  uid?: InputMaybe<Scalars["String"]>;
+  external_id?: InputMaybe<Scalars['String']>;
+  global_version?: InputMaybe<Scalars['Int']>;
+  language?: InputMaybe<Scalars['String']>;
+  language_version?: InputMaybe<Scalars['Int']>;
+  uid?: InputMaybe<Scalars['String']>;
 };
+
 
 export type MutationUpdateCreditArgs = {
   credit?: InputMaybe<CreditInput>;
-  external_id?: InputMaybe<Scalars["String"]>;
-  global_version?: InputMaybe<Scalars["Int"]>;
-  language?: InputMaybe<Scalars["String"]>;
-  language_version?: InputMaybe<Scalars["Int"]>;
-  uid?: InputMaybe<Scalars["String"]>;
+  external_id?: InputMaybe<Scalars['String']>;
+  global_version?: InputMaybe<Scalars['Int']>;
+  language?: InputMaybe<Scalars['String']>;
+  language_version?: InputMaybe<Scalars['Int']>;
+  uid?: InputMaybe<Scalars['String']>;
 };
+
 
 export type MutationUpdateDimensionArgs = {
   dimension: DimensionInput;
-  dimension_id?: InputMaybe<Scalars["String"]>;
-  external_id?: InputMaybe<Scalars["String"]>;
+  dimension_id?: InputMaybe<Scalars['String']>;
+  external_id?: InputMaybe<Scalars['String']>;
 };
 
+
 export type MutationUpdateDimensionValueArgs = {
-  dimension_id?: InputMaybe<Scalars["String"]>;
+  dimension_id?: InputMaybe<Scalars['String']>;
   dimension_value: DimensionInput;
-  external_id?: InputMaybe<Scalars["String"]>;
-  value_external_id?: InputMaybe<Scalars["String"]>;
-  value_id?: InputMaybe<Scalars["String"]>;
+  external_id?: InputMaybe<Scalars['String']>;
+  value_external_id?: InputMaybe<Scalars['String']>;
+  value_id?: InputMaybe<Scalars['String']>;
 };
+
 
 export type MutationUpdateEpisodeArgs = {
   episode?: InputMaybe<EpisodeInput>;
-  external_id?: InputMaybe<Scalars["String"]>;
-  global_version?: InputMaybe<Scalars["Int"]>;
-  language?: InputMaybe<Scalars["String"]>;
-  language_version?: InputMaybe<Scalars["Int"]>;
-  uid?: InputMaybe<Scalars["String"]>;
+  external_id?: InputMaybe<Scalars['String']>;
+  global_version?: InputMaybe<Scalars['Int']>;
+  language?: InputMaybe<Scalars['String']>;
+  language_version?: InputMaybe<Scalars['Int']>;
+  uid?: InputMaybe<Scalars['String']>;
 };
+
 
 export type MutationUpdateGenreArgs = {
-  external_id?: InputMaybe<Scalars["String"]>;
+  external_id?: InputMaybe<Scalars['String']>;
   genre?: InputMaybe<GenreInput>;
-  global_version?: InputMaybe<Scalars["Int"]>;
-  language?: InputMaybe<Scalars["String"]>;
-  language_version?: InputMaybe<Scalars["Int"]>;
-  uid?: InputMaybe<Scalars["String"]>;
+  global_version?: InputMaybe<Scalars['Int']>;
+  language?: InputMaybe<Scalars['String']>;
+  language_version?: InputMaybe<Scalars['Int']>;
+  uid?: InputMaybe<Scalars['String']>;
 };
+
 
 export type MutationUpdateImageArgs = {
-  external_id?: InputMaybe<Scalars["String"]>;
-  global_version?: InputMaybe<Scalars["Int"]>;
+  external_id?: InputMaybe<Scalars['String']>;
+  global_version?: InputMaybe<Scalars['Int']>;
   image?: InputMaybe<ImageInput>;
-  language?: InputMaybe<Scalars["String"]>;
-  language_version?: InputMaybe<Scalars["Int"]>;
-  uid?: InputMaybe<Scalars["String"]>;
+  language?: InputMaybe<Scalars['String']>;
+  language_version?: InputMaybe<Scalars['Int']>;
+  uid?: InputMaybe<Scalars['String']>;
 };
+
 
 export type MutationUpdateMovieArgs = {
-  external_id?: InputMaybe<Scalars["String"]>;
-  global_version?: InputMaybe<Scalars["Int"]>;
-  language?: InputMaybe<Scalars["String"]>;
-  language_version?: InputMaybe<Scalars["Int"]>;
+  external_id?: InputMaybe<Scalars['String']>;
+  global_version?: InputMaybe<Scalars['Int']>;
+  language?: InputMaybe<Scalars['String']>;
+  language_version?: InputMaybe<Scalars['Int']>;
   movie?: InputMaybe<MovieInput>;
-  uid?: InputMaybe<Scalars["String"]>;
+  uid?: InputMaybe<Scalars['String']>;
 };
+
 
 export type MutationUpdateParentalGuidanceArgs = {
-  external_id?: InputMaybe<Scalars["String"]>;
-  global_version?: InputMaybe<Scalars["Int"]>;
-  language?: InputMaybe<Scalars["String"]>;
-  language_version?: InputMaybe<Scalars["Int"]>;
+  external_id?: InputMaybe<Scalars['String']>;
+  global_version?: InputMaybe<Scalars['Int']>;
+  language?: InputMaybe<Scalars['String']>;
+  language_version?: InputMaybe<Scalars['Int']>;
   parental_guidance?: InputMaybe<ParentalGuidanceInput>;
-  uid?: InputMaybe<Scalars["String"]>;
+  uid?: InputMaybe<Scalars['String']>;
 };
+
 
 export type MutationUpdatePersonArgs = {
-  external_id?: InputMaybe<Scalars["String"]>;
-  global_version?: InputMaybe<Scalars["Int"]>;
-  language?: InputMaybe<Scalars["String"]>;
-  language_version?: InputMaybe<Scalars["Int"]>;
+  external_id?: InputMaybe<Scalars['String']>;
+  global_version?: InputMaybe<Scalars['Int']>;
+  language?: InputMaybe<Scalars['String']>;
+  language_version?: InputMaybe<Scalars['Int']>;
   person?: InputMaybe<PersonInput>;
-  uid?: InputMaybe<Scalars["String"]>;
+  uid?: InputMaybe<Scalars['String']>;
 };
+
 
 export type MutationUpdateRatingArgs = {
-  external_id?: InputMaybe<Scalars["String"]>;
-  global_version?: InputMaybe<Scalars["Int"]>;
-  language?: InputMaybe<Scalars["String"]>;
-  language_version?: InputMaybe<Scalars["Int"]>;
+  external_id?: InputMaybe<Scalars['String']>;
+  global_version?: InputMaybe<Scalars['Int']>;
+  language?: InputMaybe<Scalars['String']>;
+  language_version?: InputMaybe<Scalars['Int']>;
   rating?: InputMaybe<RatingInput>;
-  uid?: InputMaybe<Scalars["String"]>;
+  uid?: InputMaybe<Scalars['String']>;
 };
+
 
 export type MutationUpdateRoleArgs = {
-  external_id?: InputMaybe<Scalars["String"]>;
-  global_version?: InputMaybe<Scalars["Int"]>;
-  language?: InputMaybe<Scalars["String"]>;
-  language_version?: InputMaybe<Scalars["Int"]>;
+  external_id?: InputMaybe<Scalars['String']>;
+  global_version?: InputMaybe<Scalars['Int']>;
+  language?: InputMaybe<Scalars['String']>;
+  language_version?: InputMaybe<Scalars['Int']>;
   role?: InputMaybe<RoleInput>;
-  uid?: InputMaybe<Scalars["String"]>;
+  uid?: InputMaybe<Scalars['String']>;
 };
+
 
 export type MutationUpdateSeasonArgs = {
-  external_id?: InputMaybe<Scalars["String"]>;
-  global_version?: InputMaybe<Scalars["Int"]>;
-  language?: InputMaybe<Scalars["String"]>;
-  language_version?: InputMaybe<Scalars["Int"]>;
+  external_id?: InputMaybe<Scalars['String']>;
+  global_version?: InputMaybe<Scalars['Int']>;
+  language?: InputMaybe<Scalars['String']>;
+  language_version?: InputMaybe<Scalars['Int']>;
   season?: InputMaybe<SeasonInput>;
-  uid?: InputMaybe<Scalars["String"]>;
+  uid?: InputMaybe<Scalars['String']>;
 };
+
 
 export type MutationUpdateSetArgs = {
-  external_id?: InputMaybe<Scalars["String"]>;
-  global_version?: InputMaybe<Scalars["Int"]>;
-  language?: InputMaybe<Scalars["String"]>;
-  language_version?: InputMaybe<Scalars["Int"]>;
+  external_id?: InputMaybe<Scalars['String']>;
+  global_version?: InputMaybe<Scalars['Int']>;
+  language?: InputMaybe<Scalars['String']>;
+  language_version?: InputMaybe<Scalars['Int']>;
   set?: InputMaybe<SetInput>;
-  uid?: InputMaybe<Scalars["String"]>;
+  uid?: InputMaybe<Scalars['String']>;
 };
+
 
 export type MutationUpdateTagArgs = {
-  external_id?: InputMaybe<Scalars["String"]>;
-  global_version?: InputMaybe<Scalars["Int"]>;
-  language?: InputMaybe<Scalars["String"]>;
-  language_version?: InputMaybe<Scalars["Int"]>;
+  external_id?: InputMaybe<Scalars['String']>;
+  global_version?: InputMaybe<Scalars['Int']>;
+  language?: InputMaybe<Scalars['String']>;
+  language_version?: InputMaybe<Scalars['Int']>;
   tag?: InputMaybe<TagInput>;
-  uid?: InputMaybe<Scalars["String"]>;
+  uid?: InputMaybe<Scalars['String']>;
 };
 
+
 export type MutationUpdateThemeArgs = {
-  external_id?: InputMaybe<Scalars["String"]>;
-  global_version?: InputMaybe<Scalars["Int"]>;
-  language?: InputMaybe<Scalars["String"]>;
-  language_version?: InputMaybe<Scalars["Int"]>;
+  external_id?: InputMaybe<Scalars['String']>;
+  global_version?: InputMaybe<Scalars['Int']>;
+  language?: InputMaybe<Scalars['String']>;
+  language_version?: InputMaybe<Scalars['Int']>;
   theme?: InputMaybe<ThemeInput>;
-  uid?: InputMaybe<Scalars["String"]>;
+  uid?: InputMaybe<Scalars['String']>;
 };
 
 export type ObjectDeleteResponse = {
-  __typename?: "ObjectDeleteResponse";
-  global_version?: Maybe<Scalars["String"]>;
-  language?: Maybe<Scalars["String"]>;
-  language_version?: Maybe<Scalars["String"]>;
-  message?: Maybe<Scalars["String"]>;
-  removed_relationships?: Maybe<Array<Maybe<Scalars["String"]>>>;
-  uid: Scalars["String"];
+  __typename?: 'ObjectDeleteResponse';
+  global_version?: Maybe<Scalars['String']>;
+  language?: Maybe<Scalars['String']>;
+  language_version?: Maybe<Scalars['String']>;
+  message?: Maybe<Scalars['String']>;
+  removed_relationships?: Maybe<Array<Maybe<Scalars['String']>>>;
+  uid: Scalars['String'];
 };
 
 export enum OrderDirections {
-  Asc = "ASC",
-  Desc = "DESC",
+  Asc = 'ASC',
+  Desc = 'DESC'
 }
 
 export type ParentalGuidance = Metadata & {
-  __typename?: "ParentalGuidance";
+  __typename?: 'ParentalGuidance';
   _meta?: Maybe<_ParentalGuidanceMeta>;
   assets?: Maybe<AssetListing>;
   availability?: Maybe<AvailabilityListing>;
-  external_id?: Maybe<Scalars["String"]>;
+  external_id?: Maybe<Scalars['String']>;
   ratings?: Maybe<RatingListing>;
-  reason?: Maybe<Scalars["String"]>;
-  slug?: Maybe<Scalars["String"]>;
-  uid: Scalars["String"];
+  reason?: Maybe<Scalars['String']>;
+  slug?: Maybe<Scalars['String']>;
+  uid: Scalars['String'];
 };
+
 
 export type ParentalGuidance_MetaArgs = {
-  global_version?: InputMaybe<Scalars["Int"]>;
-  language?: InputMaybe<Scalars["String"]>;
-  language_version?: InputMaybe<Scalars["Int"]>;
+  global_version?: InputMaybe<Scalars['Int']>;
+  language?: InputMaybe<Scalars['String']>;
+  language_version?: InputMaybe<Scalars['Int']>;
 };
+
 
 export type ParentalGuidanceAssetsArgs = {
-  language?: InputMaybe<Scalars["String"]>;
-  limit?: InputMaybe<Scalars["Int"]>;
-  next_token?: InputMaybe<Scalars["String"]>;
+  language?: InputMaybe<Scalars['String']>;
+  limit?: InputMaybe<Scalars['Int']>;
+  next_token?: InputMaybe<Scalars['String']>;
 };
+
 
 export type ParentalGuidanceAvailabilityArgs = {
-  limit?: InputMaybe<Scalars["Int"]>;
-  next_token?: InputMaybe<Scalars["String"]>;
+  limit?: InputMaybe<Scalars['Int']>;
+  next_token?: InputMaybe<Scalars['String']>;
 };
 
+
 export type ParentalGuidanceRatingsArgs = {
-  language?: InputMaybe<Scalars["String"]>;
-  limit?: InputMaybe<Scalars["Int"]>;
-  next_token?: InputMaybe<Scalars["String"]>;
+  language?: InputMaybe<Scalars['String']>;
+  limit?: InputMaybe<Scalars['Int']>;
+  next_token?: InputMaybe<Scalars['String']>;
 };
 
 export type ParentalGuidanceInput = {
   availability?: InputMaybe<AssignAvailabilityInput>;
-  data_source_fields?: InputMaybe<Array<InputMaybe<Scalars["String"]>>>;
-  data_source_id?: InputMaybe<Scalars["String"]>;
-  external_id?: InputMaybe<Scalars["String"]>;
-  reason?: InputMaybe<Scalars["String"]>;
+  data_source_fields?: InputMaybe<Array<InputMaybe<Scalars['String']>>>;
+  data_source_id?: InputMaybe<Scalars['String']>;
+  external_id?: InputMaybe<Scalars['String']>;
+  reason?: InputMaybe<Scalars['String']>;
   relationships?: InputMaybe<ParentalGuidanceRelationships>;
-  slug?: InputMaybe<Scalars["String"]>;
+  slug?: InputMaybe<Scalars['String']>;
 };
 
 export type ParentalGuidanceListing = Listing & {
-  __typename?: "ParentalGuidanceListing";
-  count?: Maybe<Scalars["Int"]>;
-  next_token?: Maybe<Scalars["String"]>;
+  __typename?: 'ParentalGuidanceListing';
+  count?: Maybe<Scalars['Int']>;
+  next_token?: Maybe<Scalars['String']>;
   objects?: Maybe<Array<Maybe<ParentalGuidance>>>;
 };
 
 export type ParentalGuidanceRelationshipInput = {
   create?: InputMaybe<Array<InputMaybe<ParentalGuidanceInput>>>;
-  link?: InputMaybe<Array<InputMaybe<Scalars["String"]>>>;
-  unlink?: InputMaybe<Array<InputMaybe<Scalars["String"]>>>;
+  link?: InputMaybe<Array<InputMaybe<Scalars['String']>>>;
+  unlink?: InputMaybe<Array<InputMaybe<Scalars['String']>>>;
 };
 
 export type ParentalGuidanceRelationships = {
@@ -1481,85 +1592,90 @@ export type ParentalGuidanceRelationships = {
 };
 
 export type Person = CurationMetadata & {
-  __typename?: "Person";
+  __typename?: 'Person';
   _meta?: Maybe<_PersonMeta>;
-  abbreviation?: Maybe<Scalars["String"]>;
-  alias?: Maybe<Scalars["String"]>;
+  abbreviation?: Maybe<Scalars['String']>;
+  alias?: Maybe<Scalars['String']>;
   availability?: Maybe<AvailabilityListing>;
-  bio_long?: Maybe<Scalars["String"]>;
-  bio_medium?: Maybe<Scalars["String"]>;
-  bio_short?: Maybe<Scalars["String"]>;
+  bio_long?: Maybe<Scalars['String']>;
+  bio_medium?: Maybe<Scalars['String']>;
+  bio_short?: Maybe<Scalars['String']>;
   credits?: Maybe<CreditListing>;
-  date_of_birth?: Maybe<Scalars["AWSDateTime"]>;
-  external_id?: Maybe<Scalars["String"]>;
-  gender?: Maybe<Scalars["String"]>;
+  date_of_birth?: Maybe<Scalars['AWSDateTime']>;
+  external_id?: Maybe<Scalars['String']>;
+  gender?: Maybe<Scalars['String']>;
   images?: Maybe<ImageListing>;
-  name?: Maybe<Scalars["String"]>;
-  name_sort?: Maybe<Scalars["String"]>;
-  place_of_birth?: Maybe<Scalars["String"]>;
+  name?: Maybe<Scalars['String']>;
+  name_sort?: Maybe<Scalars['String']>;
+  place_of_birth?: Maybe<Scalars['String']>;
   sets?: Maybe<SetListing>;
-  slug?: Maybe<Scalars["String"]>;
-  uid: Scalars["String"];
+  slug?: Maybe<Scalars['String']>;
+  uid: Scalars['String'];
 };
+
 
 export type Person_MetaArgs = {
-  global_version?: InputMaybe<Scalars["Int"]>;
-  language?: InputMaybe<Scalars["String"]>;
-  language_version?: InputMaybe<Scalars["Int"]>;
+  global_version?: InputMaybe<Scalars['Int']>;
+  language?: InputMaybe<Scalars['String']>;
+  language_version?: InputMaybe<Scalars['Int']>;
 };
+
 
 export type PersonAvailabilityArgs = {
-  limit?: InputMaybe<Scalars["Int"]>;
-  next_token?: InputMaybe<Scalars["String"]>;
+  limit?: InputMaybe<Scalars['Int']>;
+  next_token?: InputMaybe<Scalars['String']>;
 };
+
 
 export type PersonCreditsArgs = {
-  language?: InputMaybe<Scalars["String"]>;
-  limit?: InputMaybe<Scalars["Int"]>;
-  next_token?: InputMaybe<Scalars["String"]>;
+  language?: InputMaybe<Scalars['String']>;
+  limit?: InputMaybe<Scalars['Int']>;
+  next_token?: InputMaybe<Scalars['String']>;
 };
+
 
 export type PersonImagesArgs = {
-  language?: InputMaybe<Scalars["String"]>;
-  limit?: InputMaybe<Scalars["Int"]>;
-  next_token?: InputMaybe<Scalars["String"]>;
+  language?: InputMaybe<Scalars['String']>;
+  limit?: InputMaybe<Scalars['Int']>;
+  next_token?: InputMaybe<Scalars['String']>;
 };
 
+
 export type PersonSetsArgs = {
-  limit?: InputMaybe<Scalars["Int"]>;
-  next_token?: InputMaybe<Scalars["String"]>;
+  limit?: InputMaybe<Scalars['Int']>;
+  next_token?: InputMaybe<Scalars['String']>;
 };
 
 export type PersonInput = {
-  abbreviation?: InputMaybe<Scalars["String"]>;
-  alias?: InputMaybe<Scalars["String"]>;
+  abbreviation?: InputMaybe<Scalars['String']>;
+  alias?: InputMaybe<Scalars['String']>;
   availability?: InputMaybe<AssignAvailabilityInput>;
-  bio_long?: InputMaybe<Scalars["String"]>;
-  bio_medium?: InputMaybe<Scalars["String"]>;
-  bio_short?: InputMaybe<Scalars["String"]>;
-  data_source_fields?: InputMaybe<Array<InputMaybe<Scalars["String"]>>>;
-  data_source_id?: InputMaybe<Scalars["String"]>;
-  date_of_birth?: InputMaybe<Scalars["AWSDateTime"]>;
-  external_id?: InputMaybe<Scalars["String"]>;
-  gender?: InputMaybe<Scalars["String"]>;
-  name?: InputMaybe<Scalars["String"]>;
-  name_sort?: InputMaybe<Scalars["String"]>;
-  place_of_birth?: InputMaybe<Scalars["String"]>;
+  bio_long?: InputMaybe<Scalars['String']>;
+  bio_medium?: InputMaybe<Scalars['String']>;
+  bio_short?: InputMaybe<Scalars['String']>;
+  data_source_fields?: InputMaybe<Array<InputMaybe<Scalars['String']>>>;
+  data_source_id?: InputMaybe<Scalars['String']>;
+  date_of_birth?: InputMaybe<Scalars['AWSDateTime']>;
+  external_id?: InputMaybe<Scalars['String']>;
+  gender?: InputMaybe<Scalars['String']>;
+  name?: InputMaybe<Scalars['String']>;
+  name_sort?: InputMaybe<Scalars['String']>;
+  place_of_birth?: InputMaybe<Scalars['String']>;
   relationships?: InputMaybe<PersonRelationships>;
-  slug?: InputMaybe<Scalars["String"]>;
+  slug?: InputMaybe<Scalars['String']>;
 };
 
 export type PersonListing = Listing & {
-  __typename?: "PersonListing";
-  count?: Maybe<Scalars["Int"]>;
-  next_token?: Maybe<Scalars["String"]>;
+  __typename?: 'PersonListing';
+  count?: Maybe<Scalars['Int']>;
+  next_token?: Maybe<Scalars['String']>;
   objects?: Maybe<Array<Maybe<Person>>>;
 };
 
 export type PersonRelationshipInput = {
   create?: InputMaybe<Array<InputMaybe<PersonInput>>>;
-  link?: InputMaybe<Array<InputMaybe<Scalars["String"]>>>;
-  unlink?: InputMaybe<Array<InputMaybe<Scalars["String"]>>>;
+  link?: InputMaybe<Array<InputMaybe<Scalars['String']>>>;
+  unlink?: InputMaybe<Array<InputMaybe<Scalars['String']>>>;
 };
 
 export type PersonRelationships = {
@@ -1569,24 +1685,24 @@ export type PersonRelationships = {
 
 export type PersonSetCreate = {
   object?: InputMaybe<PersonInput>;
-  position: Scalars["Int"];
+  position: Scalars['Int'];
 };
 
 export type PersonSetInput = {
   create?: InputMaybe<Array<InputMaybe<PersonSetCreate>>>;
   link?: InputMaybe<Array<InputMaybe<SetLink>>>;
   reposition?: InputMaybe<Array<InputMaybe<SetLink>>>;
-  unlink?: InputMaybe<Array<InputMaybe<Scalars["String"]>>>;
+  unlink?: InputMaybe<Array<InputMaybe<Scalars['String']>>>;
 };
 
 export enum PublishStage {
-  Archive = "ARCHIVE",
-  Preview = "PREVIEW",
-  Prod = "PROD",
+  Archive = 'ARCHIVE',
+  Preview = 'PREVIEW',
+  Prod = 'PROD'
 }
 
 export type Query = {
-  __typename?: "Query";
+  __typename?: 'Query';
   getAsset?: Maybe<Asset>;
   getAvailability?: Maybe<Availability>;
   getBrand?: Maybe<Brand>;
@@ -1623,538 +1739,589 @@ export type Query = {
   listTheme?: Maybe<ThemeListing>;
 };
 
+
 export type QueryGetAssetArgs = {
   dimensions?: InputMaybe<Array<InputMaybe<UserDimension>>>;
-  external_id?: InputMaybe<Scalars["String"]>;
-  ignore_availability?: InputMaybe<Scalars["Boolean"]>;
-  language?: InputMaybe<Scalars["String"]>;
-  time_travel?: InputMaybe<Scalars["AWSDateTime"]>;
-  uid?: InputMaybe<Scalars["String"]>;
+  external_id?: InputMaybe<Scalars['String']>;
+  ignore_availability?: InputMaybe<Scalars['Boolean']>;
+  language?: InputMaybe<Scalars['String']>;
+  time_travel?: InputMaybe<Scalars['AWSDateTime']>;
+  uid?: InputMaybe<Scalars['String']>;
 };
 
+
 export type QueryGetAvailabilityArgs = {
-  external_id?: InputMaybe<Scalars["String"]>;
-  uid?: InputMaybe<Scalars["String"]>;
+  external_id?: InputMaybe<Scalars['String']>;
+  uid?: InputMaybe<Scalars['String']>;
 };
+
 
 export type QueryGetBrandArgs = {
   dimensions?: InputMaybe<Array<InputMaybe<UserDimension>>>;
-  external_id?: InputMaybe<Scalars["String"]>;
-  ignore_availability?: InputMaybe<Scalars["Boolean"]>;
-  language?: InputMaybe<Scalars["String"]>;
-  time_travel?: InputMaybe<Scalars["AWSDateTime"]>;
-  uid?: InputMaybe<Scalars["String"]>;
+  external_id?: InputMaybe<Scalars['String']>;
+  ignore_availability?: InputMaybe<Scalars['Boolean']>;
+  language?: InputMaybe<Scalars['String']>;
+  time_travel?: InputMaybe<Scalars['AWSDateTime']>;
+  uid?: InputMaybe<Scalars['String']>;
 };
+
 
 export type QueryGetCreditArgs = {
   dimensions?: InputMaybe<Array<InputMaybe<UserDimension>>>;
-  external_id?: InputMaybe<Scalars["String"]>;
-  ignore_availability?: InputMaybe<Scalars["Boolean"]>;
-  language?: InputMaybe<Scalars["String"]>;
-  time_travel?: InputMaybe<Scalars["AWSDateTime"]>;
-  uid?: InputMaybe<Scalars["String"]>;
+  external_id?: InputMaybe<Scalars['String']>;
+  ignore_availability?: InputMaybe<Scalars['Boolean']>;
+  language?: InputMaybe<Scalars['String']>;
+  time_travel?: InputMaybe<Scalars['AWSDateTime']>;
+  uid?: InputMaybe<Scalars['String']>;
 };
 
+
 export type QueryGetDimensionArgs = {
-  dimension_id?: InputMaybe<Scalars["String"]>;
-  external_id?: InputMaybe<Scalars["String"]>;
+  dimension_id?: InputMaybe<Scalars['String']>;
+  external_id?: InputMaybe<Scalars['String']>;
 };
+
 
 export type QueryGetEpisodeArgs = {
   dimensions?: InputMaybe<Array<InputMaybe<UserDimension>>>;
-  external_id?: InputMaybe<Scalars["String"]>;
-  ignore_availability?: InputMaybe<Scalars["Boolean"]>;
-  language?: InputMaybe<Scalars["String"]>;
-  time_travel?: InputMaybe<Scalars["AWSDateTime"]>;
-  uid?: InputMaybe<Scalars["String"]>;
+  external_id?: InputMaybe<Scalars['String']>;
+  ignore_availability?: InputMaybe<Scalars['Boolean']>;
+  language?: InputMaybe<Scalars['String']>;
+  time_travel?: InputMaybe<Scalars['AWSDateTime']>;
+  uid?: InputMaybe<Scalars['String']>;
 };
+
 
 export type QueryGetGenreArgs = {
   dimensions?: InputMaybe<Array<InputMaybe<UserDimension>>>;
-  external_id?: InputMaybe<Scalars["String"]>;
-  ignore_availability?: InputMaybe<Scalars["Boolean"]>;
-  language?: InputMaybe<Scalars["String"]>;
-  time_travel?: InputMaybe<Scalars["AWSDateTime"]>;
-  uid?: InputMaybe<Scalars["String"]>;
+  external_id?: InputMaybe<Scalars['String']>;
+  ignore_availability?: InputMaybe<Scalars['Boolean']>;
+  language?: InputMaybe<Scalars['String']>;
+  time_travel?: InputMaybe<Scalars['AWSDateTime']>;
+  uid?: InputMaybe<Scalars['String']>;
 };
+
 
 export type QueryGetImageArgs = {
   dimensions?: InputMaybe<Array<InputMaybe<UserDimension>>>;
-  external_id?: InputMaybe<Scalars["String"]>;
-  ignore_availability?: InputMaybe<Scalars["Boolean"]>;
-  language?: InputMaybe<Scalars["String"]>;
-  time_travel?: InputMaybe<Scalars["AWSDateTime"]>;
-  uid?: InputMaybe<Scalars["String"]>;
+  external_id?: InputMaybe<Scalars['String']>;
+  ignore_availability?: InputMaybe<Scalars['Boolean']>;
+  language?: InputMaybe<Scalars['String']>;
+  time_travel?: InputMaybe<Scalars['AWSDateTime']>;
+  uid?: InputMaybe<Scalars['String']>;
 };
+
 
 export type QueryGetMovieArgs = {
   dimensions?: InputMaybe<Array<InputMaybe<UserDimension>>>;
-  external_id?: InputMaybe<Scalars["String"]>;
-  ignore_availability?: InputMaybe<Scalars["Boolean"]>;
-  language?: InputMaybe<Scalars["String"]>;
-  time_travel?: InputMaybe<Scalars["AWSDateTime"]>;
-  uid?: InputMaybe<Scalars["String"]>;
+  external_id?: InputMaybe<Scalars['String']>;
+  ignore_availability?: InputMaybe<Scalars['Boolean']>;
+  language?: InputMaybe<Scalars['String']>;
+  time_travel?: InputMaybe<Scalars['AWSDateTime']>;
+  uid?: InputMaybe<Scalars['String']>;
 };
+
 
 export type QueryGetParentalGuidanceArgs = {
   dimensions?: InputMaybe<Array<InputMaybe<UserDimension>>>;
-  external_id?: InputMaybe<Scalars["String"]>;
-  ignore_availability?: InputMaybe<Scalars["Boolean"]>;
-  language?: InputMaybe<Scalars["String"]>;
-  time_travel?: InputMaybe<Scalars["AWSDateTime"]>;
-  uid?: InputMaybe<Scalars["String"]>;
+  external_id?: InputMaybe<Scalars['String']>;
+  ignore_availability?: InputMaybe<Scalars['Boolean']>;
+  language?: InputMaybe<Scalars['String']>;
+  time_travel?: InputMaybe<Scalars['AWSDateTime']>;
+  uid?: InputMaybe<Scalars['String']>;
 };
+
 
 export type QueryGetPersonArgs = {
   dimensions?: InputMaybe<Array<InputMaybe<UserDimension>>>;
-  external_id?: InputMaybe<Scalars["String"]>;
-  ignore_availability?: InputMaybe<Scalars["Boolean"]>;
-  language?: InputMaybe<Scalars["String"]>;
-  time_travel?: InputMaybe<Scalars["AWSDateTime"]>;
-  uid?: InputMaybe<Scalars["String"]>;
+  external_id?: InputMaybe<Scalars['String']>;
+  ignore_availability?: InputMaybe<Scalars['Boolean']>;
+  language?: InputMaybe<Scalars['String']>;
+  time_travel?: InputMaybe<Scalars['AWSDateTime']>;
+  uid?: InputMaybe<Scalars['String']>;
 };
+
 
 export type QueryGetRatingArgs = {
   dimensions?: InputMaybe<Array<InputMaybe<UserDimension>>>;
-  external_id?: InputMaybe<Scalars["String"]>;
-  ignore_availability?: InputMaybe<Scalars["Boolean"]>;
-  language?: InputMaybe<Scalars["String"]>;
-  time_travel?: InputMaybe<Scalars["AWSDateTime"]>;
-  uid?: InputMaybe<Scalars["String"]>;
+  external_id?: InputMaybe<Scalars['String']>;
+  ignore_availability?: InputMaybe<Scalars['Boolean']>;
+  language?: InputMaybe<Scalars['String']>;
+  time_travel?: InputMaybe<Scalars['AWSDateTime']>;
+  uid?: InputMaybe<Scalars['String']>;
 };
+
 
 export type QueryGetRoleArgs = {
   dimensions?: InputMaybe<Array<InputMaybe<UserDimension>>>;
-  external_id?: InputMaybe<Scalars["String"]>;
-  ignore_availability?: InputMaybe<Scalars["Boolean"]>;
-  language?: InputMaybe<Scalars["String"]>;
-  time_travel?: InputMaybe<Scalars["AWSDateTime"]>;
-  uid?: InputMaybe<Scalars["String"]>;
+  external_id?: InputMaybe<Scalars['String']>;
+  ignore_availability?: InputMaybe<Scalars['Boolean']>;
+  language?: InputMaybe<Scalars['String']>;
+  time_travel?: InputMaybe<Scalars['AWSDateTime']>;
+  uid?: InputMaybe<Scalars['String']>;
 };
+
 
 export type QueryGetSeasonArgs = {
   dimensions?: InputMaybe<Array<InputMaybe<UserDimension>>>;
-  external_id?: InputMaybe<Scalars["String"]>;
-  ignore_availability?: InputMaybe<Scalars["Boolean"]>;
-  language?: InputMaybe<Scalars["String"]>;
-  time_travel?: InputMaybe<Scalars["AWSDateTime"]>;
-  uid?: InputMaybe<Scalars["String"]>;
+  external_id?: InputMaybe<Scalars['String']>;
+  ignore_availability?: InputMaybe<Scalars['Boolean']>;
+  language?: InputMaybe<Scalars['String']>;
+  time_travel?: InputMaybe<Scalars['AWSDateTime']>;
+  uid?: InputMaybe<Scalars['String']>;
 };
+
 
 export type QueryGetSetArgs = {
   dimensions?: InputMaybe<Array<InputMaybe<UserDimension>>>;
-  external_id?: InputMaybe<Scalars["String"]>;
-  ignore_availability?: InputMaybe<Scalars["Boolean"]>;
-  language?: InputMaybe<Scalars["String"]>;
-  time_travel?: InputMaybe<Scalars["AWSDateTime"]>;
-  uid?: InputMaybe<Scalars["String"]>;
+  external_id?: InputMaybe<Scalars['String']>;
+  ignore_availability?: InputMaybe<Scalars['Boolean']>;
+  language?: InputMaybe<Scalars['String']>;
+  time_travel?: InputMaybe<Scalars['AWSDateTime']>;
+  uid?: InputMaybe<Scalars['String']>;
 };
+
 
 export type QueryGetTagArgs = {
   dimensions?: InputMaybe<Array<InputMaybe<UserDimension>>>;
-  external_id?: InputMaybe<Scalars["String"]>;
-  ignore_availability?: InputMaybe<Scalars["Boolean"]>;
-  language?: InputMaybe<Scalars["String"]>;
-  time_travel?: InputMaybe<Scalars["AWSDateTime"]>;
-  uid?: InputMaybe<Scalars["String"]>;
+  external_id?: InputMaybe<Scalars['String']>;
+  ignore_availability?: InputMaybe<Scalars['Boolean']>;
+  language?: InputMaybe<Scalars['String']>;
+  time_travel?: InputMaybe<Scalars['AWSDateTime']>;
+  uid?: InputMaybe<Scalars['String']>;
 };
+
 
 export type QueryGetThemeArgs = {
   dimensions?: InputMaybe<Array<InputMaybe<UserDimension>>>;
-  external_id?: InputMaybe<Scalars["String"]>;
-  ignore_availability?: InputMaybe<Scalars["Boolean"]>;
-  language?: InputMaybe<Scalars["String"]>;
-  time_travel?: InputMaybe<Scalars["AWSDateTime"]>;
-  uid?: InputMaybe<Scalars["String"]>;
+  external_id?: InputMaybe<Scalars['String']>;
+  ignore_availability?: InputMaybe<Scalars['Boolean']>;
+  language?: InputMaybe<Scalars['String']>;
+  time_travel?: InputMaybe<Scalars['AWSDateTime']>;
+  uid?: InputMaybe<Scalars['String']>;
 };
+
 
 export type QueryListAssetArgs = {
   dimensions?: InputMaybe<Array<InputMaybe<UserDimension>>>;
-  ignore_availability?: InputMaybe<Scalars["Boolean"]>;
-  language?: InputMaybe<Scalars["String"]>;
-  limit?: InputMaybe<Scalars["Int"]>;
-  next_token?: InputMaybe<Scalars["String"]>;
-  time_travel?: InputMaybe<Scalars["AWSDateTime"]>;
+  ignore_availability?: InputMaybe<Scalars['Boolean']>;
+  language?: InputMaybe<Scalars['String']>;
+  limit?: InputMaybe<Scalars['Int']>;
+  next_token?: InputMaybe<Scalars['String']>;
+  time_travel?: InputMaybe<Scalars['AWSDateTime']>;
 };
 
+
 export type QueryListAvailabilityArgs = {
-  limit?: InputMaybe<Scalars["Int"]>;
-  next_token?: InputMaybe<Scalars["String"]>;
+  limit?: InputMaybe<Scalars['Int']>;
+  next_token?: InputMaybe<Scalars['String']>;
 };
+
 
 export type QueryListBrandArgs = {
   dimensions?: InputMaybe<Array<InputMaybe<UserDimension>>>;
-  ignore_availability?: InputMaybe<Scalars["Boolean"]>;
-  language?: InputMaybe<Scalars["String"]>;
-  limit?: InputMaybe<Scalars["Int"]>;
-  next_token?: InputMaybe<Scalars["String"]>;
-  time_travel?: InputMaybe<Scalars["AWSDateTime"]>;
+  ignore_availability?: InputMaybe<Scalars['Boolean']>;
+  language?: InputMaybe<Scalars['String']>;
+  limit?: InputMaybe<Scalars['Int']>;
+  next_token?: InputMaybe<Scalars['String']>;
+  time_travel?: InputMaybe<Scalars['AWSDateTime']>;
 };
+
 
 export type QueryListCreditArgs = {
   dimensions?: InputMaybe<Array<InputMaybe<UserDimension>>>;
-  ignore_availability?: InputMaybe<Scalars["Boolean"]>;
-  language?: InputMaybe<Scalars["String"]>;
-  limit?: InputMaybe<Scalars["Int"]>;
-  next_token?: InputMaybe<Scalars["String"]>;
-  time_travel?: InputMaybe<Scalars["AWSDateTime"]>;
+  ignore_availability?: InputMaybe<Scalars['Boolean']>;
+  language?: InputMaybe<Scalars['String']>;
+  limit?: InputMaybe<Scalars['Int']>;
+  next_token?: InputMaybe<Scalars['String']>;
+  time_travel?: InputMaybe<Scalars['AWSDateTime']>;
 };
+
 
 export type QueryListEpisodeArgs = {
   dimensions?: InputMaybe<Array<InputMaybe<UserDimension>>>;
-  ignore_availability?: InputMaybe<Scalars["Boolean"]>;
-  language?: InputMaybe<Scalars["String"]>;
-  limit?: InputMaybe<Scalars["Int"]>;
-  next_token?: InputMaybe<Scalars["String"]>;
-  time_travel?: InputMaybe<Scalars["AWSDateTime"]>;
+  ignore_availability?: InputMaybe<Scalars['Boolean']>;
+  language?: InputMaybe<Scalars['String']>;
+  limit?: InputMaybe<Scalars['Int']>;
+  next_token?: InputMaybe<Scalars['String']>;
+  time_travel?: InputMaybe<Scalars['AWSDateTime']>;
 };
+
 
 export type QueryListGenreArgs = {
   dimensions?: InputMaybe<Array<InputMaybe<UserDimension>>>;
-  ignore_availability?: InputMaybe<Scalars["Boolean"]>;
-  language?: InputMaybe<Scalars["String"]>;
-  limit?: InputMaybe<Scalars["Int"]>;
-  next_token?: InputMaybe<Scalars["String"]>;
-  time_travel?: InputMaybe<Scalars["AWSDateTime"]>;
+  ignore_availability?: InputMaybe<Scalars['Boolean']>;
+  language?: InputMaybe<Scalars['String']>;
+  limit?: InputMaybe<Scalars['Int']>;
+  next_token?: InputMaybe<Scalars['String']>;
+  time_travel?: InputMaybe<Scalars['AWSDateTime']>;
 };
+
 
 export type QueryListImageArgs = {
   dimensions?: InputMaybe<Array<InputMaybe<UserDimension>>>;
-  ignore_availability?: InputMaybe<Scalars["Boolean"]>;
-  language?: InputMaybe<Scalars["String"]>;
-  limit?: InputMaybe<Scalars["Int"]>;
-  next_token?: InputMaybe<Scalars["String"]>;
-  time_travel?: InputMaybe<Scalars["AWSDateTime"]>;
+  ignore_availability?: InputMaybe<Scalars['Boolean']>;
+  language?: InputMaybe<Scalars['String']>;
+  limit?: InputMaybe<Scalars['Int']>;
+  next_token?: InputMaybe<Scalars['String']>;
+  time_travel?: InputMaybe<Scalars['AWSDateTime']>;
 };
+
 
 export type QueryListMovieArgs = {
   dimensions?: InputMaybe<Array<InputMaybe<UserDimension>>>;
-  ignore_availability?: InputMaybe<Scalars["Boolean"]>;
-  language?: InputMaybe<Scalars["String"]>;
-  limit?: InputMaybe<Scalars["Int"]>;
-  next_token?: InputMaybe<Scalars["String"]>;
-  time_travel?: InputMaybe<Scalars["AWSDateTime"]>;
+  ignore_availability?: InputMaybe<Scalars['Boolean']>;
+  language?: InputMaybe<Scalars['String']>;
+  limit?: InputMaybe<Scalars['Int']>;
+  next_token?: InputMaybe<Scalars['String']>;
+  time_travel?: InputMaybe<Scalars['AWSDateTime']>;
 };
+
 
 export type QueryListParentalGuidanceArgs = {
   dimensions?: InputMaybe<Array<InputMaybe<UserDimension>>>;
-  ignore_availability?: InputMaybe<Scalars["Boolean"]>;
-  language?: InputMaybe<Scalars["String"]>;
-  limit?: InputMaybe<Scalars["Int"]>;
-  next_token?: InputMaybe<Scalars["String"]>;
-  time_travel?: InputMaybe<Scalars["AWSDateTime"]>;
+  ignore_availability?: InputMaybe<Scalars['Boolean']>;
+  language?: InputMaybe<Scalars['String']>;
+  limit?: InputMaybe<Scalars['Int']>;
+  next_token?: InputMaybe<Scalars['String']>;
+  time_travel?: InputMaybe<Scalars['AWSDateTime']>;
 };
+
 
 export type QueryListPersonArgs = {
   dimensions?: InputMaybe<Array<InputMaybe<UserDimension>>>;
-  ignore_availability?: InputMaybe<Scalars["Boolean"]>;
-  language?: InputMaybe<Scalars["String"]>;
-  limit?: InputMaybe<Scalars["Int"]>;
-  next_token?: InputMaybe<Scalars["String"]>;
-  time_travel?: InputMaybe<Scalars["AWSDateTime"]>;
+  ignore_availability?: InputMaybe<Scalars['Boolean']>;
+  language?: InputMaybe<Scalars['String']>;
+  limit?: InputMaybe<Scalars['Int']>;
+  next_token?: InputMaybe<Scalars['String']>;
+  time_travel?: InputMaybe<Scalars['AWSDateTime']>;
 };
+
 
 export type QueryListRatingArgs = {
   dimensions?: InputMaybe<Array<InputMaybe<UserDimension>>>;
-  ignore_availability?: InputMaybe<Scalars["Boolean"]>;
-  language?: InputMaybe<Scalars["String"]>;
-  limit?: InputMaybe<Scalars["Int"]>;
-  next_token?: InputMaybe<Scalars["String"]>;
-  time_travel?: InputMaybe<Scalars["AWSDateTime"]>;
+  ignore_availability?: InputMaybe<Scalars['Boolean']>;
+  language?: InputMaybe<Scalars['String']>;
+  limit?: InputMaybe<Scalars['Int']>;
+  next_token?: InputMaybe<Scalars['String']>;
+  time_travel?: InputMaybe<Scalars['AWSDateTime']>;
 };
+
 
 export type QueryListRoleArgs = {
   dimensions?: InputMaybe<Array<InputMaybe<UserDimension>>>;
-  ignore_availability?: InputMaybe<Scalars["Boolean"]>;
-  language?: InputMaybe<Scalars["String"]>;
-  limit?: InputMaybe<Scalars["Int"]>;
-  next_token?: InputMaybe<Scalars["String"]>;
-  time_travel?: InputMaybe<Scalars["AWSDateTime"]>;
+  ignore_availability?: InputMaybe<Scalars['Boolean']>;
+  language?: InputMaybe<Scalars['String']>;
+  limit?: InputMaybe<Scalars['Int']>;
+  next_token?: InputMaybe<Scalars['String']>;
+  time_travel?: InputMaybe<Scalars['AWSDateTime']>;
 };
+
 
 export type QueryListSeasonArgs = {
   dimensions?: InputMaybe<Array<InputMaybe<UserDimension>>>;
-  ignore_availability?: InputMaybe<Scalars["Boolean"]>;
-  language?: InputMaybe<Scalars["String"]>;
-  limit?: InputMaybe<Scalars["Int"]>;
-  next_token?: InputMaybe<Scalars["String"]>;
-  time_travel?: InputMaybe<Scalars["AWSDateTime"]>;
+  ignore_availability?: InputMaybe<Scalars['Boolean']>;
+  language?: InputMaybe<Scalars['String']>;
+  limit?: InputMaybe<Scalars['Int']>;
+  next_token?: InputMaybe<Scalars['String']>;
+  time_travel?: InputMaybe<Scalars['AWSDateTime']>;
 };
+
 
 export type QueryListSetArgs = {
   dimensions?: InputMaybe<Array<InputMaybe<UserDimension>>>;
-  ignore_availability?: InputMaybe<Scalars["Boolean"]>;
-  language?: InputMaybe<Scalars["String"]>;
-  limit?: InputMaybe<Scalars["Int"]>;
-  next_token?: InputMaybe<Scalars["String"]>;
-  time_travel?: InputMaybe<Scalars["AWSDateTime"]>;
+  ignore_availability?: InputMaybe<Scalars['Boolean']>;
+  language?: InputMaybe<Scalars['String']>;
+  limit?: InputMaybe<Scalars['Int']>;
+  next_token?: InputMaybe<Scalars['String']>;
+  time_travel?: InputMaybe<Scalars['AWSDateTime']>;
 };
+
 
 export type QueryListTagArgs = {
   dimensions?: InputMaybe<Array<InputMaybe<UserDimension>>>;
-  ignore_availability?: InputMaybe<Scalars["Boolean"]>;
-  language?: InputMaybe<Scalars["String"]>;
-  limit?: InputMaybe<Scalars["Int"]>;
-  next_token?: InputMaybe<Scalars["String"]>;
-  time_travel?: InputMaybe<Scalars["AWSDateTime"]>;
+  ignore_availability?: InputMaybe<Scalars['Boolean']>;
+  language?: InputMaybe<Scalars['String']>;
+  limit?: InputMaybe<Scalars['Int']>;
+  next_token?: InputMaybe<Scalars['String']>;
+  time_travel?: InputMaybe<Scalars['AWSDateTime']>;
 };
+
 
 export type QueryListThemeArgs = {
   dimensions?: InputMaybe<Array<InputMaybe<UserDimension>>>;
-  ignore_availability?: InputMaybe<Scalars["Boolean"]>;
-  language?: InputMaybe<Scalars["String"]>;
-  limit?: InputMaybe<Scalars["Int"]>;
-  next_token?: InputMaybe<Scalars["String"]>;
-  time_travel?: InputMaybe<Scalars["AWSDateTime"]>;
+  ignore_availability?: InputMaybe<Scalars['Boolean']>;
+  language?: InputMaybe<Scalars['String']>;
+  limit?: InputMaybe<Scalars['Int']>;
+  next_token?: InputMaybe<Scalars['String']>;
+  time_travel?: InputMaybe<Scalars['AWSDateTime']>;
 };
 
 export type Rating = Metadata & {
-  __typename?: "Rating";
+  __typename?: 'Rating';
   _meta?: Maybe<_RatingMeta>;
   availability?: Maybe<AvailabilityListing>;
-  description?: Maybe<Scalars["String"]>;
-  external_id?: Maybe<Scalars["String"]>;
+  description?: Maybe<Scalars['String']>;
+  external_id?: Maybe<Scalars['String']>;
   parental_guidance?: Maybe<ParentalGuidanceListing>;
   parents?: Maybe<EntertainmentListing>;
-  scheme?: Maybe<Scalars["String"]>;
-  slug?: Maybe<Scalars["String"]>;
-  title?: Maybe<Scalars["String"]>;
-  uid: Scalars["String"];
-  value: Scalars["String"];
+  scheme?: Maybe<Scalars['String']>;
+  slug?: Maybe<Scalars['String']>;
+  title?: Maybe<Scalars['String']>;
+  uid: Scalars['String'];
+  value: Scalars['String'];
 };
+
 
 export type Rating_MetaArgs = {
-  global_version?: InputMaybe<Scalars["Int"]>;
-  language?: InputMaybe<Scalars["String"]>;
-  language_version?: InputMaybe<Scalars["Int"]>;
+  global_version?: InputMaybe<Scalars['Int']>;
+  language?: InputMaybe<Scalars['String']>;
+  language_version?: InputMaybe<Scalars['Int']>;
 };
+
 
 export type RatingAvailabilityArgs = {
-  limit?: InputMaybe<Scalars["Int"]>;
-  next_token?: InputMaybe<Scalars["String"]>;
+  limit?: InputMaybe<Scalars['Int']>;
+  next_token?: InputMaybe<Scalars['String']>;
 };
+
 
 export type RatingParental_GuidanceArgs = {
-  language?: InputMaybe<Scalars["String"]>;
-  limit?: InputMaybe<Scalars["Int"]>;
-  next_token?: InputMaybe<Scalars["String"]>;
+  language?: InputMaybe<Scalars['String']>;
+  limit?: InputMaybe<Scalars['Int']>;
+  next_token?: InputMaybe<Scalars['String']>;
 };
 
+
 export type RatingParentsArgs = {
-  language?: InputMaybe<Scalars["String"]>;
-  limit?: InputMaybe<Scalars["Int"]>;
-  next_token?: InputMaybe<Scalars["String"]>;
+  language?: InputMaybe<Scalars['String']>;
+  limit?: InputMaybe<Scalars['Int']>;
+  next_token?: InputMaybe<Scalars['String']>;
 };
 
 export type RatingInput = {
   availability?: InputMaybe<AssignAvailabilityInput>;
-  data_source_fields?: InputMaybe<Array<InputMaybe<Scalars["String"]>>>;
-  data_source_id?: InputMaybe<Scalars["String"]>;
-  description?: InputMaybe<Scalars["String"]>;
-  external_id?: InputMaybe<Scalars["String"]>;
-  scheme?: InputMaybe<Scalars["String"]>;
-  slug?: InputMaybe<Scalars["String"]>;
-  title?: InputMaybe<Scalars["String"]>;
-  value: Scalars["String"];
+  data_source_fields?: InputMaybe<Array<InputMaybe<Scalars['String']>>>;
+  data_source_id?: InputMaybe<Scalars['String']>;
+  description?: InputMaybe<Scalars['String']>;
+  external_id?: InputMaybe<Scalars['String']>;
+  scheme?: InputMaybe<Scalars['String']>;
+  slug?: InputMaybe<Scalars['String']>;
+  title?: InputMaybe<Scalars['String']>;
+  value: Scalars['String'];
 };
 
 export type RatingListing = Listing & {
-  __typename?: "RatingListing";
-  count?: Maybe<Scalars["Int"]>;
-  next_token?: Maybe<Scalars["String"]>;
+  __typename?: 'RatingListing';
+  count?: Maybe<Scalars['Int']>;
+  next_token?: Maybe<Scalars['String']>;
   objects?: Maybe<Array<Maybe<Rating>>>;
 };
 
 export type RatingRelationshipInput = {
   create?: InputMaybe<Array<InputMaybe<RatingInput>>>;
-  link?: InputMaybe<Array<InputMaybe<Scalars["String"]>>>;
-  unlink?: InputMaybe<Array<InputMaybe<Scalars["String"]>>>;
+  link?: InputMaybe<Array<InputMaybe<Scalars['String']>>>;
+  unlink?: InputMaybe<Array<InputMaybe<Scalars['String']>>>;
 };
 
 export type Role = Metadata & {
-  __typename?: "Role";
+  __typename?: 'Role';
   _meta?: Maybe<_RoleMeta>;
   availability?: Maybe<AvailabilityListing>;
   credits?: Maybe<CreditListing>;
-  external_id?: Maybe<Scalars["String"]>;
-  slug?: Maybe<Scalars["String"]>;
-  title?: Maybe<Scalars["String"]>;
-  uid: Scalars["String"];
+  external_id?: Maybe<Scalars['String']>;
+  slug?: Maybe<Scalars['String']>;
+  title?: Maybe<Scalars['String']>;
+  uid: Scalars['String'];
 };
+
 
 export type Role_MetaArgs = {
-  global_version?: InputMaybe<Scalars["Int"]>;
-  language?: InputMaybe<Scalars["String"]>;
-  language_version?: InputMaybe<Scalars["Int"]>;
+  global_version?: InputMaybe<Scalars['Int']>;
+  language?: InputMaybe<Scalars['String']>;
+  language_version?: InputMaybe<Scalars['Int']>;
 };
+
 
 export type RoleAvailabilityArgs = {
-  limit?: InputMaybe<Scalars["Int"]>;
-  next_token?: InputMaybe<Scalars["String"]>;
+  limit?: InputMaybe<Scalars['Int']>;
+  next_token?: InputMaybe<Scalars['String']>;
 };
 
+
 export type RoleCreditsArgs = {
-  language?: InputMaybe<Scalars["String"]>;
-  limit?: InputMaybe<Scalars["Int"]>;
-  next_token?: InputMaybe<Scalars["String"]>;
+  language?: InputMaybe<Scalars['String']>;
+  limit?: InputMaybe<Scalars['Int']>;
+  next_token?: InputMaybe<Scalars['String']>;
 };
 
 export type RoleInput = {
   availability?: InputMaybe<AssignAvailabilityInput>;
-  data_source_fields?: InputMaybe<Array<InputMaybe<Scalars["String"]>>>;
-  data_source_id?: InputMaybe<Scalars["String"]>;
-  external_id?: InputMaybe<Scalars["String"]>;
+  data_source_fields?: InputMaybe<Array<InputMaybe<Scalars['String']>>>;
+  data_source_id?: InputMaybe<Scalars['String']>;
+  external_id?: InputMaybe<Scalars['String']>;
   relationships?: InputMaybe<RoleRelationships>;
-  title?: InputMaybe<Scalars["String"]>;
+  title?: InputMaybe<Scalars['String']>;
 };
 
 export type RoleListing = Listing & {
-  __typename?: "RoleListing";
-  count?: Maybe<Scalars["Int"]>;
-  next_token?: Maybe<Scalars["String"]>;
+  __typename?: 'RoleListing';
+  count?: Maybe<Scalars['Int']>;
+  next_token?: Maybe<Scalars['String']>;
   objects?: Maybe<Array<Maybe<Role>>>;
 };
 
 export type RoleRelationshipInput = {
   create?: InputMaybe<Array<InputMaybe<RoleInput>>>;
-  link?: InputMaybe<Array<InputMaybe<Scalars["String"]>>>;
-  unlink?: InputMaybe<Array<InputMaybe<Scalars["String"]>>>;
+  link?: InputMaybe<Array<InputMaybe<Scalars['String']>>>;
+  unlink?: InputMaybe<Array<InputMaybe<Scalars['String']>>>;
 };
 
 export type RoleRelationships = {
   credits?: InputMaybe<CreditRelationshipInput>;
 };
 
-export type Season = CurationMetadata &
-  Entertainment & {
-    __typename?: "Season";
-    _meta?: Maybe<_SeasonMeta>;
-    assets?: Maybe<AssetListing>;
-    availability?: Maybe<AvailabilityListing>;
-    brands?: Maybe<BrandListing>;
-    credits?: Maybe<CreditListing>;
-    episodes?: Maybe<EpisodeListing>;
-    external_id?: Maybe<Scalars["String"]>;
-    genres?: Maybe<GenreListing>;
-    images?: Maybe<ImageListing>;
-    number_of_episodes?: Maybe<Scalars["Int"]>;
-    ratings?: Maybe<RatingListing>;
-    release_date?: Maybe<Scalars["String"]>;
-    season_number?: Maybe<Scalars["Int"]>;
-    sets?: Maybe<SetListing>;
-    slug?: Maybe<Scalars["String"]>;
-    synopsis_long?: Maybe<Scalars["String"]>;
-    synopsis_medium?: Maybe<Scalars["String"]>;
-    synopsis_short?: Maybe<Scalars["String"]>;
-    tags?: Maybe<TagListing>;
-    themes?: Maybe<ThemeListing>;
-    title?: Maybe<Scalars["String"]>;
-    title_long?: Maybe<Scalars["String"]>;
-    title_medium?: Maybe<Scalars["String"]>;
-    title_short?: Maybe<Scalars["String"]>;
-    uid: Scalars["String"];
-  };
+export type Season = CurationMetadata & Entertainment & {
+  __typename?: 'Season';
+  _meta?: Maybe<_SeasonMeta>;
+  assets?: Maybe<AssetListing>;
+  availability?: Maybe<AvailabilityListing>;
+  brands?: Maybe<BrandListing>;
+  credits?: Maybe<CreditListing>;
+  episodes?: Maybe<EpisodeListing>;
+  external_id?: Maybe<Scalars['String']>;
+  genres?: Maybe<GenreListing>;
+  images?: Maybe<ImageListing>;
+  number_of_episodes?: Maybe<Scalars['Int']>;
+  ratings?: Maybe<RatingListing>;
+  release_date?: Maybe<Scalars['String']>;
+  season_number?: Maybe<Scalars['Int']>;
+  sets?: Maybe<SetListing>;
+  slug?: Maybe<Scalars['String']>;
+  synopsis_long?: Maybe<Scalars['String']>;
+  synopsis_medium?: Maybe<Scalars['String']>;
+  synopsis_short?: Maybe<Scalars['String']>;
+  tags?: Maybe<TagListing>;
+  themes?: Maybe<ThemeListing>;
+  title?: Maybe<Scalars['String']>;
+  title_long?: Maybe<Scalars['String']>;
+  title_medium?: Maybe<Scalars['String']>;
+  title_short?: Maybe<Scalars['String']>;
+  uid: Scalars['String'];
+};
+
 
 export type Season_MetaArgs = {
-  global_version?: InputMaybe<Scalars["Int"]>;
-  language?: InputMaybe<Scalars["String"]>;
-  language_version?: InputMaybe<Scalars["Int"]>;
+  global_version?: InputMaybe<Scalars['Int']>;
+  language?: InputMaybe<Scalars['String']>;
+  language_version?: InputMaybe<Scalars['Int']>;
 };
+
 
 export type SeasonAssetsArgs = {
-  language?: InputMaybe<Scalars["String"]>;
-  limit?: InputMaybe<Scalars["Int"]>;
-  next_token?: InputMaybe<Scalars["String"]>;
+  language?: InputMaybe<Scalars['String']>;
+  limit?: InputMaybe<Scalars['Int']>;
+  next_token?: InputMaybe<Scalars['String']>;
 };
+
 
 export type SeasonAvailabilityArgs = {
-  limit?: InputMaybe<Scalars["Int"]>;
-  next_token?: InputMaybe<Scalars["String"]>;
+  limit?: InputMaybe<Scalars['Int']>;
+  next_token?: InputMaybe<Scalars['String']>;
 };
+
 
 export type SeasonBrandsArgs = {
-  language?: InputMaybe<Scalars["String"]>;
-  limit?: InputMaybe<Scalars["Int"]>;
-  next_token?: InputMaybe<Scalars["String"]>;
+  language?: InputMaybe<Scalars['String']>;
+  limit?: InputMaybe<Scalars['Int']>;
+  next_token?: InputMaybe<Scalars['String']>;
 };
+
 
 export type SeasonCreditsArgs = {
-  language?: InputMaybe<Scalars["String"]>;
-  limit?: InputMaybe<Scalars["Int"]>;
-  next_token?: InputMaybe<Scalars["String"]>;
+  language?: InputMaybe<Scalars['String']>;
+  limit?: InputMaybe<Scalars['Int']>;
+  next_token?: InputMaybe<Scalars['String']>;
 };
+
 
 export type SeasonEpisodesArgs = {
-  language?: InputMaybe<Scalars["String"]>;
-  limit?: InputMaybe<Scalars["Int"]>;
-  next_token?: InputMaybe<Scalars["String"]>;
+  language?: InputMaybe<Scalars['String']>;
+  limit?: InputMaybe<Scalars['Int']>;
+  next_token?: InputMaybe<Scalars['String']>;
 };
+
 
 export type SeasonGenresArgs = {
-  language?: InputMaybe<Scalars["String"]>;
-  limit?: InputMaybe<Scalars["Int"]>;
-  next_token?: InputMaybe<Scalars["String"]>;
+  language?: InputMaybe<Scalars['String']>;
+  limit?: InputMaybe<Scalars['Int']>;
+  next_token?: InputMaybe<Scalars['String']>;
 };
+
 
 export type SeasonImagesArgs = {
-  language?: InputMaybe<Scalars["String"]>;
-  limit?: InputMaybe<Scalars["Int"]>;
-  next_token?: InputMaybe<Scalars["String"]>;
+  language?: InputMaybe<Scalars['String']>;
+  limit?: InputMaybe<Scalars['Int']>;
+  next_token?: InputMaybe<Scalars['String']>;
 };
+
 
 export type SeasonRatingsArgs = {
-  language?: InputMaybe<Scalars["String"]>;
-  limit?: InputMaybe<Scalars["Int"]>;
-  next_token?: InputMaybe<Scalars["String"]>;
+  language?: InputMaybe<Scalars['String']>;
+  limit?: InputMaybe<Scalars['Int']>;
+  next_token?: InputMaybe<Scalars['String']>;
 };
+
 
 export type SeasonSetsArgs = {
-  limit?: InputMaybe<Scalars["Int"]>;
-  next_token?: InputMaybe<Scalars["String"]>;
+  limit?: InputMaybe<Scalars['Int']>;
+  next_token?: InputMaybe<Scalars['String']>;
 };
+
 
 export type SeasonTagsArgs = {
-  language?: InputMaybe<Scalars["String"]>;
-  limit?: InputMaybe<Scalars["Int"]>;
-  next_token?: InputMaybe<Scalars["String"]>;
+  language?: InputMaybe<Scalars['String']>;
+  limit?: InputMaybe<Scalars['Int']>;
+  next_token?: InputMaybe<Scalars['String']>;
 };
 
+
 export type SeasonThemesArgs = {
-  language?: InputMaybe<Scalars["String"]>;
-  limit?: InputMaybe<Scalars["Int"]>;
-  next_token?: InputMaybe<Scalars["String"]>;
+  language?: InputMaybe<Scalars['String']>;
+  limit?: InputMaybe<Scalars['Int']>;
+  next_token?: InputMaybe<Scalars['String']>;
 };
 
 export type SeasonInput = {
   availability?: InputMaybe<AssignAvailabilityInput>;
-  data_source_fields?: InputMaybe<Array<InputMaybe<Scalars["String"]>>>;
-  data_source_id?: InputMaybe<Scalars["String"]>;
-  external_id?: InputMaybe<Scalars["String"]>;
-  number_of_episodes?: InputMaybe<Scalars["Int"]>;
+  data_source_fields?: InputMaybe<Array<InputMaybe<Scalars['String']>>>;
+  data_source_id?: InputMaybe<Scalars['String']>;
+  external_id?: InputMaybe<Scalars['String']>;
+  number_of_episodes?: InputMaybe<Scalars['Int']>;
   relationships?: InputMaybe<SeasonRelationships>;
-  release_date?: InputMaybe<Scalars["String"]>;
-  season_number?: InputMaybe<Scalars["Int"]>;
-  slug?: InputMaybe<Scalars["String"]>;
-  synopsis_long?: InputMaybe<Scalars["String"]>;
-  synopsis_medium?: InputMaybe<Scalars["String"]>;
-  synopsis_short?: InputMaybe<Scalars["String"]>;
-  title?: InputMaybe<Scalars["String"]>;
-  title_long?: InputMaybe<Scalars["String"]>;
-  title_medium?: InputMaybe<Scalars["String"]>;
-  title_short?: InputMaybe<Scalars["String"]>;
+  release_date?: InputMaybe<Scalars['String']>;
+  season_number?: InputMaybe<Scalars['Int']>;
+  slug?: InputMaybe<Scalars['String']>;
+  synopsis_long?: InputMaybe<Scalars['String']>;
+  synopsis_medium?: InputMaybe<Scalars['String']>;
+  synopsis_short?: InputMaybe<Scalars['String']>;
+  title?: InputMaybe<Scalars['String']>;
+  title_long?: InputMaybe<Scalars['String']>;
+  title_medium?: InputMaybe<Scalars['String']>;
+  title_short?: InputMaybe<Scalars['String']>;
 };
 
 export type SeasonListing = Listing & {
-  __typename?: "SeasonListing";
-  count?: Maybe<Scalars["Int"]>;
-  next_token?: Maybe<Scalars["String"]>;
+  __typename?: 'SeasonListing';
+  count?: Maybe<Scalars['Int']>;
+  next_token?: Maybe<Scalars['String']>;
   objects?: Maybe<Array<Maybe<Season>>>;
 };
 
 export type SeasonRelationshipInput = {
   create?: InputMaybe<Array<InputMaybe<SeasonInput>>>;
-  link?: InputMaybe<Array<InputMaybe<Scalars["String"]>>>;
-  unlink?: InputMaybe<Array<InputMaybe<Scalars["String"]>>>;
+  link?: InputMaybe<Array<InputMaybe<Scalars['String']>>>;
+  unlink?: InputMaybe<Array<InputMaybe<Scalars['String']>>>;
 };
 
 export type SeasonRelationships = {
@@ -2171,114 +2338,124 @@ export type SeasonRelationships = {
 
 export type SeasonSetCreate = {
   object?: InputMaybe<SeasonInput>;
-  position: Scalars["Int"];
+  position: Scalars['Int'];
 };
 
 export type SeasonSetInput = {
   create?: InputMaybe<Array<InputMaybe<SeasonSetCreate>>>;
   link?: InputMaybe<Array<InputMaybe<SetLink>>>;
   reposition?: InputMaybe<Array<InputMaybe<SetLink>>>;
-  unlink?: InputMaybe<Array<InputMaybe<Scalars["String"]>>>;
+  unlink?: InputMaybe<Array<InputMaybe<Scalars['String']>>>;
 };
 
-export type Set = CurationMetadata &
-  Entertainment & {
-    __typename?: "Set";
-    _meta?: Maybe<_SetMeta>;
-    assets?: Maybe<AssetListing>;
-    availability?: Maybe<AvailabilityListing>;
-    content?: Maybe<CurationMetadataListing>;
-    credits?: Maybe<CreditListing>;
-    description?: Maybe<Scalars["String"]>;
-    external_id?: Maybe<Scalars["String"]>;
-    genres?: Maybe<GenreListing>;
-    images?: Maybe<ImageListing>;
-    ratings?: Maybe<RatingListing>;
-    release_date?: Maybe<Scalars["String"]>;
-    sets?: Maybe<SetListing>;
-    slug?: Maybe<Scalars["String"]>;
-    synopsis_long?: Maybe<Scalars["String"]>;
-    synopsis_medium?: Maybe<Scalars["String"]>;
-    synopsis_short?: Maybe<Scalars["String"]>;
-    tags?: Maybe<TagListing>;
-    themes?: Maybe<ThemeListing>;
-    title?: Maybe<Scalars["String"]>;
-    title_long?: Maybe<Scalars["String"]>;
-    title_medium?: Maybe<Scalars["String"]>;
-    title_short?: Maybe<Scalars["String"]>;
-    type?: Maybe<Scalars["String"]>;
-    uid: Scalars["String"];
-  };
+export type Set = CurationMetadata & Entertainment & {
+  __typename?: 'Set';
+  _meta?: Maybe<_SetMeta>;
+  assets?: Maybe<AssetListing>;
+  availability?: Maybe<AvailabilityListing>;
+  content?: Maybe<CurationMetadataListing>;
+  credits?: Maybe<CreditListing>;
+  description?: Maybe<Scalars['String']>;
+  external_id?: Maybe<Scalars['String']>;
+  genres?: Maybe<GenreListing>;
+  images?: Maybe<ImageListing>;
+  ratings?: Maybe<RatingListing>;
+  release_date?: Maybe<Scalars['String']>;
+  sets?: Maybe<SetListing>;
+  slug?: Maybe<Scalars['String']>;
+  synopsis_long?: Maybe<Scalars['String']>;
+  synopsis_medium?: Maybe<Scalars['String']>;
+  synopsis_short?: Maybe<Scalars['String']>;
+  tags?: Maybe<TagListing>;
+  themes?: Maybe<ThemeListing>;
+  title?: Maybe<Scalars['String']>;
+  title_long?: Maybe<Scalars['String']>;
+  title_medium?: Maybe<Scalars['String']>;
+  title_short?: Maybe<Scalars['String']>;
+  type?: Maybe<Scalars['String']>;
+  uid: Scalars['String'];
+};
+
 
 export type Set_MetaArgs = {
-  global_version?: InputMaybe<Scalars["Int"]>;
-  language?: InputMaybe<Scalars["String"]>;
-  language_version?: InputMaybe<Scalars["Int"]>;
+  global_version?: InputMaybe<Scalars['Int']>;
+  language?: InputMaybe<Scalars['String']>;
+  language_version?: InputMaybe<Scalars['Int']>;
 };
+
 
 export type SetAssetsArgs = {
-  language?: InputMaybe<Scalars["String"]>;
-  limit?: InputMaybe<Scalars["Int"]>;
-  next_token?: InputMaybe<Scalars["String"]>;
+  language?: InputMaybe<Scalars['String']>;
+  limit?: InputMaybe<Scalars['Int']>;
+  next_token?: InputMaybe<Scalars['String']>;
 };
+
 
 export type SetAvailabilityArgs = {
-  limit?: InputMaybe<Scalars["Int"]>;
-  next_token?: InputMaybe<Scalars["String"]>;
+  limit?: InputMaybe<Scalars['Int']>;
+  next_token?: InputMaybe<Scalars['String']>;
 };
 
+
 export type SetContentArgs = {
-  language?: InputMaybe<Scalars["String"]>;
-  limit?: InputMaybe<Scalars["Int"]>;
-  next_token?: InputMaybe<Scalars["String"]>;
+  language?: InputMaybe<Scalars['String']>;
+  limit?: InputMaybe<Scalars['Int']>;
+  next_token?: InputMaybe<Scalars['String']>;
   order?: InputMaybe<OrderDirections>;
 };
 
+
 export type SetCreditsArgs = {
-  language?: InputMaybe<Scalars["String"]>;
-  limit?: InputMaybe<Scalars["Int"]>;
-  next_token?: InputMaybe<Scalars["String"]>;
+  language?: InputMaybe<Scalars['String']>;
+  limit?: InputMaybe<Scalars['Int']>;
+  next_token?: InputMaybe<Scalars['String']>;
 };
+
 
 export type SetGenresArgs = {
-  language?: InputMaybe<Scalars["String"]>;
-  limit?: InputMaybe<Scalars["Int"]>;
-  next_token?: InputMaybe<Scalars["String"]>;
+  language?: InputMaybe<Scalars['String']>;
+  limit?: InputMaybe<Scalars['Int']>;
+  next_token?: InputMaybe<Scalars['String']>;
 };
+
 
 export type SetImagesArgs = {
-  language?: InputMaybe<Scalars["String"]>;
-  limit?: InputMaybe<Scalars["Int"]>;
-  next_token?: InputMaybe<Scalars["String"]>;
+  language?: InputMaybe<Scalars['String']>;
+  limit?: InputMaybe<Scalars['Int']>;
+  next_token?: InputMaybe<Scalars['String']>;
 };
+
 
 export type SetRatingsArgs = {
-  language?: InputMaybe<Scalars["String"]>;
-  limit?: InputMaybe<Scalars["Int"]>;
-  next_token?: InputMaybe<Scalars["String"]>;
+  language?: InputMaybe<Scalars['String']>;
+  limit?: InputMaybe<Scalars['Int']>;
+  next_token?: InputMaybe<Scalars['String']>;
 };
+
 
 export type SetSetsArgs = {
-  limit?: InputMaybe<Scalars["Int"]>;
-  next_token?: InputMaybe<Scalars["String"]>;
+  limit?: InputMaybe<Scalars['Int']>;
+  next_token?: InputMaybe<Scalars['String']>;
 };
+
 
 export type SetTagsArgs = {
-  language?: InputMaybe<Scalars["String"]>;
-  limit?: InputMaybe<Scalars["Int"]>;
-  next_token?: InputMaybe<Scalars["String"]>;
+  language?: InputMaybe<Scalars['String']>;
+  limit?: InputMaybe<Scalars['Int']>;
+  next_token?: InputMaybe<Scalars['String']>;
 };
 
+
 export type SetThemesArgs = {
-  language?: InputMaybe<Scalars["String"]>;
-  limit?: InputMaybe<Scalars["Int"]>;
-  next_token?: InputMaybe<Scalars["String"]>;
+  language?: InputMaybe<Scalars['String']>;
+  limit?: InputMaybe<Scalars['Int']>;
+  next_token?: InputMaybe<Scalars['String']>;
 };
 
 export type SetContent = {
-  __typename?: "SetContent";
+  __typename?: 'SetContent';
   object?: Maybe<CurationMetadata>;
-  position?: Maybe<Scalars["Int"]>;
+  position?: Maybe<Scalars['Int']>;
 };
 
 export type SetContentRelationships = {
@@ -2295,32 +2472,32 @@ export type SetContentRelationships = {
 export type SetInput = {
   availability?: InputMaybe<AssignAvailabilityInput>;
   content?: InputMaybe<SetContentRelationships>;
-  data_source_fields?: InputMaybe<Array<InputMaybe<Scalars["String"]>>>;
-  data_source_id?: InputMaybe<Scalars["String"]>;
-  description?: InputMaybe<Scalars["String"]>;
-  external_id?: InputMaybe<Scalars["String"]>;
+  data_source_fields?: InputMaybe<Array<InputMaybe<Scalars['String']>>>;
+  data_source_id?: InputMaybe<Scalars['String']>;
+  description?: InputMaybe<Scalars['String']>;
+  external_id?: InputMaybe<Scalars['String']>;
   relationships?: InputMaybe<SetRelationships>;
-  release_date?: InputMaybe<Scalars["String"]>;
-  slug?: InputMaybe<Scalars["String"]>;
-  synopsis_long?: InputMaybe<Scalars["String"]>;
-  synopsis_medium?: InputMaybe<Scalars["String"]>;
-  synopsis_short?: InputMaybe<Scalars["String"]>;
-  title?: InputMaybe<Scalars["String"]>;
-  title_long?: InputMaybe<Scalars["String"]>;
-  title_medium?: InputMaybe<Scalars["String"]>;
-  title_short?: InputMaybe<Scalars["String"]>;
+  release_date?: InputMaybe<Scalars['String']>;
+  slug?: InputMaybe<Scalars['String']>;
+  synopsis_long?: InputMaybe<Scalars['String']>;
+  synopsis_medium?: InputMaybe<Scalars['String']>;
+  synopsis_short?: InputMaybe<Scalars['String']>;
+  title?: InputMaybe<Scalars['String']>;
+  title_long?: InputMaybe<Scalars['String']>;
+  title_medium?: InputMaybe<Scalars['String']>;
+  title_short?: InputMaybe<Scalars['String']>;
   type?: InputMaybe<SetType>;
 };
 
 export type SetLink = {
-  position: Scalars["Int"];
-  uid: Scalars["String"];
+  position: Scalars['Int'];
+  uid: Scalars['String'];
 };
 
 export type SetListing = {
-  __typename?: "SetListing";
-  count?: Maybe<Scalars["Int"]>;
-  next_token?: Maybe<Scalars["String"]>;
+  __typename?: 'SetListing';
+  count?: Maybe<Scalars['Int']>;
+  next_token?: Maybe<Scalars['String']>;
   objects?: Maybe<Array<Maybe<Set>>>;
 };
 
@@ -2335,189 +2512,196 @@ export type SetRelationships = {
 };
 
 export enum SetType {
-  Collection = "COLLECTION",
-  Page = "PAGE",
-  Rail = "RAIL",
-  Slider = "SLIDER",
+  Collection = 'COLLECTION',
+  Page = 'PAGE',
+  Rail = 'RAIL',
+  Slider = 'SLIDER'
 }
 
 export type SubsetCreate = {
   object?: InputMaybe<SetInput>;
-  position: Scalars["Int"];
+  position: Scalars['Int'];
 };
 
 export type SubsetInput = {
   create?: InputMaybe<Array<InputMaybe<SubsetCreate>>>;
   link?: InputMaybe<Array<InputMaybe<SetLink>>>;
   reposition?: InputMaybe<Array<InputMaybe<SetLink>>>;
-  unlink?: InputMaybe<Array<InputMaybe<Scalars["String"]>>>;
+  unlink?: InputMaybe<Array<InputMaybe<Scalars['String']>>>;
 };
 
 export type Tag = Metadata & {
-  __typename?: "Tag";
+  __typename?: 'Tag';
   _meta?: Maybe<_TagMeta>;
   availability?: Maybe<AvailabilityListing>;
-  external_id?: Maybe<Scalars["String"]>;
-  name?: Maybe<Scalars["String"]>;
+  external_id?: Maybe<Scalars['String']>;
+  name?: Maybe<Scalars['String']>;
   parents?: Maybe<EntertainmentListing>;
-  slug?: Maybe<Scalars["String"]>;
-  tag_category?: Maybe<Scalars["String"]>;
-  uid: Scalars["String"];
+  slug?: Maybe<Scalars['String']>;
+  tag_category?: Maybe<Scalars['String']>;
+  uid: Scalars['String'];
 };
+
 
 export type Tag_MetaArgs = {
-  global_version?: InputMaybe<Scalars["Int"]>;
-  language?: InputMaybe<Scalars["String"]>;
-  language_version?: InputMaybe<Scalars["Int"]>;
+  global_version?: InputMaybe<Scalars['Int']>;
+  language?: InputMaybe<Scalars['String']>;
+  language_version?: InputMaybe<Scalars['Int']>;
 };
+
 
 export type TagAvailabilityArgs = {
-  limit?: InputMaybe<Scalars["Int"]>;
-  next_token?: InputMaybe<Scalars["String"]>;
+  limit?: InputMaybe<Scalars['Int']>;
+  next_token?: InputMaybe<Scalars['String']>;
 };
 
+
 export type TagParentsArgs = {
-  language?: InputMaybe<Scalars["String"]>;
-  limit?: InputMaybe<Scalars["Int"]>;
-  next_token?: InputMaybe<Scalars["String"]>;
+  language?: InputMaybe<Scalars['String']>;
+  limit?: InputMaybe<Scalars['Int']>;
+  next_token?: InputMaybe<Scalars['String']>;
 };
 
 export type TagInput = {
   availability?: InputMaybe<AssignAvailabilityInput>;
-  data_source_fields?: InputMaybe<Array<InputMaybe<Scalars["String"]>>>;
-  data_source_id?: InputMaybe<Scalars["String"]>;
-  external_id?: InputMaybe<Scalars["String"]>;
-  name?: InputMaybe<Scalars["String"]>;
-  slug?: InputMaybe<Scalars["String"]>;
-  tag_category?: InputMaybe<Scalars["String"]>;
+  data_source_fields?: InputMaybe<Array<InputMaybe<Scalars['String']>>>;
+  data_source_id?: InputMaybe<Scalars['String']>;
+  external_id?: InputMaybe<Scalars['String']>;
+  name?: InputMaybe<Scalars['String']>;
+  slug?: InputMaybe<Scalars['String']>;
+  tag_category?: InputMaybe<Scalars['String']>;
 };
 
 export type TagListing = Listing & {
-  __typename?: "TagListing";
-  count?: Maybe<Scalars["Int"]>;
-  next_token?: Maybe<Scalars["String"]>;
+  __typename?: 'TagListing';
+  count?: Maybe<Scalars['Int']>;
+  next_token?: Maybe<Scalars['String']>;
   objects?: Maybe<Array<Maybe<Tag>>>;
 };
 
 export type TagRelationshipInput = {
   create?: InputMaybe<Array<InputMaybe<TagInput>>>;
-  link?: InputMaybe<Array<InputMaybe<Scalars["String"]>>>;
-  unlink?: InputMaybe<Array<InputMaybe<Scalars["String"]>>>;
+  link?: InputMaybe<Array<InputMaybe<Scalars['String']>>>;
+  unlink?: InputMaybe<Array<InputMaybe<Scalars['String']>>>;
 };
 
 export type TagSetCreate = {
   object?: InputMaybe<TagInput>;
-  position: Scalars["Int"];
+  position: Scalars['Int'];
 };
 
 export type TagSetInput = {
   create?: InputMaybe<Array<InputMaybe<TagSetCreate>>>;
   link?: InputMaybe<Array<InputMaybe<SetLink>>>;
   reposition?: InputMaybe<Array<InputMaybe<SetLink>>>;
-  unlink?: InputMaybe<Array<InputMaybe<Scalars["String"]>>>;
+  unlink?: InputMaybe<Array<InputMaybe<Scalars['String']>>>;
 };
 
 export type Theme = CurationMetadata & {
-  __typename?: "Theme";
+  __typename?: 'Theme';
   _meta?: Maybe<_ThemeMeta>;
   availability?: Maybe<AvailabilityListing>;
-  external_id?: Maybe<Scalars["String"]>;
-  metadata_source?: Maybe<Scalars["String"]>;
-  name?: Maybe<Scalars["String"]>;
+  external_id?: Maybe<Scalars['String']>;
+  metadata_source?: Maybe<Scalars['String']>;
+  name?: Maybe<Scalars['String']>;
   parents?: Maybe<EntertainmentListing>;
   sets?: Maybe<SetListing>;
-  slug?: Maybe<Scalars["String"]>;
-  uid: Scalars["String"];
+  slug?: Maybe<Scalars['String']>;
+  uid: Scalars['String'];
 };
+
 
 export type Theme_MetaArgs = {
-  global_version?: InputMaybe<Scalars["Int"]>;
-  language?: InputMaybe<Scalars["String"]>;
-  language_version?: InputMaybe<Scalars["Int"]>;
+  global_version?: InputMaybe<Scalars['Int']>;
+  language?: InputMaybe<Scalars['String']>;
+  language_version?: InputMaybe<Scalars['Int']>;
 };
+
 
 export type ThemeAvailabilityArgs = {
-  limit?: InputMaybe<Scalars["Int"]>;
-  next_token?: InputMaybe<Scalars["String"]>;
+  limit?: InputMaybe<Scalars['Int']>;
+  next_token?: InputMaybe<Scalars['String']>;
 };
+
 
 export type ThemeParentsArgs = {
-  language?: InputMaybe<Scalars["String"]>;
-  limit?: InputMaybe<Scalars["Int"]>;
-  next_token?: InputMaybe<Scalars["String"]>;
+  language?: InputMaybe<Scalars['String']>;
+  limit?: InputMaybe<Scalars['Int']>;
+  next_token?: InputMaybe<Scalars['String']>;
 };
 
+
 export type ThemeSetsArgs = {
-  limit?: InputMaybe<Scalars["Int"]>;
-  next_token?: InputMaybe<Scalars["String"]>;
+  limit?: InputMaybe<Scalars['Int']>;
+  next_token?: InputMaybe<Scalars['String']>;
 };
 
 export type ThemeInput = {
   availability?: InputMaybe<AssignAvailabilityInput>;
-  data_source_fields?: InputMaybe<Array<InputMaybe<Scalars["String"]>>>;
-  data_source_id?: InputMaybe<Scalars["String"]>;
-  external_id?: InputMaybe<Scalars["String"]>;
-  metadata_source?: InputMaybe<Scalars["String"]>;
-  name?: InputMaybe<Scalars["String"]>;
-  slug?: InputMaybe<Scalars["String"]>;
+  data_source_fields?: InputMaybe<Array<InputMaybe<Scalars['String']>>>;
+  data_source_id?: InputMaybe<Scalars['String']>;
+  external_id?: InputMaybe<Scalars['String']>;
+  metadata_source?: InputMaybe<Scalars['String']>;
+  name?: InputMaybe<Scalars['String']>;
+  slug?: InputMaybe<Scalars['String']>;
 };
 
 export type ThemeListing = Listing & {
-  __typename?: "ThemeListing";
-  count?: Maybe<Scalars["Int"]>;
-  next_token?: Maybe<Scalars["String"]>;
+  __typename?: 'ThemeListing';
+  count?: Maybe<Scalars['Int']>;
+  next_token?: Maybe<Scalars['String']>;
   objects?: Maybe<Array<Maybe<Theme>>>;
 };
 
 export type ThemeRelationshipInput = {
   create?: InputMaybe<Array<InputMaybe<ThemeInput>>>;
-  link?: InputMaybe<Array<InputMaybe<Scalars["String"]>>>;
-  unlink?: InputMaybe<Array<InputMaybe<Scalars["String"]>>>;
+  link?: InputMaybe<Array<InputMaybe<Scalars['String']>>>;
+  unlink?: InputMaybe<Array<InputMaybe<Scalars['String']>>>;
 };
 
 export type ThemeSetCreate = {
   object?: InputMaybe<ThemeInput>;
-  position: Scalars["Int"];
+  position: Scalars['Int'];
 };
 
 export type ThemeSetInput = {
   create?: InputMaybe<Array<InputMaybe<ThemeSetCreate>>>;
   link?: InputMaybe<Array<InputMaybe<SetLink>>>;
   reposition?: InputMaybe<Array<InputMaybe<SetLink>>>;
-  unlink?: InputMaybe<Array<InputMaybe<Scalars["String"]>>>;
+  unlink?: InputMaybe<Array<InputMaybe<Scalars['String']>>>;
 };
 
 export type UserDimension = {
-  dimension: Scalars["String"];
-  value: Scalars["String"];
+  dimension: Scalars['String'];
+  value: Scalars['String'];
 };
 
 export type _AssetGlobal = _Global & {
-  __typename?: "_AssetGlobal";
-  asset_url?: Maybe<Scalars["String"]>;
+  __typename?: '_AssetGlobal';
+  asset_url?: Maybe<Scalars['String']>;
   created?: Maybe<_Audit>;
   history?: Maybe<Array<Maybe<_AssetGlobal>>>;
   modified?: Maybe<_Audit>;
   publish_stage?: Maybe<PublishStage>;
-  version?: Maybe<Scalars["Int"]>;
+  version?: Maybe<Scalars['Int']>;
 };
 
 export type _AssetLanguage = _Language & {
-  __typename?: "_AssetLanguage";
+  __typename?: '_AssetLanguage';
   created?: Maybe<_Audit>;
   history?: Maybe<Array<Maybe<_AssetLanguage>>>;
-  language?: Maybe<Scalars["String"]>;
+  language?: Maybe<Scalars['String']>;
   modified?: Maybe<_Audit>;
   publish_stage?: Maybe<PublishStage>;
-  slug?: Maybe<Scalars["String"]>;
-  title?: Maybe<Scalars["String"]>;
-  type?: Maybe<Scalars["String"]>;
-  version?: Maybe<Scalars["Int"]>;
+  slug?: Maybe<Scalars['String']>;
+  title?: Maybe<Scalars['String']>;
+  type?: Maybe<Scalars['String']>;
+  version?: Maybe<Scalars['Int']>;
 };
 
 export type _AssetMeta = {
-  __typename?: "_AssetMeta";
-  available_languages?: Maybe<Array<Maybe<Scalars["String"]>>>;
+  __typename?: '_AssetMeta';
+  available_languages?: Maybe<Array<Maybe<Scalars['String']>>>;
   created?: Maybe<_Audit>;
   data_source?: Maybe<Asset>;
   field_config?: Maybe<Array<Maybe<_FieldConfig>>>;
@@ -2528,49 +2712,49 @@ export type _AssetMeta = {
 };
 
 export type _Audit = {
-  __typename?: "_Audit";
-  account?: Maybe<Scalars["String"]>;
-  date?: Maybe<Scalars["String"]>;
-  user?: Maybe<Scalars["String"]>;
+  __typename?: '_Audit';
+  account?: Maybe<Scalars['String']>;
+  date?: Maybe<Scalars['String']>;
+  user?: Maybe<Scalars['String']>;
 };
 
 export type _AvailabilityMeta = {
-  __typename?: "_AvailabilityMeta";
+  __typename?: '_AvailabilityMeta';
   created?: Maybe<_Audit>;
   modified?: Maybe<_Audit>;
 };
 
 export type _BrandGlobal = _Global & {
-  __typename?: "_BrandGlobal";
+  __typename?: '_BrandGlobal';
   created?: Maybe<_Audit>;
   history?: Maybe<Array<Maybe<_BrandGlobal>>>;
   modified?: Maybe<_Audit>;
   publish_stage?: Maybe<PublishStage>;
-  version?: Maybe<Scalars["Int"]>;
+  version?: Maybe<Scalars['Int']>;
 };
 
 export type _BrandLanguage = _Language & {
-  __typename?: "_BrandLanguage";
+  __typename?: '_BrandLanguage';
   created?: Maybe<_Audit>;
   history?: Maybe<Array<Maybe<_BrandLanguage>>>;
-  language?: Maybe<Scalars["String"]>;
+  language?: Maybe<Scalars['String']>;
   modified?: Maybe<_Audit>;
   publish_stage?: Maybe<PublishStage>;
-  release_date?: Maybe<Scalars["String"]>;
-  slug?: Maybe<Scalars["String"]>;
-  synopsis_long?: Maybe<Scalars["String"]>;
-  synopsis_medium?: Maybe<Scalars["String"]>;
-  synopsis_short?: Maybe<Scalars["String"]>;
-  title?: Maybe<Scalars["String"]>;
-  title_long?: Maybe<Scalars["String"]>;
-  title_medium?: Maybe<Scalars["String"]>;
-  title_short?: Maybe<Scalars["String"]>;
-  version?: Maybe<Scalars["Int"]>;
+  release_date?: Maybe<Scalars['String']>;
+  slug?: Maybe<Scalars['String']>;
+  synopsis_long?: Maybe<Scalars['String']>;
+  synopsis_medium?: Maybe<Scalars['String']>;
+  synopsis_short?: Maybe<Scalars['String']>;
+  title?: Maybe<Scalars['String']>;
+  title_long?: Maybe<Scalars['String']>;
+  title_medium?: Maybe<Scalars['String']>;
+  title_short?: Maybe<Scalars['String']>;
+  version?: Maybe<Scalars['Int']>;
 };
 
 export type _BrandMeta = {
-  __typename?: "_BrandMeta";
-  available_languages?: Maybe<Array<Maybe<Scalars["String"]>>>;
+  __typename?: '_BrandMeta';
+  available_languages?: Maybe<Array<Maybe<Scalars['String']>>>;
   created?: Maybe<_Audit>;
   data_source?: Maybe<Brand>;
   field_config?: Maybe<Array<Maybe<_FieldConfig>>>;
@@ -2581,30 +2765,30 @@ export type _BrandMeta = {
 };
 
 export type _CreditGlobal = _Global & {
-  __typename?: "_CreditGlobal";
+  __typename?: '_CreditGlobal';
   created?: Maybe<_Audit>;
   history?: Maybe<Array<Maybe<_CreditGlobal>>>;
   modified?: Maybe<_Audit>;
-  position?: Maybe<Scalars["Int"]>;
+  position?: Maybe<Scalars['Int']>;
   publish_stage?: Maybe<PublishStage>;
-  version?: Maybe<Scalars["Int"]>;
+  version?: Maybe<Scalars['Int']>;
 };
 
 export type _CreditLanguage = _Language & {
-  __typename?: "_CreditLanguage";
-  character?: Maybe<Scalars["String"]>;
+  __typename?: '_CreditLanguage';
+  character?: Maybe<Scalars['String']>;
   created?: Maybe<_Audit>;
   history?: Maybe<Array<Maybe<_CreditLanguage>>>;
-  language?: Maybe<Scalars["String"]>;
+  language?: Maybe<Scalars['String']>;
   modified?: Maybe<_Audit>;
   publish_stage?: Maybe<PublishStage>;
-  slug?: Maybe<Scalars["String"]>;
-  version?: Maybe<Scalars["Int"]>;
+  slug?: Maybe<Scalars['String']>;
+  version?: Maybe<Scalars['Int']>;
 };
 
 export type _CreditMeta = {
-  __typename?: "_CreditMeta";
-  available_languages?: Maybe<Array<Maybe<Scalars["String"]>>>;
+  __typename?: '_CreditMeta';
+  available_languages?: Maybe<Array<Maybe<Scalars['String']>>>;
   created?: Maybe<_Audit>;
   data_source?: Maybe<Credit>;
   field_config?: Maybe<Array<Maybe<_FieldConfig>>>;
@@ -2615,50 +2799,50 @@ export type _CreditMeta = {
 };
 
 export type _DimensionMeta = {
-  __typename?: "_DimensionMeta";
+  __typename?: '_DimensionMeta';
   created?: Maybe<_Audit>;
   modified?: Maybe<_Audit>;
   values?: Maybe<Array<Maybe<DimensionValue>>>;
 };
 
 export type _DimensionValueMeta = {
-  __typename?: "_DimensionValueMeta";
+  __typename?: '_DimensionValueMeta';
   created?: Maybe<_Audit>;
   modified?: Maybe<_Audit>;
 };
 
 export type _EpisodeGlobal = _Global & {
-  __typename?: "_EpisodeGlobal";
+  __typename?: '_EpisodeGlobal';
   created?: Maybe<_Audit>;
-  episode_number?: Maybe<Scalars["Int"]>;
+  episode_number?: Maybe<Scalars['Int']>;
   history?: Maybe<Array<Maybe<_EpisodeGlobal>>>;
   modified?: Maybe<_Audit>;
   publish_stage?: Maybe<PublishStage>;
-  version?: Maybe<Scalars["Int"]>;
+  version?: Maybe<Scalars['Int']>;
 };
 
 export type _EpisodeLanguage = _Language & {
-  __typename?: "_EpisodeLanguage";
+  __typename?: '_EpisodeLanguage';
   created?: Maybe<_Audit>;
   history?: Maybe<Array<Maybe<_EpisodeLanguage>>>;
-  language?: Maybe<Scalars["String"]>;
+  language?: Maybe<Scalars['String']>;
   modified?: Maybe<_Audit>;
   publish_stage?: Maybe<PublishStage>;
-  release_date?: Maybe<Scalars["String"]>;
-  slug?: Maybe<Scalars["String"]>;
-  synopsis_long?: Maybe<Scalars["String"]>;
-  synopsis_medium?: Maybe<Scalars["String"]>;
-  synopsis_short?: Maybe<Scalars["String"]>;
-  title?: Maybe<Scalars["String"]>;
-  title_long?: Maybe<Scalars["String"]>;
-  title_medium?: Maybe<Scalars["String"]>;
-  title_short?: Maybe<Scalars["String"]>;
-  version?: Maybe<Scalars["Int"]>;
+  release_date?: Maybe<Scalars['String']>;
+  slug?: Maybe<Scalars['String']>;
+  synopsis_long?: Maybe<Scalars['String']>;
+  synopsis_medium?: Maybe<Scalars['String']>;
+  synopsis_short?: Maybe<Scalars['String']>;
+  title?: Maybe<Scalars['String']>;
+  title_long?: Maybe<Scalars['String']>;
+  title_medium?: Maybe<Scalars['String']>;
+  title_short?: Maybe<Scalars['String']>;
+  version?: Maybe<Scalars['Int']>;
 };
 
 export type _EpisodeMeta = {
-  __typename?: "_EpisodeMeta";
-  available_languages?: Maybe<Array<Maybe<Scalars["String"]>>>;
+  __typename?: '_EpisodeMeta';
+  available_languages?: Maybe<Array<Maybe<Scalars['String']>>>;
   created?: Maybe<_Audit>;
   data_source?: Maybe<Episode>;
   field_config?: Maybe<Array<Maybe<_FieldConfig>>>;
@@ -2669,37 +2853,37 @@ export type _EpisodeMeta = {
 };
 
 export type _FieldConfig = {
-  __typename?: "_FieldConfig";
-  name: Scalars["String"];
-  use_data_source?: Maybe<Scalars["Boolean"]>;
+  __typename?: '_FieldConfig';
+  name: Scalars['String'];
+  use_data_source?: Maybe<Scalars['Boolean']>;
 };
 
 export type _GenreGlobal = _Global & {
-  __typename?: "_GenreGlobal";
+  __typename?: '_GenreGlobal';
   created?: Maybe<_Audit>;
   history?: Maybe<Array<Maybe<_GenreGlobal>>>;
   modified?: Maybe<_Audit>;
   publish_stage?: Maybe<PublishStage>;
-  version?: Maybe<Scalars["Int"]>;
+  version?: Maybe<Scalars['Int']>;
 };
 
 export type _GenreLanguage = _Language & {
-  __typename?: "_GenreLanguage";
+  __typename?: '_GenreLanguage';
   created?: Maybe<_Audit>;
   history?: Maybe<Array<Maybe<_GenreLanguage>>>;
-  language?: Maybe<Scalars["String"]>;
-  metadata_source?: Maybe<Scalars["String"]>;
+  language?: Maybe<Scalars['String']>;
+  metadata_source?: Maybe<Scalars['String']>;
   modified?: Maybe<_Audit>;
-  name?: Maybe<Scalars["String"]>;
+  name?: Maybe<Scalars['String']>;
   parents?: Maybe<Array<Maybe<Metadata>>>;
   publish_stage?: Maybe<PublishStage>;
-  slug?: Maybe<Scalars["String"]>;
-  version?: Maybe<Scalars["Int"]>;
+  slug?: Maybe<Scalars['String']>;
+  version?: Maybe<Scalars['Int']>;
 };
 
 export type _GenreMeta = {
-  __typename?: "_GenreMeta";
-  available_languages?: Maybe<Array<Maybe<Scalars["String"]>>>;
+  __typename?: '_GenreMeta';
+  available_languages?: Maybe<Array<Maybe<Scalars['String']>>>;
   created?: Maybe<_Audit>;
   data_source?: Maybe<Genre>;
   field_config?: Maybe<Array<Maybe<_FieldConfig>>>;
@@ -2714,36 +2898,36 @@ export type _Global = {
   history?: Maybe<Array<Maybe<_Global>>>;
   modified?: Maybe<_Audit>;
   publish_stage?: Maybe<PublishStage>;
-  version?: Maybe<Scalars["Int"]>;
+  version?: Maybe<Scalars['Int']>;
 };
 
 export type _ImageGlobal = _Global & {
-  __typename?: "_ImageGlobal";
+  __typename?: '_ImageGlobal';
   created?: Maybe<_Audit>;
   history?: Maybe<Array<Maybe<_ImageGlobal>>>;
   modified?: Maybe<_Audit>;
   publish_stage?: Maybe<PublishStage>;
-  type?: Maybe<Scalars["String"]>;
-  url?: Maybe<Scalars["String"]>;
-  version?: Maybe<Scalars["Int"]>;
+  type?: Maybe<Scalars['String']>;
+  url?: Maybe<Scalars['String']>;
+  version?: Maybe<Scalars['Int']>;
 };
 
 export type _ImageLanguage = _Language & {
-  __typename?: "_ImageLanguage";
+  __typename?: '_ImageLanguage';
   created?: Maybe<_Audit>;
-  description?: Maybe<Scalars["String"]>;
+  description?: Maybe<Scalars['String']>;
   history?: Maybe<Array<Maybe<_ImageLanguage>>>;
-  language?: Maybe<Scalars["String"]>;
+  language?: Maybe<Scalars['String']>;
   modified?: Maybe<_Audit>;
   publish_stage?: Maybe<PublishStage>;
-  slug?: Maybe<Scalars["String"]>;
-  title?: Maybe<Scalars["String"]>;
-  version?: Maybe<Scalars["Int"]>;
+  slug?: Maybe<Scalars['String']>;
+  title?: Maybe<Scalars['String']>;
+  version?: Maybe<Scalars['Int']>;
 };
 
 export type _ImageMeta = {
-  __typename?: "_ImageMeta";
-  available_languages?: Maybe<Array<Maybe<Scalars["String"]>>>;
+  __typename?: '_ImageMeta';
+  available_languages?: Maybe<Array<Maybe<Scalars['String']>>>;
   created?: Maybe<_Audit>;
   data_source?: Maybe<Image>;
   field_config?: Maybe<Array<Maybe<_FieldConfig>>>;
@@ -2756,45 +2940,45 @@ export type _ImageMeta = {
 export type _Language = {
   created?: Maybe<_Audit>;
   history?: Maybe<Array<Maybe<_Language>>>;
-  language?: Maybe<Scalars["String"]>;
+  language?: Maybe<Scalars['String']>;
   modified?: Maybe<_Audit>;
   publish_stage?: Maybe<PublishStage>;
-  slug?: Maybe<Scalars["String"]>;
-  version?: Maybe<Scalars["Int"]>;
+  slug?: Maybe<Scalars['String']>;
+  version?: Maybe<Scalars['Int']>;
 };
 
 export type _MovieGlobal = _Global & {
-  __typename?: "_MovieGlobal";
+  __typename?: '_MovieGlobal';
   created?: Maybe<_Audit>;
   history?: Maybe<Array<Maybe<_MovieGlobal>>>;
   modified?: Maybe<_Audit>;
   publish_stage?: Maybe<PublishStage>;
-  version?: Maybe<Scalars["Int"]>;
-  year_of_release?: Maybe<Scalars["Int"]>;
+  version?: Maybe<Scalars['Int']>;
+  year_of_release?: Maybe<Scalars['Int']>;
 };
 
 export type _MovieLanguage = _Language & {
-  __typename?: "_MovieLanguage";
+  __typename?: '_MovieLanguage';
   created?: Maybe<_Audit>;
   history?: Maybe<Array<Maybe<_MovieLanguage>>>;
-  language?: Maybe<Scalars["String"]>;
+  language?: Maybe<Scalars['String']>;
   modified?: Maybe<_Audit>;
   publish_stage?: Maybe<PublishStage>;
-  release_date?: Maybe<Scalars["String"]>;
-  slug?: Maybe<Scalars["String"]>;
-  synopsis_long?: Maybe<Scalars["String"]>;
-  synopsis_medium?: Maybe<Scalars["String"]>;
-  synopsis_short?: Maybe<Scalars["String"]>;
-  title?: Maybe<Scalars["String"]>;
-  title_long?: Maybe<Scalars["String"]>;
-  title_medium?: Maybe<Scalars["String"]>;
-  title_short?: Maybe<Scalars["String"]>;
-  version?: Maybe<Scalars["Int"]>;
+  release_date?: Maybe<Scalars['String']>;
+  slug?: Maybe<Scalars['String']>;
+  synopsis_long?: Maybe<Scalars['String']>;
+  synopsis_medium?: Maybe<Scalars['String']>;
+  synopsis_short?: Maybe<Scalars['String']>;
+  title?: Maybe<Scalars['String']>;
+  title_long?: Maybe<Scalars['String']>;
+  title_medium?: Maybe<Scalars['String']>;
+  title_short?: Maybe<Scalars['String']>;
+  version?: Maybe<Scalars['Int']>;
 };
 
 export type _MovieMeta = {
-  __typename?: "_MovieMeta";
-  available_languages?: Maybe<Array<Maybe<Scalars["String"]>>>;
+  __typename?: '_MovieMeta';
+  available_languages?: Maybe<Array<Maybe<Scalars['String']>>>;
   created?: Maybe<_Audit>;
   data_source?: Maybe<Movie>;
   field_config?: Maybe<Array<Maybe<_FieldConfig>>>;
@@ -2805,29 +2989,29 @@ export type _MovieMeta = {
 };
 
 export type _ParentalGuidanceGlobal = _Global & {
-  __typename?: "_ParentalGuidanceGlobal";
+  __typename?: '_ParentalGuidanceGlobal';
   created?: Maybe<_Audit>;
   history?: Maybe<Array<Maybe<_ParentalGuidanceGlobal>>>;
   modified?: Maybe<_Audit>;
   publish_stage?: Maybe<PublishStage>;
-  version?: Maybe<Scalars["Int"]>;
+  version?: Maybe<Scalars['Int']>;
 };
 
 export type _ParentalGuidanceLanguage = _Language & {
-  __typename?: "_ParentalGuidanceLanguage";
+  __typename?: '_ParentalGuidanceLanguage';
   created?: Maybe<_Audit>;
   history?: Maybe<Array<Maybe<_ParentalGuidanceLanguage>>>;
-  language?: Maybe<Scalars["String"]>;
+  language?: Maybe<Scalars['String']>;
   modified?: Maybe<_Audit>;
   publish_stage?: Maybe<PublishStage>;
-  reason?: Maybe<Scalars["String"]>;
-  slug?: Maybe<Scalars["String"]>;
-  version?: Maybe<Scalars["Int"]>;
+  reason?: Maybe<Scalars['String']>;
+  slug?: Maybe<Scalars['String']>;
+  version?: Maybe<Scalars['Int']>;
 };
 
 export type _ParentalGuidanceMeta = {
-  __typename?: "_ParentalGuidanceMeta";
-  available_languages?: Maybe<Array<Maybe<Scalars["String"]>>>;
+  __typename?: '_ParentalGuidanceMeta';
+  available_languages?: Maybe<Array<Maybe<Scalars['String']>>>;
   created?: Maybe<_Audit>;
   data_source?: Maybe<ParentalGuidance>;
   field_config?: Maybe<Array<Maybe<_FieldConfig>>>;
@@ -2838,38 +3022,38 @@ export type _ParentalGuidanceMeta = {
 };
 
 export type _PersonGlobal = _Global & {
-  __typename?: "_PersonGlobal";
+  __typename?: '_PersonGlobal';
   created?: Maybe<_Audit>;
-  date_of_birth?: Maybe<Scalars["AWSDateTime"]>;
+  date_of_birth?: Maybe<Scalars['AWSDateTime']>;
   history?: Maybe<Array<Maybe<_PersonGlobal>>>;
   modified?: Maybe<_Audit>;
   publish_stage?: Maybe<PublishStage>;
-  version?: Maybe<Scalars["Int"]>;
+  version?: Maybe<Scalars['Int']>;
 };
 
 export type _PersonLanguage = _Language & {
-  __typename?: "_PersonLanguage";
-  abbreviation?: Maybe<Scalars["String"]>;
-  alias?: Maybe<Scalars["String"]>;
-  bio_long?: Maybe<Scalars["String"]>;
-  bio_medium?: Maybe<Scalars["String"]>;
-  bio_short?: Maybe<Scalars["String"]>;
+  __typename?: '_PersonLanguage';
+  abbreviation?: Maybe<Scalars['String']>;
+  alias?: Maybe<Scalars['String']>;
+  bio_long?: Maybe<Scalars['String']>;
+  bio_medium?: Maybe<Scalars['String']>;
+  bio_short?: Maybe<Scalars['String']>;
   created?: Maybe<_Audit>;
-  gender?: Maybe<Scalars["String"]>;
+  gender?: Maybe<Scalars['String']>;
   history?: Maybe<Array<Maybe<_PersonLanguage>>>;
-  language?: Maybe<Scalars["String"]>;
+  language?: Maybe<Scalars['String']>;
   modified?: Maybe<_Audit>;
-  name?: Maybe<Scalars["String"]>;
-  name_sort?: Maybe<Scalars["String"]>;
-  place_of_birth?: Maybe<Scalars["String"]>;
+  name?: Maybe<Scalars['String']>;
+  name_sort?: Maybe<Scalars['String']>;
+  place_of_birth?: Maybe<Scalars['String']>;
   publish_stage?: Maybe<PublishStage>;
-  slug?: Maybe<Scalars["String"]>;
-  version?: Maybe<Scalars["Int"]>;
+  slug?: Maybe<Scalars['String']>;
+  version?: Maybe<Scalars['Int']>;
 };
 
 export type _PersonMeta = {
-  __typename?: "_PersonMeta";
-  available_languages?: Maybe<Array<Maybe<Scalars["String"]>>>;
+  __typename?: '_PersonMeta';
+  available_languages?: Maybe<Array<Maybe<Scalars['String']>>>;
   created?: Maybe<_Audit>;
   data_source?: Maybe<Person>;
   field_config?: Maybe<Array<Maybe<_FieldConfig>>>;
@@ -2880,31 +3064,31 @@ export type _PersonMeta = {
 };
 
 export type _RatingGlobal = _Global & {
-  __typename?: "_RatingGlobal";
+  __typename?: '_RatingGlobal';
   created?: Maybe<_Audit>;
   history?: Maybe<Array<Maybe<_RatingGlobal>>>;
   modified?: Maybe<_Audit>;
   publish_stage?: Maybe<PublishStage>;
-  scheme?: Maybe<Scalars["String"]>;
-  value: Scalars["String"];
-  version?: Maybe<Scalars["Int"]>;
+  scheme?: Maybe<Scalars['String']>;
+  value: Scalars['String'];
+  version?: Maybe<Scalars['Int']>;
 };
 
 export type _RatingLanguage = _Language & {
-  __typename?: "_RatingLanguage";
+  __typename?: '_RatingLanguage';
   created?: Maybe<_Audit>;
-  description?: Maybe<Scalars["String"]>;
+  description?: Maybe<Scalars['String']>;
   history?: Maybe<Array<Maybe<_RatingLanguage>>>;
-  language?: Maybe<Scalars["String"]>;
+  language?: Maybe<Scalars['String']>;
   modified?: Maybe<_Audit>;
   publish_stage?: Maybe<PublishStage>;
-  slug?: Maybe<Scalars["String"]>;
-  version?: Maybe<Scalars["Int"]>;
+  slug?: Maybe<Scalars['String']>;
+  version?: Maybe<Scalars['Int']>;
 };
 
 export type _RatingMeta = {
-  __typename?: "_RatingMeta";
-  available_languages?: Maybe<Array<Maybe<Scalars["String"]>>>;
+  __typename?: '_RatingMeta';
+  available_languages?: Maybe<Array<Maybe<Scalars['String']>>>;
   created?: Maybe<_Audit>;
   data_source?: Maybe<Rating>;
   field_config?: Maybe<Array<Maybe<_FieldConfig>>>;
@@ -2915,29 +3099,29 @@ export type _RatingMeta = {
 };
 
 export type _RoleGlobal = _Global & {
-  __typename?: "_RoleGlobal";
+  __typename?: '_RoleGlobal';
   created?: Maybe<_Audit>;
   history?: Maybe<Array<Maybe<_RoleGlobal>>>;
   modified?: Maybe<_Audit>;
   publish_stage?: Maybe<PublishStage>;
-  version?: Maybe<Scalars["Int"]>;
+  version?: Maybe<Scalars['Int']>;
 };
 
 export type _RoleLanguage = _Language & {
-  __typename?: "_RoleLanguage";
+  __typename?: '_RoleLanguage';
   created?: Maybe<_Audit>;
   history?: Maybe<Array<Maybe<_RoleLanguage>>>;
-  language?: Maybe<Scalars["String"]>;
+  language?: Maybe<Scalars['String']>;
   modified?: Maybe<_Audit>;
   publish_stage?: Maybe<PublishStage>;
-  slug?: Maybe<Scalars["String"]>;
-  title?: Maybe<Scalars["String"]>;
-  version?: Maybe<Scalars["Int"]>;
+  slug?: Maybe<Scalars['String']>;
+  title?: Maybe<Scalars['String']>;
+  version?: Maybe<Scalars['Int']>;
 };
 
 export type _RoleMeta = {
-  __typename?: "_RoleMeta";
-  available_languages?: Maybe<Array<Maybe<Scalars["String"]>>>;
+  __typename?: '_RoleMeta';
+  available_languages?: Maybe<Array<Maybe<Scalars['String']>>>;
   created?: Maybe<_Audit>;
   data_source?: Maybe<Role>;
   field_config?: Maybe<Array<Maybe<_FieldConfig>>>;
@@ -2948,38 +3132,38 @@ export type _RoleMeta = {
 };
 
 export type _SeasonGlobal = _Global & {
-  __typename?: "_SeasonGlobal";
+  __typename?: '_SeasonGlobal';
   created?: Maybe<_Audit>;
   history?: Maybe<Array<Maybe<_SeasonGlobal>>>;
   modified?: Maybe<_Audit>;
-  number_of_episodes?: Maybe<Scalars["Int"]>;
+  number_of_episodes?: Maybe<Scalars['Int']>;
   publish_stage?: Maybe<PublishStage>;
-  season_number?: Maybe<Scalars["Int"]>;
-  version?: Maybe<Scalars["Int"]>;
+  season_number?: Maybe<Scalars['Int']>;
+  version?: Maybe<Scalars['Int']>;
 };
 
 export type _SeasonLanguage = _Language & {
-  __typename?: "_SeasonLanguage";
+  __typename?: '_SeasonLanguage';
   created?: Maybe<_Audit>;
   history?: Maybe<Array<Maybe<_EpisodeLanguage>>>;
-  language?: Maybe<Scalars["String"]>;
+  language?: Maybe<Scalars['String']>;
   modified?: Maybe<_Audit>;
   publish_stage?: Maybe<PublishStage>;
-  release_date?: Maybe<Scalars["String"]>;
-  slug?: Maybe<Scalars["String"]>;
-  synopsis_long?: Maybe<Scalars["String"]>;
-  synopsis_medium?: Maybe<Scalars["String"]>;
-  synopsis_short?: Maybe<Scalars["String"]>;
-  title?: Maybe<Scalars["String"]>;
-  title_long?: Maybe<Scalars["String"]>;
-  title_medium?: Maybe<Scalars["String"]>;
-  title_short?: Maybe<Scalars["String"]>;
-  version?: Maybe<Scalars["Int"]>;
+  release_date?: Maybe<Scalars['String']>;
+  slug?: Maybe<Scalars['String']>;
+  synopsis_long?: Maybe<Scalars['String']>;
+  synopsis_medium?: Maybe<Scalars['String']>;
+  synopsis_short?: Maybe<Scalars['String']>;
+  title?: Maybe<Scalars['String']>;
+  title_long?: Maybe<Scalars['String']>;
+  title_medium?: Maybe<Scalars['String']>;
+  title_short?: Maybe<Scalars['String']>;
+  version?: Maybe<Scalars['Int']>;
 };
 
 export type _SeasonMeta = {
-  __typename?: "_SeasonMeta";
-  available_languages?: Maybe<Array<Maybe<Scalars["String"]>>>;
+  __typename?: '_SeasonMeta';
+  available_languages?: Maybe<Array<Maybe<Scalars['String']>>>;
   created?: Maybe<_Audit>;
   data_source?: Maybe<Season>;
   field_config?: Maybe<Array<Maybe<_FieldConfig>>>;
@@ -2990,38 +3174,38 @@ export type _SeasonMeta = {
 };
 
 export type _SetGlobal = _Global & {
-  __typename?: "_SetGlobal";
+  __typename?: '_SetGlobal';
   created?: Maybe<_Audit>;
   history?: Maybe<Array<Maybe<_SetGlobal>>>;
   modified?: Maybe<_Audit>;
   publish_stage?: Maybe<PublishStage>;
-  type?: Maybe<Scalars["String"]>;
-  version?: Maybe<Scalars["Int"]>;
+  type?: Maybe<Scalars['String']>;
+  version?: Maybe<Scalars['Int']>;
 };
 
 export type _SetLanguage = _Language & {
-  __typename?: "_SetLanguage";
+  __typename?: '_SetLanguage';
   created?: Maybe<_Audit>;
-  description?: Maybe<Scalars["String"]>;
+  description?: Maybe<Scalars['String']>;
   history?: Maybe<Array<Maybe<_SetLanguage>>>;
-  language?: Maybe<Scalars["String"]>;
+  language?: Maybe<Scalars['String']>;
   modified?: Maybe<_Audit>;
   publish_stage?: Maybe<PublishStage>;
-  release_date?: Maybe<Scalars["String"]>;
-  slug?: Maybe<Scalars["String"]>;
-  synopsis_long?: Maybe<Scalars["String"]>;
-  synopsis_medium?: Maybe<Scalars["String"]>;
-  synopsis_short?: Maybe<Scalars["String"]>;
-  title?: Maybe<Scalars["String"]>;
-  title_long?: Maybe<Scalars["String"]>;
-  title_medium?: Maybe<Scalars["String"]>;
-  title_short?: Maybe<Scalars["String"]>;
-  version?: Maybe<Scalars["Int"]>;
+  release_date?: Maybe<Scalars['String']>;
+  slug?: Maybe<Scalars['String']>;
+  synopsis_long?: Maybe<Scalars['String']>;
+  synopsis_medium?: Maybe<Scalars['String']>;
+  synopsis_short?: Maybe<Scalars['String']>;
+  title?: Maybe<Scalars['String']>;
+  title_long?: Maybe<Scalars['String']>;
+  title_medium?: Maybe<Scalars['String']>;
+  title_short?: Maybe<Scalars['String']>;
+  version?: Maybe<Scalars['Int']>;
 };
 
 export type _SetMeta = {
-  __typename?: "_SetMeta";
-  available_languages?: Maybe<Array<Maybe<Scalars["String"]>>>;
+  __typename?: '_SetMeta';
+  available_languages?: Maybe<Array<Maybe<Scalars['String']>>>;
   created?: Maybe<_Audit>;
   data_source?: Maybe<Set>;
   field_config?: Maybe<Array<Maybe<_FieldConfig>>>;
@@ -3032,30 +3216,30 @@ export type _SetMeta = {
 };
 
 export type _TagGlobal = _Global & {
-  __typename?: "_TagGlobal";
+  __typename?: '_TagGlobal';
   created?: Maybe<_Audit>;
   history?: Maybe<Array<Maybe<_TagGlobal>>>;
   modified?: Maybe<_Audit>;
   publish_stage?: Maybe<PublishStage>;
-  tag_category?: Maybe<Scalars["String"]>;
-  version?: Maybe<Scalars["Int"]>;
+  tag_category?: Maybe<Scalars['String']>;
+  version?: Maybe<Scalars['Int']>;
 };
 
 export type _TagLanguage = _Language & {
-  __typename?: "_TagLanguage";
+  __typename?: '_TagLanguage';
   created?: Maybe<_Audit>;
   history?: Maybe<Array<Maybe<_TagLanguage>>>;
-  language?: Maybe<Scalars["String"]>;
+  language?: Maybe<Scalars['String']>;
   modified?: Maybe<_Audit>;
-  name?: Maybe<Scalars["String"]>;
+  name?: Maybe<Scalars['String']>;
   publish_stage?: Maybe<PublishStage>;
-  slug?: Maybe<Scalars["String"]>;
-  version?: Maybe<Scalars["Int"]>;
+  slug?: Maybe<Scalars['String']>;
+  version?: Maybe<Scalars['Int']>;
 };
 
 export type _TagMeta = {
-  __typename?: "_TagMeta";
-  available_languages?: Maybe<Array<Maybe<Scalars["String"]>>>;
+  __typename?: '_TagMeta';
+  available_languages?: Maybe<Array<Maybe<Scalars['String']>>>;
   created?: Maybe<_Audit>;
   data_source?: Maybe<Tag>;
   field_config?: Maybe<Array<Maybe<_FieldConfig>>>;
@@ -3066,30 +3250,30 @@ export type _TagMeta = {
 };
 
 export type _ThemeGlobal = _Global & {
-  __typename?: "_ThemeGlobal";
+  __typename?: '_ThemeGlobal';
   created?: Maybe<_Audit>;
   history?: Maybe<Array<Maybe<_ThemeGlobal>>>;
   modified?: Maybe<_Audit>;
   publish_stage?: Maybe<PublishStage>;
-  version?: Maybe<Scalars["Int"]>;
+  version?: Maybe<Scalars['Int']>;
 };
 
 export type _ThemeLanguage = _Language & {
-  __typename?: "_ThemeLanguage";
+  __typename?: '_ThemeLanguage';
   created?: Maybe<_Audit>;
   history?: Maybe<Array<Maybe<_ThemeLanguage>>>;
-  language?: Maybe<Scalars["String"]>;
-  metadata_source?: Maybe<Scalars["String"]>;
+  language?: Maybe<Scalars['String']>;
+  metadata_source?: Maybe<Scalars['String']>;
   modified?: Maybe<_Audit>;
-  name?: Maybe<Scalars["String"]>;
+  name?: Maybe<Scalars['String']>;
   publish_stage?: Maybe<PublishStage>;
-  slug?: Maybe<Scalars["String"]>;
-  version?: Maybe<Scalars["Int"]>;
+  slug?: Maybe<Scalars['String']>;
+  version?: Maybe<Scalars['Int']>;
 };
 
 export type _ThemeMeta = {
-  __typename?: "_ThemeMeta";
-  available_languages?: Maybe<Array<Maybe<Scalars["String"]>>>;
+  __typename?: '_ThemeMeta';
+  available_languages?: Maybe<Array<Maybe<Scalars['String']>>>;
   created?: Maybe<_Audit>;
   data_source?: Maybe<Theme>;
   field_config?: Maybe<Array<Maybe<_FieldConfig>>>;

--- a/apps/saas/types/gql.ts
+++ b/apps/saas/types/gql.ts
@@ -3,9 +3,15 @@
 /* eslint-disable */
 export type Maybe<T> = T | null;
 export type InputMaybe<T> = Maybe<T>;
-export type Exact<T extends { [key: string]: unknown }> = { [K in keyof T]: T[K] };
-export type MakeOptional<T, K extends keyof T> = Omit<T, K> & { [SubKey in K]?: Maybe<T[SubKey]> };
-export type MakeMaybe<T, K extends keyof T> = Omit<T, K> & { [SubKey in K]: Maybe<T[SubKey]> };
+export type Exact<T extends { [key: string]: unknown }> = {
+  [K in keyof T]: T[K];
+};
+export type MakeOptional<T, K extends keyof T> = Omit<T, K> & {
+  [SubKey in K]?: Maybe<T[SubKey]>;
+};
+export type MakeMaybe<T, K extends keyof T> = Omit<T, K> & {
+  [SubKey in K]: Maybe<T[SubKey]>;
+};
 /** All built-in and custom scalars, mapped to their actual values */
 export type Scalars = {
   ID: string;
@@ -17,77 +23,72 @@ export type Scalars = {
 };
 
 export type Asset = Metadata & {
-  __typename?: 'Asset';
+  __typename?: "Asset";
   _meta?: Maybe<_AssetMeta>;
   availability?: Maybe<AvailabilityListing>;
-  external_id?: Maybe<Scalars['String']>;
+  external_id?: Maybe<Scalars["String"]>;
   images?: Maybe<ImageListing>;
   parental_guidance?: Maybe<ParentalGuidanceListing>;
   parents?: Maybe<EntertainmentListing>;
-  slug?: Maybe<Scalars['String']>;
-  title?: Maybe<Scalars['String']>;
-  type: Scalars['String'];
-  uid: Scalars['String'];
-  url?: Maybe<Scalars['String']>;
+  slug?: Maybe<Scalars["String"]>;
+  title?: Maybe<Scalars["String"]>;
+  type: Scalars["String"];
+  uid: Scalars["String"];
+  url?: Maybe<Scalars["String"]>;
 };
-
 
 export type Asset_MetaArgs = {
-  global_version?: InputMaybe<Scalars['Int']>;
-  language?: InputMaybe<Scalars['String']>;
-  language_version?: InputMaybe<Scalars['Int']>;
+  global_version?: InputMaybe<Scalars["Int"]>;
+  language?: InputMaybe<Scalars["String"]>;
+  language_version?: InputMaybe<Scalars["Int"]>;
 };
-
 
 export type AssetAvailabilityArgs = {
-  limit?: InputMaybe<Scalars['Int']>;
-  next_token?: InputMaybe<Scalars['String']>;
+  limit?: InputMaybe<Scalars["Int"]>;
+  next_token?: InputMaybe<Scalars["String"]>;
 };
-
 
 export type AssetImagesArgs = {
-  language?: InputMaybe<Scalars['String']>;
-  limit?: InputMaybe<Scalars['Int']>;
-  next_token?: InputMaybe<Scalars['String']>;
+  language?: InputMaybe<Scalars["String"]>;
+  limit?: InputMaybe<Scalars["Int"]>;
+  next_token?: InputMaybe<Scalars["String"]>;
 };
-
 
 export type AssetParental_GuidanceArgs = {
-  language?: InputMaybe<Scalars['String']>;
-  limit?: InputMaybe<Scalars['Int']>;
-  next_token?: InputMaybe<Scalars['String']>;
+  language?: InputMaybe<Scalars["String"]>;
+  limit?: InputMaybe<Scalars["Int"]>;
+  next_token?: InputMaybe<Scalars["String"]>;
 };
 
-
 export type AssetParentsArgs = {
-  language?: InputMaybe<Scalars['String']>;
-  limit?: InputMaybe<Scalars['Int']>;
-  next_token?: InputMaybe<Scalars['String']>;
+  language?: InputMaybe<Scalars["String"]>;
+  limit?: InputMaybe<Scalars["Int"]>;
+  next_token?: InputMaybe<Scalars["String"]>;
 };
 
 export type AssetInput = {
   availability?: InputMaybe<AssignAvailabilityInput>;
-  data_source_fields?: InputMaybe<Array<InputMaybe<Scalars['String']>>>;
-  data_source_id?: InputMaybe<Scalars['String']>;
-  external_id?: InputMaybe<Scalars['String']>;
+  data_source_fields?: InputMaybe<Array<InputMaybe<Scalars["String"]>>>;
+  data_source_id?: InputMaybe<Scalars["String"]>;
+  external_id?: InputMaybe<Scalars["String"]>;
   relationships?: InputMaybe<AssetRelationships>;
-  slug?: InputMaybe<Scalars['String']>;
-  title?: InputMaybe<Scalars['String']>;
+  slug?: InputMaybe<Scalars["String"]>;
+  title?: InputMaybe<Scalars["String"]>;
   type?: InputMaybe<AssetType>;
-  url?: InputMaybe<Scalars['String']>;
+  url?: InputMaybe<Scalars["String"]>;
 };
 
 export type AssetListing = Listing & {
-  __typename?: 'AssetListing';
-  count?: Maybe<Scalars['Int']>;
-  next_token?: Maybe<Scalars['String']>;
+  __typename?: "AssetListing";
+  count?: Maybe<Scalars["Int"]>;
+  next_token?: Maybe<Scalars["String"]>;
   objects?: Maybe<Array<Maybe<Asset>>>;
 };
 
 export type AssetRelationshipInput = {
   create?: InputMaybe<Array<InputMaybe<AssetInput>>>;
-  link?: InputMaybe<Array<InputMaybe<Scalars['String']>>>;
-  unlink?: InputMaybe<Array<InputMaybe<Scalars['String']>>>;
+  link?: InputMaybe<Array<InputMaybe<Scalars["String"]>>>;
+  unlink?: InputMaybe<Array<InputMaybe<Scalars["String"]>>>;
 };
 
 export type AssetRelationships = {
@@ -96,194 +97,182 @@ export type AssetRelationships = {
 };
 
 export enum AssetType {
-  Main = 'MAIN',
-  Trailer = 'TRAILER'
+  Main = "MAIN",
+  Trailer = "TRAILER",
 }
 
 export type AssignAvailabilityInput = {
   create?: InputMaybe<Array<InputMaybe<AvailabilityInput>>>;
-  link?: InputMaybe<Array<InputMaybe<Scalars['String']>>>;
-  unlink?: InputMaybe<Array<InputMaybe<Scalars['String']>>>;
+  link?: InputMaybe<Array<InputMaybe<Scalars["String"]>>>;
+  unlink?: InputMaybe<Array<InputMaybe<Scalars["String"]>>>;
 };
 
 export type AssignDimensionInput = {
-  dimension_slug?: InputMaybe<Scalars['String']>;
-  value_slugs?: InputMaybe<Array<InputMaybe<Scalars['String']>>>;
+  dimension_slug?: InputMaybe<Scalars["String"]>;
+  value_slugs?: InputMaybe<Array<InputMaybe<Scalars["String"]>>>;
 };
 
 export type Availability = {
-  __typename?: 'Availability';
+  __typename?: "Availability";
   _meta?: Maybe<_AvailabilityMeta>;
   dimensions?: Maybe<Array<Maybe<DimensionAssigned>>>;
-  end?: Maybe<Scalars['AWSDateTime']>;
-  external_id?: Maybe<Scalars['String']>;
-  slug?: Maybe<Scalars['String']>;
-  start?: Maybe<Scalars['AWSDateTime']>;
-  title?: Maybe<Scalars['String']>;
-  uid?: Maybe<Scalars['String']>;
+  end?: Maybe<Scalars["AWSDateTime"]>;
+  external_id?: Maybe<Scalars["String"]>;
+  slug?: Maybe<Scalars["String"]>;
+  start?: Maybe<Scalars["AWSDateTime"]>;
+  title?: Maybe<Scalars["String"]>;
+  uid?: Maybe<Scalars["String"]>;
 };
 
 export type AvailabilityInput = {
   dimensions?: InputMaybe<Array<InputMaybe<AssignDimensionInput>>>;
-  end?: InputMaybe<Scalars['AWSDateTime']>;
-  external_id?: InputMaybe<Scalars['String']>;
-  slug?: InputMaybe<Scalars['String']>;
-  start?: InputMaybe<Scalars['AWSDateTime']>;
-  title?: InputMaybe<Scalars['String']>;
+  end?: InputMaybe<Scalars["AWSDateTime"]>;
+  external_id?: InputMaybe<Scalars["String"]>;
+  slug?: InputMaybe<Scalars["String"]>;
+  start?: InputMaybe<Scalars["AWSDateTime"]>;
+  title?: InputMaybe<Scalars["String"]>;
 };
 
 export type AvailabilityListing = {
-  __typename?: 'AvailabilityListing';
-  count?: Maybe<Scalars['Int']>;
-  next_token?: Maybe<Scalars['String']>;
+  __typename?: "AvailabilityListing";
+  count?: Maybe<Scalars["Int"]>;
+  next_token?: Maybe<Scalars["String"]>;
   objects?: Maybe<Array<Maybe<Availability>>>;
 };
 
-export type Brand = CurationMetadata & Entertainment & {
-  __typename?: 'Brand';
-  _meta?: Maybe<_BrandMeta>;
-  assets?: Maybe<AssetListing>;
-  availability?: Maybe<AvailabilityListing>;
-  credits?: Maybe<CreditListing>;
-  episodes?: Maybe<EpisodeListing>;
-  external_id?: Maybe<Scalars['String']>;
-  genres?: Maybe<GenreListing>;
-  images?: Maybe<ImageListing>;
-  movies?: Maybe<MovieListing>;
-  ratings?: Maybe<RatingListing>;
-  release_date?: Maybe<Scalars['String']>;
-  seasons?: Maybe<SeasonListing>;
-  sets?: Maybe<SetListing>;
-  slug?: Maybe<Scalars['String']>;
-  synopsis_long?: Maybe<Scalars['String']>;
-  synopsis_medium?: Maybe<Scalars['String']>;
-  synopsis_short?: Maybe<Scalars['String']>;
-  tags?: Maybe<TagListing>;
-  themes?: Maybe<ThemeListing>;
-  title?: Maybe<Scalars['String']>;
-  title_long?: Maybe<Scalars['String']>;
-  title_medium?: Maybe<Scalars['String']>;
-  title_short?: Maybe<Scalars['String']>;
-  uid: Scalars['String'];
-};
-
+export type Brand = CurationMetadata &
+  Entertainment & {
+    __typename?: "Brand";
+    _meta?: Maybe<_BrandMeta>;
+    assets?: Maybe<AssetListing>;
+    availability?: Maybe<AvailabilityListing>;
+    credits?: Maybe<CreditListing>;
+    episodes?: Maybe<EpisodeListing>;
+    external_id?: Maybe<Scalars["String"]>;
+    genres?: Maybe<GenreListing>;
+    images?: Maybe<ImageListing>;
+    movies?: Maybe<MovieListing>;
+    ratings?: Maybe<RatingListing>;
+    release_date?: Maybe<Scalars["String"]>;
+    seasons?: Maybe<SeasonListing>;
+    sets?: Maybe<SetListing>;
+    slug?: Maybe<Scalars["String"]>;
+    synopsis_long?: Maybe<Scalars["String"]>;
+    synopsis_medium?: Maybe<Scalars["String"]>;
+    synopsis_short?: Maybe<Scalars["String"]>;
+    tags?: Maybe<TagListing>;
+    themes?: Maybe<ThemeListing>;
+    title?: Maybe<Scalars["String"]>;
+    title_long?: Maybe<Scalars["String"]>;
+    title_medium?: Maybe<Scalars["String"]>;
+    title_short?: Maybe<Scalars["String"]>;
+    uid: Scalars["String"];
+  };
 
 export type Brand_MetaArgs = {
-  global_version?: InputMaybe<Scalars['Int']>;
-  language?: InputMaybe<Scalars['String']>;
-  language_version?: InputMaybe<Scalars['Int']>;
+  global_version?: InputMaybe<Scalars["Int"]>;
+  language?: InputMaybe<Scalars["String"]>;
+  language_version?: InputMaybe<Scalars["Int"]>;
 };
-
 
 export type BrandAssetsArgs = {
-  language?: InputMaybe<Scalars['String']>;
-  limit?: InputMaybe<Scalars['Int']>;
-  next_token?: InputMaybe<Scalars['String']>;
+  language?: InputMaybe<Scalars["String"]>;
+  limit?: InputMaybe<Scalars["Int"]>;
+  next_token?: InputMaybe<Scalars["String"]>;
 };
-
 
 export type BrandAvailabilityArgs = {
-  limit?: InputMaybe<Scalars['Int']>;
-  next_token?: InputMaybe<Scalars['String']>;
+  limit?: InputMaybe<Scalars["Int"]>;
+  next_token?: InputMaybe<Scalars["String"]>;
 };
-
 
 export type BrandCreditsArgs = {
-  language?: InputMaybe<Scalars['String']>;
-  limit?: InputMaybe<Scalars['Int']>;
-  next_token?: InputMaybe<Scalars['String']>;
+  language?: InputMaybe<Scalars["String"]>;
+  limit?: InputMaybe<Scalars["Int"]>;
+  next_token?: InputMaybe<Scalars["String"]>;
 };
-
 
 export type BrandEpisodesArgs = {
-  language?: InputMaybe<Scalars['String']>;
-  limit?: InputMaybe<Scalars['Int']>;
-  next_token?: InputMaybe<Scalars['String']>;
+  language?: InputMaybe<Scalars["String"]>;
+  limit?: InputMaybe<Scalars["Int"]>;
+  next_token?: InputMaybe<Scalars["String"]>;
 };
-
 
 export type BrandGenresArgs = {
-  language?: InputMaybe<Scalars['String']>;
-  limit?: InputMaybe<Scalars['Int']>;
-  next_token?: InputMaybe<Scalars['String']>;
+  language?: InputMaybe<Scalars["String"]>;
+  limit?: InputMaybe<Scalars["Int"]>;
+  next_token?: InputMaybe<Scalars["String"]>;
 };
-
 
 export type BrandImagesArgs = {
-  language?: InputMaybe<Scalars['String']>;
-  limit?: InputMaybe<Scalars['Int']>;
-  next_token?: InputMaybe<Scalars['String']>;
+  language?: InputMaybe<Scalars["String"]>;
+  limit?: InputMaybe<Scalars["Int"]>;
+  next_token?: InputMaybe<Scalars["String"]>;
 };
-
 
 export type BrandMoviesArgs = {
-  language?: InputMaybe<Scalars['String']>;
-  limit?: InputMaybe<Scalars['Int']>;
-  next_token?: InputMaybe<Scalars['String']>;
+  language?: InputMaybe<Scalars["String"]>;
+  limit?: InputMaybe<Scalars["Int"]>;
+  next_token?: InputMaybe<Scalars["String"]>;
 };
-
 
 export type BrandRatingsArgs = {
-  language?: InputMaybe<Scalars['String']>;
-  limit?: InputMaybe<Scalars['Int']>;
-  next_token?: InputMaybe<Scalars['String']>;
+  language?: InputMaybe<Scalars["String"]>;
+  limit?: InputMaybe<Scalars["Int"]>;
+  next_token?: InputMaybe<Scalars["String"]>;
 };
-
 
 export type BrandSeasonsArgs = {
-  language?: InputMaybe<Scalars['String']>;
-  limit?: InputMaybe<Scalars['Int']>;
-  next_token?: InputMaybe<Scalars['String']>;
+  language?: InputMaybe<Scalars["String"]>;
+  limit?: InputMaybe<Scalars["Int"]>;
+  next_token?: InputMaybe<Scalars["String"]>;
 };
-
 
 export type BrandSetsArgs = {
-  limit?: InputMaybe<Scalars['Int']>;
-  next_token?: InputMaybe<Scalars['String']>;
+  limit?: InputMaybe<Scalars["Int"]>;
+  next_token?: InputMaybe<Scalars["String"]>;
 };
-
 
 export type BrandTagsArgs = {
-  language?: InputMaybe<Scalars['String']>;
-  limit?: InputMaybe<Scalars['Int']>;
-  next_token?: InputMaybe<Scalars['String']>;
+  language?: InputMaybe<Scalars["String"]>;
+  limit?: InputMaybe<Scalars["Int"]>;
+  next_token?: InputMaybe<Scalars["String"]>;
 };
 
-
 export type BrandThemesArgs = {
-  language?: InputMaybe<Scalars['String']>;
-  limit?: InputMaybe<Scalars['Int']>;
-  next_token?: InputMaybe<Scalars['String']>;
+  language?: InputMaybe<Scalars["String"]>;
+  limit?: InputMaybe<Scalars["Int"]>;
+  next_token?: InputMaybe<Scalars["String"]>;
 };
 
 export type BrandInput = {
   availability?: InputMaybe<AssignAvailabilityInput>;
-  data_source_fields?: InputMaybe<Array<InputMaybe<Scalars['String']>>>;
-  data_source_id?: InputMaybe<Scalars['String']>;
-  external_id?: InputMaybe<Scalars['String']>;
+  data_source_fields?: InputMaybe<Array<InputMaybe<Scalars["String"]>>>;
+  data_source_id?: InputMaybe<Scalars["String"]>;
+  external_id?: InputMaybe<Scalars["String"]>;
   relationships?: InputMaybe<BrandRelationships>;
-  release_date?: InputMaybe<Scalars['String']>;
-  slug?: InputMaybe<Scalars['String']>;
-  synopsis_long?: InputMaybe<Scalars['String']>;
-  synopsis_medium?: InputMaybe<Scalars['String']>;
-  synopsis_short?: InputMaybe<Scalars['String']>;
-  title?: InputMaybe<Scalars['String']>;
-  title_long?: InputMaybe<Scalars['String']>;
-  title_medium?: InputMaybe<Scalars['String']>;
-  title_short?: InputMaybe<Scalars['String']>;
+  release_date?: InputMaybe<Scalars["String"]>;
+  slug?: InputMaybe<Scalars["String"]>;
+  synopsis_long?: InputMaybe<Scalars["String"]>;
+  synopsis_medium?: InputMaybe<Scalars["String"]>;
+  synopsis_short?: InputMaybe<Scalars["String"]>;
+  title?: InputMaybe<Scalars["String"]>;
+  title_long?: InputMaybe<Scalars["String"]>;
+  title_medium?: InputMaybe<Scalars["String"]>;
+  title_short?: InputMaybe<Scalars["String"]>;
 };
 
 export type BrandListing = Listing & {
-  __typename?: 'BrandListing';
-  count?: Maybe<Scalars['Int']>;
-  next_token?: Maybe<Scalars['String']>;
+  __typename?: "BrandListing";
+  count?: Maybe<Scalars["Int"]>;
+  next_token?: Maybe<Scalars["String"]>;
   objects?: Maybe<Array<Maybe<Brand>>>;
 };
 
 export type BrandRelationshipInput = {
   create?: InputMaybe<Array<InputMaybe<BrandInput>>>;
-  link?: InputMaybe<Array<InputMaybe<Scalars['String']>>>;
-  unlink?: InputMaybe<Array<InputMaybe<Scalars['String']>>>;
+  link?: InputMaybe<Array<InputMaybe<Scalars["String"]>>>;
+  unlink?: InputMaybe<Array<InputMaybe<Scalars["String"]>>>;
 };
 
 export type BrandRelationships = {
@@ -302,83 +291,79 @@ export type BrandRelationships = {
 
 export type BrandSetCreate = {
   object?: InputMaybe<BrandInput>;
-  position: Scalars['Int'];
+  position: Scalars["Int"];
 };
 
 export type BrandSetInput = {
   create?: InputMaybe<Array<InputMaybe<BrandSetCreate>>>;
   link?: InputMaybe<Array<InputMaybe<SetLink>>>;
   reposition?: InputMaybe<Array<InputMaybe<SetLink>>>;
-  unlink?: InputMaybe<Array<InputMaybe<Scalars['String']>>>;
+  unlink?: InputMaybe<Array<InputMaybe<Scalars["String"]>>>;
 };
 
 export type CountResponse = {
-  __typename?: 'CountResponse';
-  count?: Maybe<Scalars['Int']>;
+  __typename?: "CountResponse";
+  count?: Maybe<Scalars["Int"]>;
 };
 
 export type Credit = Metadata & {
-  __typename?: 'Credit';
+  __typename?: "Credit";
   _meta?: Maybe<_CreditMeta>;
   availability?: Maybe<AvailabilityListing>;
-  character?: Maybe<Scalars['String']>;
-  external_id?: Maybe<Scalars['String']>;
+  character?: Maybe<Scalars["String"]>;
+  external_id?: Maybe<Scalars["String"]>;
   people?: Maybe<PersonListing>;
-  position?: Maybe<Scalars['Int']>;
+  position?: Maybe<Scalars["Int"]>;
   roles?: Maybe<RoleListing>;
-  slug?: Maybe<Scalars['String']>;
-  uid: Scalars['String'];
+  slug?: Maybe<Scalars["String"]>;
+  uid: Scalars["String"];
 };
-
 
 export type Credit_MetaArgs = {
-  global_version?: InputMaybe<Scalars['Int']>;
-  language?: InputMaybe<Scalars['String']>;
-  language_version?: InputMaybe<Scalars['Int']>;
+  global_version?: InputMaybe<Scalars["Int"]>;
+  language?: InputMaybe<Scalars["String"]>;
+  language_version?: InputMaybe<Scalars["Int"]>;
 };
-
 
 export type CreditAvailabilityArgs = {
-  limit?: InputMaybe<Scalars['Int']>;
-  next_token?: InputMaybe<Scalars['String']>;
+  limit?: InputMaybe<Scalars["Int"]>;
+  next_token?: InputMaybe<Scalars["String"]>;
 };
-
 
 export type CreditPeopleArgs = {
-  language?: InputMaybe<Scalars['String']>;
-  limit?: InputMaybe<Scalars['Int']>;
-  next_token?: InputMaybe<Scalars['String']>;
+  language?: InputMaybe<Scalars["String"]>;
+  limit?: InputMaybe<Scalars["Int"]>;
+  next_token?: InputMaybe<Scalars["String"]>;
 };
 
-
 export type CreditRolesArgs = {
-  language?: InputMaybe<Scalars['String']>;
-  limit?: InputMaybe<Scalars['Int']>;
-  next_token?: InputMaybe<Scalars['String']>;
+  language?: InputMaybe<Scalars["String"]>;
+  limit?: InputMaybe<Scalars["Int"]>;
+  next_token?: InputMaybe<Scalars["String"]>;
 };
 
 export type CreditInput = {
   availability?: InputMaybe<AssignAvailabilityInput>;
-  character?: InputMaybe<Scalars['String']>;
-  data_source_fields?: InputMaybe<Array<InputMaybe<Scalars['String']>>>;
-  data_source_id?: InputMaybe<Scalars['String']>;
-  external_id?: InputMaybe<Scalars['String']>;
-  position?: InputMaybe<Scalars['Int']>;
+  character?: InputMaybe<Scalars["String"]>;
+  data_source_fields?: InputMaybe<Array<InputMaybe<Scalars["String"]>>>;
+  data_source_id?: InputMaybe<Scalars["String"]>;
+  external_id?: InputMaybe<Scalars["String"]>;
+  position?: InputMaybe<Scalars["Int"]>;
   relationships?: InputMaybe<CreditRelationships>;
-  slug?: InputMaybe<Scalars['String']>;
+  slug?: InputMaybe<Scalars["String"]>;
 };
 
 export type CreditListing = Listing & {
-  __typename?: 'CreditListing';
-  count?: Maybe<Scalars['Int']>;
-  next_token?: Maybe<Scalars['String']>;
+  __typename?: "CreditListing";
+  count?: Maybe<Scalars["Int"]>;
+  next_token?: Maybe<Scalars["String"]>;
   objects?: Maybe<Array<Maybe<Credit>>>;
 };
 
 export type CreditRelationshipInput = {
   create?: InputMaybe<Array<InputMaybe<CreditInput>>>;
-  link?: InputMaybe<Array<InputMaybe<Scalars['String']>>>;
-  unlink?: InputMaybe<Array<InputMaybe<Scalars['String']>>>;
+  link?: InputMaybe<Array<InputMaybe<Scalars["String"]>>>;
+  unlink?: InputMaybe<Array<InputMaybe<Scalars["String"]>>>;
 };
 
 export type CreditRelationships = {
@@ -387,62 +372,60 @@ export type CreditRelationships = {
 };
 
 export type CurationMetadata = {
-  external_id?: Maybe<Scalars['String']>;
+  external_id?: Maybe<Scalars["String"]>;
   sets?: Maybe<SetListing>;
-  slug?: Maybe<Scalars['String']>;
-  uid: Scalars['String'];
+  slug?: Maybe<Scalars["String"]>;
+  uid: Scalars["String"];
 };
 
-
 export type CurationMetadataSetsArgs = {
-  limit?: InputMaybe<Scalars['Int']>;
-  next_token?: InputMaybe<Scalars['String']>;
+  limit?: InputMaybe<Scalars["Int"]>;
+  next_token?: InputMaybe<Scalars["String"]>;
 };
 
 export type CurationMetadataListing = Listing & {
-  __typename?: 'CurationMetadataListing';
-  count?: Maybe<Scalars['Int']>;
-  next_token?: Maybe<Scalars['String']>;
+  __typename?: "CurationMetadataListing";
+  count?: Maybe<Scalars["Int"]>;
+  next_token?: Maybe<Scalars["String"]>;
   objects?: Maybe<Array<Maybe<SetContent>>>;
 };
 
 export type Dimension = {
-  __typename?: 'Dimension';
+  __typename?: "Dimension";
   _meta?: Maybe<_DimensionMeta>;
-  description?: Maybe<Scalars['String']>;
-  external_id?: Maybe<Scalars['String']>;
-  slug: Scalars['String'];
-  title?: Maybe<Scalars['String']>;
-  uid: Scalars['String'];
+  description?: Maybe<Scalars["String"]>;
+  external_id?: Maybe<Scalars["String"]>;
+  slug: Scalars["String"];
+  title?: Maybe<Scalars["String"]>;
+  uid: Scalars["String"];
 };
 
-
 export type Dimension_MetaArgs = {
-  value_external_id?: InputMaybe<Scalars['String']>;
-  value_id?: InputMaybe<Scalars['String']>;
+  value_external_id?: InputMaybe<Scalars["String"]>;
+  value_id?: InputMaybe<Scalars["String"]>;
 };
 
 export type DimensionAssigned = {
-  __typename?: 'DimensionAssigned';
-  dimension_slug?: Maybe<Scalars['String']>;
-  value_slugs?: Maybe<Array<Maybe<Scalars['String']>>>;
+  __typename?: "DimensionAssigned";
+  dimension_slug?: Maybe<Scalars["String"]>;
+  value_slugs?: Maybe<Array<Maybe<Scalars["String"]>>>;
 };
 
 export type DimensionInput = {
-  description?: InputMaybe<Scalars['String']>;
-  external_id?: InputMaybe<Scalars['String']>;
-  slug: Scalars['String'];
-  title?: InputMaybe<Scalars['String']>;
+  description?: InputMaybe<Scalars["String"]>;
+  external_id?: InputMaybe<Scalars["String"]>;
+  slug: Scalars["String"];
+  title?: InputMaybe<Scalars["String"]>;
 };
 
 export type DimensionValue = {
-  __typename?: 'DimensionValue';
+  __typename?: "DimensionValue";
   _meta?: Maybe<_DimensionValueMeta>;
-  description?: Maybe<Scalars['String']>;
-  external_id?: Maybe<Scalars['String']>;
-  slug: Scalars['String'];
-  title?: Maybe<Scalars['String']>;
-  uid: Scalars['String'];
+  description?: Maybe<Scalars["String"]>;
+  external_id?: Maybe<Scalars["String"]>;
+  slug: Scalars["String"];
+  title?: Maybe<Scalars["String"]>;
+  uid: Scalars["String"];
 };
 
 export type Entertainment = {
@@ -452,219 +435,200 @@ export type Entertainment = {
   genres?: Maybe<GenreListing>;
   images?: Maybe<ImageListing>;
   ratings?: Maybe<RatingListing>;
-  release_date?: Maybe<Scalars['String']>;
-  synopsis_long?: Maybe<Scalars['String']>;
-  synopsis_medium?: Maybe<Scalars['String']>;
-  synopsis_short?: Maybe<Scalars['String']>;
+  release_date?: Maybe<Scalars["String"]>;
+  synopsis_long?: Maybe<Scalars["String"]>;
+  synopsis_medium?: Maybe<Scalars["String"]>;
+  synopsis_short?: Maybe<Scalars["String"]>;
   tags?: Maybe<TagListing>;
   themes?: Maybe<ThemeListing>;
-  title?: Maybe<Scalars['String']>;
-  title_long?: Maybe<Scalars['String']>;
-  title_medium?: Maybe<Scalars['String']>;
-  title_short?: Maybe<Scalars['String']>;
+  title?: Maybe<Scalars["String"]>;
+  title_long?: Maybe<Scalars["String"]>;
+  title_medium?: Maybe<Scalars["String"]>;
+  title_short?: Maybe<Scalars["String"]>;
 };
-
 
 export type EntertainmentAssetsArgs = {
-  language?: InputMaybe<Scalars['String']>;
-  limit?: InputMaybe<Scalars['Int']>;
-  next_token?: InputMaybe<Scalars['String']>;
+  language?: InputMaybe<Scalars["String"]>;
+  limit?: InputMaybe<Scalars["Int"]>;
+  next_token?: InputMaybe<Scalars["String"]>;
 };
-
 
 export type EntertainmentAvailabilityArgs = {
-  limit?: InputMaybe<Scalars['Int']>;
-  next_token?: InputMaybe<Scalars['String']>;
+  limit?: InputMaybe<Scalars["Int"]>;
+  next_token?: InputMaybe<Scalars["String"]>;
 };
-
 
 export type EntertainmentCreditsArgs = {
-  language?: InputMaybe<Scalars['String']>;
-  limit?: InputMaybe<Scalars['Int']>;
-  next_token?: InputMaybe<Scalars['String']>;
+  language?: InputMaybe<Scalars["String"]>;
+  limit?: InputMaybe<Scalars["Int"]>;
+  next_token?: InputMaybe<Scalars["String"]>;
 };
-
 
 export type EntertainmentGenresArgs = {
-  language?: InputMaybe<Scalars['String']>;
-  limit?: InputMaybe<Scalars['Int']>;
-  next_token?: InputMaybe<Scalars['String']>;
+  language?: InputMaybe<Scalars["String"]>;
+  limit?: InputMaybe<Scalars["Int"]>;
+  next_token?: InputMaybe<Scalars["String"]>;
 };
-
 
 export type EntertainmentImagesArgs = {
-  language?: InputMaybe<Scalars['String']>;
-  limit?: InputMaybe<Scalars['Int']>;
-  next_token?: InputMaybe<Scalars['String']>;
+  language?: InputMaybe<Scalars["String"]>;
+  limit?: InputMaybe<Scalars["Int"]>;
+  next_token?: InputMaybe<Scalars["String"]>;
 };
-
 
 export type EntertainmentRatingsArgs = {
-  language?: InputMaybe<Scalars['String']>;
-  limit?: InputMaybe<Scalars['Int']>;
-  next_token?: InputMaybe<Scalars['String']>;
+  language?: InputMaybe<Scalars["String"]>;
+  limit?: InputMaybe<Scalars["Int"]>;
+  next_token?: InputMaybe<Scalars["String"]>;
 };
-
 
 export type EntertainmentTagsArgs = {
-  language?: InputMaybe<Scalars['String']>;
-  limit?: InputMaybe<Scalars['Int']>;
-  next_token?: InputMaybe<Scalars['String']>;
+  language?: InputMaybe<Scalars["String"]>;
+  limit?: InputMaybe<Scalars["Int"]>;
+  next_token?: InputMaybe<Scalars["String"]>;
 };
 
-
 export type EntertainmentThemesArgs = {
-  language?: InputMaybe<Scalars['String']>;
-  limit?: InputMaybe<Scalars['Int']>;
-  next_token?: InputMaybe<Scalars['String']>;
+  language?: InputMaybe<Scalars["String"]>;
+  limit?: InputMaybe<Scalars["Int"]>;
+  next_token?: InputMaybe<Scalars["String"]>;
 };
 
 export type EntertainmentListing = {
-  __typename?: 'EntertainmentListing';
-  count?: Maybe<Scalars['Int']>;
-  next_token?: Maybe<Scalars['String']>;
+  __typename?: "EntertainmentListing";
+  count?: Maybe<Scalars["Int"]>;
+  next_token?: Maybe<Scalars["String"]>;
   objects?: Maybe<Array<Maybe<Entertainment>>>;
 };
 
-export type Episode = CurationMetadata & Entertainment & {
-  __typename?: 'Episode';
-  _meta?: Maybe<_EpisodeMeta>;
-  assets?: Maybe<AssetListing>;
-  availability?: Maybe<AvailabilityListing>;
-  brands?: Maybe<BrandListing>;
-  credits?: Maybe<CreditListing>;
-  episode_number?: Maybe<Scalars['Int']>;
-  external_id?: Maybe<Scalars['String']>;
-  genres?: Maybe<GenreListing>;
-  images?: Maybe<ImageListing>;
-  ratings?: Maybe<RatingListing>;
-  release_date?: Maybe<Scalars['String']>;
-  seasons?: Maybe<SeasonListing>;
-  sets?: Maybe<SetListing>;
-  slug?: Maybe<Scalars['String']>;
-  synopsis_long?: Maybe<Scalars['String']>;
-  synopsis_medium?: Maybe<Scalars['String']>;
-  synopsis_short?: Maybe<Scalars['String']>;
-  tags?: Maybe<TagListing>;
-  themes?: Maybe<ThemeListing>;
-  title?: Maybe<Scalars['String']>;
-  title_long?: Maybe<Scalars['String']>;
-  title_medium?: Maybe<Scalars['String']>;
-  title_short?: Maybe<Scalars['String']>;
-  uid: Scalars['String'];
-};
-
+export type Episode = CurationMetadata &
+  Entertainment & {
+    __typename?: "Episode";
+    _meta?: Maybe<_EpisodeMeta>;
+    assets?: Maybe<AssetListing>;
+    availability?: Maybe<AvailabilityListing>;
+    brands?: Maybe<BrandListing>;
+    credits?: Maybe<CreditListing>;
+    episode_number?: Maybe<Scalars["Int"]>;
+    external_id?: Maybe<Scalars["String"]>;
+    genres?: Maybe<GenreListing>;
+    images?: Maybe<ImageListing>;
+    ratings?: Maybe<RatingListing>;
+    release_date?: Maybe<Scalars["String"]>;
+    seasons?: Maybe<SeasonListing>;
+    sets?: Maybe<SetListing>;
+    slug?: Maybe<Scalars["String"]>;
+    synopsis_long?: Maybe<Scalars["String"]>;
+    synopsis_medium?: Maybe<Scalars["String"]>;
+    synopsis_short?: Maybe<Scalars["String"]>;
+    tags?: Maybe<TagListing>;
+    themes?: Maybe<ThemeListing>;
+    title?: Maybe<Scalars["String"]>;
+    title_long?: Maybe<Scalars["String"]>;
+    title_medium?: Maybe<Scalars["String"]>;
+    title_short?: Maybe<Scalars["String"]>;
+    uid: Scalars["String"];
+  };
 
 export type Episode_MetaArgs = {
-  global_version?: InputMaybe<Scalars['Int']>;
-  language?: InputMaybe<Scalars['String']>;
-  language_version?: InputMaybe<Scalars['Int']>;
+  global_version?: InputMaybe<Scalars["Int"]>;
+  language?: InputMaybe<Scalars["String"]>;
+  language_version?: InputMaybe<Scalars["Int"]>;
 };
-
 
 export type EpisodeAssetsArgs = {
-  language?: InputMaybe<Scalars['String']>;
-  limit?: InputMaybe<Scalars['Int']>;
-  next_token?: InputMaybe<Scalars['String']>;
+  language?: InputMaybe<Scalars["String"]>;
+  limit?: InputMaybe<Scalars["Int"]>;
+  next_token?: InputMaybe<Scalars["String"]>;
 };
-
 
 export type EpisodeAvailabilityArgs = {
-  limit?: InputMaybe<Scalars['Int']>;
-  next_token?: InputMaybe<Scalars['String']>;
+  limit?: InputMaybe<Scalars["Int"]>;
+  next_token?: InputMaybe<Scalars["String"]>;
 };
-
 
 export type EpisodeBrandsArgs = {
-  language?: InputMaybe<Scalars['String']>;
-  limit?: InputMaybe<Scalars['Int']>;
-  next_token?: InputMaybe<Scalars['String']>;
+  language?: InputMaybe<Scalars["String"]>;
+  limit?: InputMaybe<Scalars["Int"]>;
+  next_token?: InputMaybe<Scalars["String"]>;
 };
-
 
 export type EpisodeCreditsArgs = {
-  language?: InputMaybe<Scalars['String']>;
-  limit?: InputMaybe<Scalars['Int']>;
-  next_token?: InputMaybe<Scalars['String']>;
+  language?: InputMaybe<Scalars["String"]>;
+  limit?: InputMaybe<Scalars["Int"]>;
+  next_token?: InputMaybe<Scalars["String"]>;
 };
-
 
 export type EpisodeGenresArgs = {
-  language?: InputMaybe<Scalars['String']>;
-  limit?: InputMaybe<Scalars['Int']>;
-  next_token?: InputMaybe<Scalars['String']>;
+  language?: InputMaybe<Scalars["String"]>;
+  limit?: InputMaybe<Scalars["Int"]>;
+  next_token?: InputMaybe<Scalars["String"]>;
 };
-
 
 export type EpisodeImagesArgs = {
-  language?: InputMaybe<Scalars['String']>;
-  limit?: InputMaybe<Scalars['Int']>;
-  next_token?: InputMaybe<Scalars['String']>;
+  language?: InputMaybe<Scalars["String"]>;
+  limit?: InputMaybe<Scalars["Int"]>;
+  next_token?: InputMaybe<Scalars["String"]>;
 };
-
 
 export type EpisodeRatingsArgs = {
-  language?: InputMaybe<Scalars['String']>;
-  limit?: InputMaybe<Scalars['Int']>;
-  next_token?: InputMaybe<Scalars['String']>;
+  language?: InputMaybe<Scalars["String"]>;
+  limit?: InputMaybe<Scalars["Int"]>;
+  next_token?: InputMaybe<Scalars["String"]>;
 };
-
 
 export type EpisodeSeasonsArgs = {
-  language?: InputMaybe<Scalars['String']>;
-  limit?: InputMaybe<Scalars['Int']>;
-  next_token?: InputMaybe<Scalars['String']>;
+  language?: InputMaybe<Scalars["String"]>;
+  limit?: InputMaybe<Scalars["Int"]>;
+  next_token?: InputMaybe<Scalars["String"]>;
 };
-
 
 export type EpisodeSetsArgs = {
-  limit?: InputMaybe<Scalars['Int']>;
-  next_token?: InputMaybe<Scalars['String']>;
+  limit?: InputMaybe<Scalars["Int"]>;
+  next_token?: InputMaybe<Scalars["String"]>;
 };
-
 
 export type EpisodeTagsArgs = {
-  language?: InputMaybe<Scalars['String']>;
-  limit?: InputMaybe<Scalars['Int']>;
-  next_token?: InputMaybe<Scalars['String']>;
+  language?: InputMaybe<Scalars["String"]>;
+  limit?: InputMaybe<Scalars["Int"]>;
+  next_token?: InputMaybe<Scalars["String"]>;
 };
 
-
 export type EpisodeThemesArgs = {
-  language?: InputMaybe<Scalars['String']>;
-  limit?: InputMaybe<Scalars['Int']>;
-  next_token?: InputMaybe<Scalars['String']>;
+  language?: InputMaybe<Scalars["String"]>;
+  limit?: InputMaybe<Scalars["Int"]>;
+  next_token?: InputMaybe<Scalars["String"]>;
 };
 
 export type EpisodeInput = {
   availability?: InputMaybe<AssignAvailabilityInput>;
-  data_source_fields?: InputMaybe<Array<InputMaybe<Scalars['String']>>>;
-  data_source_id?: InputMaybe<Scalars['String']>;
-  episode_number?: InputMaybe<Scalars['Int']>;
-  external_id?: InputMaybe<Scalars['String']>;
+  data_source_fields?: InputMaybe<Array<InputMaybe<Scalars["String"]>>>;
+  data_source_id?: InputMaybe<Scalars["String"]>;
+  episode_number?: InputMaybe<Scalars["Int"]>;
+  external_id?: InputMaybe<Scalars["String"]>;
   relationships?: InputMaybe<EpisodeRelationships>;
-  release_date?: InputMaybe<Scalars['String']>;
-  slug?: InputMaybe<Scalars['String']>;
-  synopsis_long?: InputMaybe<Scalars['String']>;
-  synopsis_medium?: InputMaybe<Scalars['String']>;
-  synopsis_short?: InputMaybe<Scalars['String']>;
-  title?: InputMaybe<Scalars['String']>;
-  title_long?: InputMaybe<Scalars['String']>;
-  title_medium?: InputMaybe<Scalars['String']>;
-  title_short?: InputMaybe<Scalars['String']>;
+  release_date?: InputMaybe<Scalars["String"]>;
+  slug?: InputMaybe<Scalars["String"]>;
+  synopsis_long?: InputMaybe<Scalars["String"]>;
+  synopsis_medium?: InputMaybe<Scalars["String"]>;
+  synopsis_short?: InputMaybe<Scalars["String"]>;
+  title?: InputMaybe<Scalars["String"]>;
+  title_long?: InputMaybe<Scalars["String"]>;
+  title_medium?: InputMaybe<Scalars["String"]>;
+  title_short?: InputMaybe<Scalars["String"]>;
 };
 
 export type EpisodeListing = Listing & {
-  __typename?: 'EpisodeListing';
-  count?: Maybe<Scalars['Int']>;
-  next_token?: Maybe<Scalars['String']>;
+  __typename?: "EpisodeListing";
+  count?: Maybe<Scalars["Int"]>;
+  next_token?: Maybe<Scalars["String"]>;
   objects?: Maybe<Array<Maybe<Episode>>>;
 };
 
 export type EpisodeRelationshipInput = {
   create?: InputMaybe<Array<InputMaybe<EpisodeInput>>>;
-  link?: InputMaybe<Array<InputMaybe<Scalars['String']>>>;
-  unlink?: InputMaybe<Array<InputMaybe<Scalars['String']>>>;
+  link?: InputMaybe<Array<InputMaybe<Scalars["String"]>>>;
+  unlink?: InputMaybe<Array<InputMaybe<Scalars["String"]>>>;
 };
 
 export type EpisodeRelationships = {
@@ -681,317 +645,300 @@ export type EpisodeRelationships = {
 
 export type EpisodeSetCreate = {
   object?: InputMaybe<EpisodeInput>;
-  position: Scalars['Int'];
+  position: Scalars["Int"];
 };
 
 export type EpisodeSetInput = {
   create?: InputMaybe<Array<InputMaybe<EpisodeSetCreate>>>;
   link?: InputMaybe<Array<InputMaybe<SetLink>>>;
   reposition?: InputMaybe<Array<InputMaybe<SetLink>>>;
-  unlink?: InputMaybe<Array<InputMaybe<Scalars['String']>>>;
+  unlink?: InputMaybe<Array<InputMaybe<Scalars["String"]>>>;
 };
 
 export type Genre = CurationMetadata & {
-  __typename?: 'Genre';
+  __typename?: "Genre";
   _meta?: Maybe<_GenreMeta>;
   availability?: Maybe<AvailabilityListing>;
-  external_id?: Maybe<Scalars['String']>;
-  metadata_source?: Maybe<Scalars['String']>;
+  external_id?: Maybe<Scalars["String"]>;
+  metadata_source?: Maybe<Scalars["String"]>;
   movies?: Maybe<MovieListing>;
-  name?: Maybe<Scalars['String']>;
+  name?: Maybe<Scalars["String"]>;
   parents?: Maybe<EntertainmentListing>;
   sets?: Maybe<SetListing>;
-  slug?: Maybe<Scalars['String']>;
-  uid: Scalars['String'];
+  slug?: Maybe<Scalars["String"]>;
+  uid: Scalars["String"];
 };
-
 
 export type Genre_MetaArgs = {
-  global_version?: InputMaybe<Scalars['Int']>;
-  language?: InputMaybe<Scalars['String']>;
-  language_version?: InputMaybe<Scalars['Int']>;
+  global_version?: InputMaybe<Scalars["Int"]>;
+  language?: InputMaybe<Scalars["String"]>;
+  language_version?: InputMaybe<Scalars["Int"]>;
 };
-
 
 export type GenreAvailabilityArgs = {
-  limit?: InputMaybe<Scalars['Int']>;
-  next_token?: InputMaybe<Scalars['String']>;
+  limit?: InputMaybe<Scalars["Int"]>;
+  next_token?: InputMaybe<Scalars["String"]>;
 };
-
 
 export type GenreMoviesArgs = {
-  language?: InputMaybe<Scalars['String']>;
-  limit?: InputMaybe<Scalars['Int']>;
-  next_token?: InputMaybe<Scalars['String']>;
+  language?: InputMaybe<Scalars["String"]>;
+  limit?: InputMaybe<Scalars["Int"]>;
+  next_token?: InputMaybe<Scalars["String"]>;
 };
-
 
 export type GenreParentsArgs = {
-  language?: InputMaybe<Scalars['String']>;
-  limit?: InputMaybe<Scalars['Int']>;
-  next_token?: InputMaybe<Scalars['String']>;
+  language?: InputMaybe<Scalars["String"]>;
+  limit?: InputMaybe<Scalars["Int"]>;
+  next_token?: InputMaybe<Scalars["String"]>;
 };
 
-
 export type GenreSetsArgs = {
-  limit?: InputMaybe<Scalars['Int']>;
-  next_token?: InputMaybe<Scalars['String']>;
+  limit?: InputMaybe<Scalars["Int"]>;
+  next_token?: InputMaybe<Scalars["String"]>;
 };
 
 export type GenreInput = {
   availability?: InputMaybe<AssignAvailabilityInput>;
-  data_source_fields?: InputMaybe<Array<InputMaybe<Scalars['String']>>>;
-  data_source_id?: InputMaybe<Scalars['String']>;
-  external_id?: InputMaybe<Scalars['String']>;
-  metadata_source?: InputMaybe<Scalars['String']>;
-  name?: InputMaybe<Scalars['String']>;
-  slug?: InputMaybe<Scalars['String']>;
+  data_source_fields?: InputMaybe<Array<InputMaybe<Scalars["String"]>>>;
+  data_source_id?: InputMaybe<Scalars["String"]>;
+  external_id?: InputMaybe<Scalars["String"]>;
+  metadata_source?: InputMaybe<Scalars["String"]>;
+  name?: InputMaybe<Scalars["String"]>;
+  slug?: InputMaybe<Scalars["String"]>;
 };
 
 export type GenreListing = Listing & {
-  __typename?: 'GenreListing';
-  count?: Maybe<Scalars['Int']>;
-  next_token?: Maybe<Scalars['String']>;
+  __typename?: "GenreListing";
+  count?: Maybe<Scalars["Int"]>;
+  next_token?: Maybe<Scalars["String"]>;
   objects?: Maybe<Array<Maybe<Genre>>>;
 };
 
 export type GenreRelationshipInput = {
   create?: InputMaybe<Array<InputMaybe<GenreInput>>>;
-  link?: InputMaybe<Array<InputMaybe<Scalars['String']>>>;
-  unlink?: InputMaybe<Array<InputMaybe<Scalars['String']>>>;
+  link?: InputMaybe<Array<InputMaybe<Scalars["String"]>>>;
+  unlink?: InputMaybe<Array<InputMaybe<Scalars["String"]>>>;
 };
 
 export type GenreSetCreate = {
   object?: InputMaybe<GenreInput>;
-  position: Scalars['Int'];
+  position: Scalars["Int"];
 };
 
 export type GenreSetInput = {
   create?: InputMaybe<Array<InputMaybe<GenreSetCreate>>>;
   link?: InputMaybe<Array<InputMaybe<SetLink>>>;
   reposition?: InputMaybe<Array<InputMaybe<SetLink>>>;
-  unlink?: InputMaybe<Array<InputMaybe<Scalars['String']>>>;
+  unlink?: InputMaybe<Array<InputMaybe<Scalars["String"]>>>;
 };
 
 export type Image = Metadata & {
-  __typename?: 'Image';
+  __typename?: "Image";
   _meta?: Maybe<_ImageMeta>;
   availability?: Maybe<AvailabilityListing>;
-  description?: Maybe<Scalars['String']>;
-  external_id?: Maybe<Scalars['String']>;
+  description?: Maybe<Scalars["String"]>;
+  external_id?: Maybe<Scalars["String"]>;
   parents?: Maybe<EntertainmentListing>;
-  slug?: Maybe<Scalars['String']>;
-  title?: Maybe<Scalars['String']>;
-  type?: Maybe<Scalars['String']>;
-  uid: Scalars['String'];
-  url?: Maybe<Scalars['String']>;
+  slug?: Maybe<Scalars["String"]>;
+  title?: Maybe<Scalars["String"]>;
+  type?: Maybe<Scalars["String"]>;
+  uid: Scalars["String"];
+  url?: Maybe<Scalars["String"]>;
 };
-
 
 export type Image_MetaArgs = {
-  global_version?: InputMaybe<Scalars['Int']>;
-  language?: InputMaybe<Scalars['String']>;
-  language_version?: InputMaybe<Scalars['Int']>;
+  global_version?: InputMaybe<Scalars["Int"]>;
+  language?: InputMaybe<Scalars["String"]>;
+  language_version?: InputMaybe<Scalars["Int"]>;
 };
 
-
 export type ImageAvailabilityArgs = {
-  limit?: InputMaybe<Scalars['Int']>;
-  next_token?: InputMaybe<Scalars['String']>;
+  limit?: InputMaybe<Scalars["Int"]>;
+  next_token?: InputMaybe<Scalars["String"]>;
 };
 
 export type ImageInput = {
   availability?: InputMaybe<AssignAvailabilityInput>;
-  data_source_fields?: InputMaybe<Array<InputMaybe<Scalars['String']>>>;
-  data_source_id?: InputMaybe<Scalars['String']>;
-  description?: InputMaybe<Scalars['String']>;
-  external_id?: InputMaybe<Scalars['String']>;
-  title?: InputMaybe<Scalars['String']>;
+  data_source_fields?: InputMaybe<Array<InputMaybe<Scalars["String"]>>>;
+  data_source_id?: InputMaybe<Scalars["String"]>;
+  description?: InputMaybe<Scalars["String"]>;
+  external_id?: InputMaybe<Scalars["String"]>;
+  title?: InputMaybe<Scalars["String"]>;
   type?: InputMaybe<ImageType>;
-  url?: InputMaybe<Scalars['String']>;
+  url?: InputMaybe<Scalars["String"]>;
 };
 
 export type ImageListing = Listing & {
-  __typename?: 'ImageListing';
-  count?: Maybe<Scalars['Int']>;
-  next_token?: Maybe<Scalars['String']>;
+  __typename?: "ImageListing";
+  count?: Maybe<Scalars["Int"]>;
+  next_token?: Maybe<Scalars["String"]>;
   objects?: Maybe<Array<Maybe<Image>>>;
 };
 
 export type ImageRelationshipInput = {
   create?: InputMaybe<Array<InputMaybe<ImageInput>>>;
-  link?: InputMaybe<Array<InputMaybe<Scalars['String']>>>;
-  unlink?: InputMaybe<Array<InputMaybe<Scalars['String']>>>;
+  link?: InputMaybe<Array<InputMaybe<Scalars["String"]>>>;
+  unlink?: InputMaybe<Array<InputMaybe<Scalars["String"]>>>;
 };
 
 export type ImageSetCreate = {
   object?: InputMaybe<ImageInput>;
-  position: Scalars['Int'];
+  position: Scalars["Int"];
 };
 
 export type ImageSetInput = {
   create?: InputMaybe<Array<InputMaybe<ImageSetCreate>>>;
   link?: InputMaybe<Array<InputMaybe<SetLink>>>;
   reposition?: InputMaybe<Array<InputMaybe<SetLink>>>;
-  unlink?: InputMaybe<Array<InputMaybe<Scalars['String']>>>;
+  unlink?: InputMaybe<Array<InputMaybe<Scalars["String"]>>>;
 };
 
 export enum ImageType {
-  Background = 'BACKGROUND',
-  Feature = 'FEATURE',
-  Footer = 'FOOTER',
-  Header = 'HEADER',
-  Landscape = 'LANDSCAPE',
-  Main = 'MAIN',
-  Poster = 'POSTER',
-  PostLive = 'POST_LIVE',
-  Preview = 'PREVIEW',
-  PreLive = 'PRE_LIVE',
-  Thumbnail = 'THUMBNAIL'
+  Background = "BACKGROUND",
+  Feature = "FEATURE",
+  Footer = "FOOTER",
+  Header = "HEADER",
+  Landscape = "LANDSCAPE",
+  Main = "MAIN",
+  Poster = "POSTER",
+  PostLive = "POST_LIVE",
+  Preview = "PREVIEW",
+  PreLive = "PRE_LIVE",
+  Thumbnail = "THUMBNAIL",
 }
 
 export type Listing = {
-  count?: Maybe<Scalars['Int']>;
-  next_token?: Maybe<Scalars['String']>;
+  count?: Maybe<Scalars["Int"]>;
+  next_token?: Maybe<Scalars["String"]>;
 };
 
 export type Metadata = {
-  external_id?: Maybe<Scalars['String']>;
-  slug?: Maybe<Scalars['String']>;
-  uid: Scalars['String'];
+  external_id?: Maybe<Scalars["String"]>;
+  slug?: Maybe<Scalars["String"]>;
+  uid: Scalars["String"];
 };
 
-export type Movie = CurationMetadata & Entertainment & {
-  __typename?: 'Movie';
-  _meta?: Maybe<_MovieMeta>;
-  assets?: Maybe<AssetListing>;
-  availability?: Maybe<AvailabilityListing>;
-  brands?: Maybe<BrandListing>;
-  credits?: Maybe<CreditListing>;
-  external_id?: Maybe<Scalars['String']>;
-  genres?: Maybe<GenreListing>;
-  images?: Maybe<ImageListing>;
-  ratings?: Maybe<RatingListing>;
-  release_date?: Maybe<Scalars['String']>;
-  sets?: Maybe<SetListing>;
-  slug?: Maybe<Scalars['String']>;
-  synopsis_long?: Maybe<Scalars['String']>;
-  synopsis_medium?: Maybe<Scalars['String']>;
-  synopsis_short?: Maybe<Scalars['String']>;
-  tags?: Maybe<TagListing>;
-  themes?: Maybe<ThemeListing>;
-  title?: Maybe<Scalars['String']>;
-  title_long?: Maybe<Scalars['String']>;
-  title_medium?: Maybe<Scalars['String']>;
-  title_short?: Maybe<Scalars['String']>;
-  uid: Scalars['String'];
-  year_of_release?: Maybe<Scalars['Int']>;
-};
-
+export type Movie = CurationMetadata &
+  Entertainment & {
+    __typename?: "Movie";
+    _meta?: Maybe<_MovieMeta>;
+    assets?: Maybe<AssetListing>;
+    availability?: Maybe<AvailabilityListing>;
+    brands?: Maybe<BrandListing>;
+    credits?: Maybe<CreditListing>;
+    external_id?: Maybe<Scalars["String"]>;
+    genres?: Maybe<GenreListing>;
+    images?: Maybe<ImageListing>;
+    ratings?: Maybe<RatingListing>;
+    release_date?: Maybe<Scalars["String"]>;
+    sets?: Maybe<SetListing>;
+    slug?: Maybe<Scalars["String"]>;
+    synopsis_long?: Maybe<Scalars["String"]>;
+    synopsis_medium?: Maybe<Scalars["String"]>;
+    synopsis_short?: Maybe<Scalars["String"]>;
+    tags?: Maybe<TagListing>;
+    themes?: Maybe<ThemeListing>;
+    title?: Maybe<Scalars["String"]>;
+    title_long?: Maybe<Scalars["String"]>;
+    title_medium?: Maybe<Scalars["String"]>;
+    title_short?: Maybe<Scalars["String"]>;
+    uid: Scalars["String"];
+    year_of_release?: Maybe<Scalars["Int"]>;
+  };
 
 export type Movie_MetaArgs = {
-  global_version?: InputMaybe<Scalars['Int']>;
-  language?: InputMaybe<Scalars['String']>;
-  language_version?: InputMaybe<Scalars['Int']>;
+  global_version?: InputMaybe<Scalars["Int"]>;
+  language?: InputMaybe<Scalars["String"]>;
+  language_version?: InputMaybe<Scalars["Int"]>;
 };
-
 
 export type MovieAssetsArgs = {
-  language?: InputMaybe<Scalars['String']>;
-  limit?: InputMaybe<Scalars['Int']>;
-  next_token?: InputMaybe<Scalars['String']>;
+  language?: InputMaybe<Scalars["String"]>;
+  limit?: InputMaybe<Scalars["Int"]>;
+  next_token?: InputMaybe<Scalars["String"]>;
 };
-
 
 export type MovieAvailabilityArgs = {
-  limit?: InputMaybe<Scalars['Int']>;
-  next_token?: InputMaybe<Scalars['String']>;
+  limit?: InputMaybe<Scalars["Int"]>;
+  next_token?: InputMaybe<Scalars["String"]>;
 };
-
 
 export type MovieBrandsArgs = {
-  language?: InputMaybe<Scalars['String']>;
-  limit?: InputMaybe<Scalars['Int']>;
-  next_token?: InputMaybe<Scalars['String']>;
+  language?: InputMaybe<Scalars["String"]>;
+  limit?: InputMaybe<Scalars["Int"]>;
+  next_token?: InputMaybe<Scalars["String"]>;
 };
-
 
 export type MovieCreditsArgs = {
-  language?: InputMaybe<Scalars['String']>;
-  limit?: InputMaybe<Scalars['Int']>;
-  next_token?: InputMaybe<Scalars['String']>;
+  language?: InputMaybe<Scalars["String"]>;
+  limit?: InputMaybe<Scalars["Int"]>;
+  next_token?: InputMaybe<Scalars["String"]>;
 };
-
 
 export type MovieGenresArgs = {
-  language?: InputMaybe<Scalars['String']>;
-  limit?: InputMaybe<Scalars['Int']>;
-  next_token?: InputMaybe<Scalars['String']>;
+  language?: InputMaybe<Scalars["String"]>;
+  limit?: InputMaybe<Scalars["Int"]>;
+  next_token?: InputMaybe<Scalars["String"]>;
 };
-
 
 export type MovieImagesArgs = {
-  language?: InputMaybe<Scalars['String']>;
-  limit?: InputMaybe<Scalars['Int']>;
-  next_token?: InputMaybe<Scalars['String']>;
+  language?: InputMaybe<Scalars["String"]>;
+  limit?: InputMaybe<Scalars["Int"]>;
+  next_token?: InputMaybe<Scalars["String"]>;
 };
-
 
 export type MovieRatingsArgs = {
-  language?: InputMaybe<Scalars['String']>;
-  limit?: InputMaybe<Scalars['Int']>;
-  next_token?: InputMaybe<Scalars['String']>;
+  language?: InputMaybe<Scalars["String"]>;
+  limit?: InputMaybe<Scalars["Int"]>;
+  next_token?: InputMaybe<Scalars["String"]>;
 };
-
 
 export type MovieSetsArgs = {
-  limit?: InputMaybe<Scalars['Int']>;
-  next_token?: InputMaybe<Scalars['String']>;
+  limit?: InputMaybe<Scalars["Int"]>;
+  next_token?: InputMaybe<Scalars["String"]>;
 };
-
 
 export type MovieTagsArgs = {
-  language?: InputMaybe<Scalars['String']>;
-  limit?: InputMaybe<Scalars['Int']>;
-  next_token?: InputMaybe<Scalars['String']>;
+  language?: InputMaybe<Scalars["String"]>;
+  limit?: InputMaybe<Scalars["Int"]>;
+  next_token?: InputMaybe<Scalars["String"]>;
 };
 
-
 export type MovieThemesArgs = {
-  language?: InputMaybe<Scalars['String']>;
-  limit?: InputMaybe<Scalars['Int']>;
-  next_token?: InputMaybe<Scalars['String']>;
+  language?: InputMaybe<Scalars["String"]>;
+  limit?: InputMaybe<Scalars["Int"]>;
+  next_token?: InputMaybe<Scalars["String"]>;
 };
 
 export type MovieInput = {
   availability?: InputMaybe<AssignAvailabilityInput>;
-  data_source_fields?: InputMaybe<Array<InputMaybe<Scalars['String']>>>;
-  data_source_id?: InputMaybe<Scalars['String']>;
-  external_id?: InputMaybe<Scalars['String']>;
+  data_source_fields?: InputMaybe<Array<InputMaybe<Scalars["String"]>>>;
+  data_source_id?: InputMaybe<Scalars["String"]>;
+  external_id?: InputMaybe<Scalars["String"]>;
   relationships?: InputMaybe<MovieRelationships>;
-  release_date?: InputMaybe<Scalars['String']>;
-  slug?: InputMaybe<Scalars['String']>;
-  synopsis_long?: InputMaybe<Scalars['String']>;
-  synopsis_medium?: InputMaybe<Scalars['String']>;
-  synopsis_short?: InputMaybe<Scalars['String']>;
-  title?: InputMaybe<Scalars['String']>;
-  title_long?: InputMaybe<Scalars['String']>;
-  title_medium?: InputMaybe<Scalars['String']>;
-  title_short?: InputMaybe<Scalars['String']>;
-  year_of_release?: InputMaybe<Scalars['Int']>;
+  release_date?: InputMaybe<Scalars["String"]>;
+  slug?: InputMaybe<Scalars["String"]>;
+  synopsis_long?: InputMaybe<Scalars["String"]>;
+  synopsis_medium?: InputMaybe<Scalars["String"]>;
+  synopsis_short?: InputMaybe<Scalars["String"]>;
+  title?: InputMaybe<Scalars["String"]>;
+  title_long?: InputMaybe<Scalars["String"]>;
+  title_medium?: InputMaybe<Scalars["String"]>;
+  title_short?: InputMaybe<Scalars["String"]>;
+  year_of_release?: InputMaybe<Scalars["Int"]>;
 };
 
 export type MovieListing = Listing & {
-  __typename?: 'MovieListing';
-  count?: Maybe<Scalars['Int']>;
-  next_token?: Maybe<Scalars['String']>;
+  __typename?: "MovieListing";
+  count?: Maybe<Scalars["Int"]>;
+  next_token?: Maybe<Scalars["String"]>;
   objects?: Maybe<Array<Maybe<Movie>>>;
 };
 
 export type MovieRelationshipInput = {
   create?: InputMaybe<Array<InputMaybe<MovieInput>>>;
-  link?: InputMaybe<Array<InputMaybe<Scalars['String']>>>;
-  unlink?: InputMaybe<Array<InputMaybe<Scalars['String']>>>;
+  link?: InputMaybe<Array<InputMaybe<Scalars["String"]>>>;
+  unlink?: InputMaybe<Array<InputMaybe<Scalars["String"]>>>;
 };
 
 export type MovieRelationships = {
@@ -1007,18 +954,18 @@ export type MovieRelationships = {
 
 export type MovieSetCreate = {
   object?: InputMaybe<MovieInput>;
-  position: Scalars['Int'];
+  position: Scalars["Int"];
 };
 
 export type MovieSetInput = {
   create?: InputMaybe<Array<InputMaybe<MovieSetCreate>>>;
   link?: InputMaybe<Array<InputMaybe<SetLink>>>;
   reposition?: InputMaybe<Array<InputMaybe<SetLink>>>;
-  unlink?: InputMaybe<Array<InputMaybe<Scalars['String']>>>;
+  unlink?: InputMaybe<Array<InputMaybe<Scalars["String"]>>>;
 };
 
 export type Mutation = {
-  __typename?: 'Mutation';
+  __typename?: "Mutation";
   createAsset?: Maybe<Asset>;
   createAvailability?: Maybe<Availability>;
   createBrand?: Maybe<Brand>;
@@ -1038,11 +985,11 @@ export type Mutation = {
   createTag?: Maybe<Tag>;
   createTheme?: Maybe<Theme>;
   deleteAsset?: Maybe<Array<Maybe<ObjectDeleteResponse>>>;
-  deleteAvailability?: Maybe<Scalars['String']>;
+  deleteAvailability?: Maybe<Scalars["String"]>;
   deleteBrand?: Maybe<Array<Maybe<ObjectDeleteResponse>>>;
   deleteCredit?: Maybe<Array<Maybe<ObjectDeleteResponse>>>;
-  deleteDimension?: Maybe<Scalars['String']>;
-  deleteDimensionValue?: Maybe<Scalars['String']>;
+  deleteDimension?: Maybe<Scalars["String"]>;
+  deleteDimensionValue?: Maybe<Scalars["String"]>;
   deleteEpisode?: Maybe<Array<Maybe<ObjectDeleteResponse>>>;
   deleteGenre?: Maybe<Array<Maybe<ObjectDeleteResponse>>>;
   deleteImage?: Maybe<Array<Maybe<ObjectDeleteResponse>>>;
@@ -1075,516 +1022,458 @@ export type Mutation = {
   updateTheme?: Maybe<Theme>;
 };
 
-
 export type MutationCreateAssetArgs = {
   asset?: InputMaybe<AssetInput>;
-  language?: InputMaybe<Scalars['String']>;
+  language?: InputMaybe<Scalars["String"]>;
 };
-
 
 export type MutationCreateAvailabilityArgs = {
   availability: AvailabilityInput;
 };
 
-
 export type MutationCreateBrandArgs = {
   brand?: InputMaybe<BrandInput>;
-  language?: InputMaybe<Scalars['String']>;
+  language?: InputMaybe<Scalars["String"]>;
 };
-
 
 export type MutationCreateCreditArgs = {
   credit?: InputMaybe<CreditInput>;
-  language?: InputMaybe<Scalars['String']>;
+  language?: InputMaybe<Scalars["String"]>;
 };
-
 
 export type MutationCreateDimensionArgs = {
   dimension: DimensionInput;
 };
 
-
 export type MutationCreateDimensionValueArgs = {
-  dimension_id?: InputMaybe<Scalars['String']>;
+  dimension_id?: InputMaybe<Scalars["String"]>;
   dimension_value: DimensionInput;
-  external_id?: InputMaybe<Scalars['String']>;
+  external_id?: InputMaybe<Scalars["String"]>;
 };
-
 
 export type MutationCreateEpisodeArgs = {
   episode?: InputMaybe<EpisodeInput>;
-  language?: InputMaybe<Scalars['String']>;
+  language?: InputMaybe<Scalars["String"]>;
 };
-
 
 export type MutationCreateGenreArgs = {
   genre?: InputMaybe<GenreInput>;
-  language?: InputMaybe<Scalars['String']>;
+  language?: InputMaybe<Scalars["String"]>;
 };
-
 
 export type MutationCreateImageArgs = {
   image?: InputMaybe<ImageInput>;
-  language?: InputMaybe<Scalars['String']>;
+  language?: InputMaybe<Scalars["String"]>;
 };
 
-
 export type MutationCreateMovieArgs = {
-  language?: InputMaybe<Scalars['String']>;
+  language?: InputMaybe<Scalars["String"]>;
   movie?: InputMaybe<MovieInput>;
 };
 
-
 export type MutationCreateParentalGuidanceArgs = {
-  language?: InputMaybe<Scalars['String']>;
+  language?: InputMaybe<Scalars["String"]>;
   parental_guidance?: InputMaybe<ParentalGuidanceInput>;
 };
 
-
 export type MutationCreatePersonArgs = {
-  language?: InputMaybe<Scalars['String']>;
+  language?: InputMaybe<Scalars["String"]>;
   person?: InputMaybe<PersonInput>;
 };
 
-
 export type MutationCreateRatingArgs = {
-  language?: InputMaybe<Scalars['String']>;
+  language?: InputMaybe<Scalars["String"]>;
   rating?: InputMaybe<RatingInput>;
 };
 
-
 export type MutationCreateRoleArgs = {
-  language?: InputMaybe<Scalars['String']>;
+  language?: InputMaybe<Scalars["String"]>;
   role?: InputMaybe<RoleInput>;
 };
 
-
 export type MutationCreateSeasonArgs = {
-  language?: InputMaybe<Scalars['String']>;
+  language?: InputMaybe<Scalars["String"]>;
   season?: InputMaybe<SeasonInput>;
 };
 
-
 export type MutationCreateSetArgs = {
-  language?: InputMaybe<Scalars['String']>;
+  language?: InputMaybe<Scalars["String"]>;
   set?: InputMaybe<SetInput>;
 };
 
-
 export type MutationCreateTagArgs = {
-  language?: InputMaybe<Scalars['String']>;
+  language?: InputMaybe<Scalars["String"]>;
   tag?: InputMaybe<TagInput>;
 };
 
-
 export type MutationCreateThemeArgs = {
-  language?: InputMaybe<Scalars['String']>;
+  language?: InputMaybe<Scalars["String"]>;
   theme?: InputMaybe<ThemeInput>;
 };
 
-
 export type MutationDeleteAssetArgs = {
-  external_id?: InputMaybe<Scalars['String']>;
-  global_version?: InputMaybe<Scalars['Int']>;
-  language?: InputMaybe<Scalars['String']>;
-  language_version?: InputMaybe<Scalars['Int']>;
-  uid: Scalars['String'];
+  external_id?: InputMaybe<Scalars["String"]>;
+  global_version?: InputMaybe<Scalars["Int"]>;
+  language?: InputMaybe<Scalars["String"]>;
+  language_version?: InputMaybe<Scalars["Int"]>;
+  uid: Scalars["String"];
 };
-
 
 export type MutationDeleteAvailabilityArgs = {
-  external_id?: InputMaybe<Scalars['String']>;
-  uid?: InputMaybe<Scalars['String']>;
+  external_id?: InputMaybe<Scalars["String"]>;
+  uid?: InputMaybe<Scalars["String"]>;
 };
-
 
 export type MutationDeleteBrandArgs = {
-  external_id?: InputMaybe<Scalars['String']>;
-  global_version?: InputMaybe<Scalars['Int']>;
-  language?: InputMaybe<Scalars['String']>;
-  language_version?: InputMaybe<Scalars['Int']>;
-  uid: Scalars['String'];
+  external_id?: InputMaybe<Scalars["String"]>;
+  global_version?: InputMaybe<Scalars["Int"]>;
+  language?: InputMaybe<Scalars["String"]>;
+  language_version?: InputMaybe<Scalars["Int"]>;
+  uid: Scalars["String"];
 };
-
 
 export type MutationDeleteCreditArgs = {
-  external_id?: InputMaybe<Scalars['String']>;
-  global_version?: InputMaybe<Scalars['Int']>;
-  language?: InputMaybe<Scalars['String']>;
-  language_version?: InputMaybe<Scalars['Int']>;
-  uid: Scalars['String'];
+  external_id?: InputMaybe<Scalars["String"]>;
+  global_version?: InputMaybe<Scalars["Int"]>;
+  language?: InputMaybe<Scalars["String"]>;
+  language_version?: InputMaybe<Scalars["Int"]>;
+  uid: Scalars["String"];
 };
-
 
 export type MutationDeleteDimensionArgs = {
-  dimension_id?: InputMaybe<Scalars['String']>;
-  external_id?: InputMaybe<Scalars['String']>;
+  dimension_id?: InputMaybe<Scalars["String"]>;
+  external_id?: InputMaybe<Scalars["String"]>;
 };
-
 
 export type MutationDeleteDimensionValueArgs = {
-  dimension_id?: InputMaybe<Scalars['String']>;
-  external_id?: InputMaybe<Scalars['String']>;
-  value_external_id?: InputMaybe<Scalars['String']>;
-  value_id?: InputMaybe<Scalars['String']>;
+  dimension_id?: InputMaybe<Scalars["String"]>;
+  external_id?: InputMaybe<Scalars["String"]>;
+  value_external_id?: InputMaybe<Scalars["String"]>;
+  value_id?: InputMaybe<Scalars["String"]>;
 };
-
 
 export type MutationDeleteEpisodeArgs = {
-  external_id?: InputMaybe<Scalars['String']>;
-  global_version?: InputMaybe<Scalars['Int']>;
-  language?: InputMaybe<Scalars['String']>;
-  language_version?: InputMaybe<Scalars['Int']>;
-  uid: Scalars['String'];
+  external_id?: InputMaybe<Scalars["String"]>;
+  global_version?: InputMaybe<Scalars["Int"]>;
+  language?: InputMaybe<Scalars["String"]>;
+  language_version?: InputMaybe<Scalars["Int"]>;
+  uid: Scalars["String"];
 };
-
 
 export type MutationDeleteGenreArgs = {
-  external_id?: InputMaybe<Scalars['String']>;
-  global_version?: InputMaybe<Scalars['Int']>;
-  language?: InputMaybe<Scalars['String']>;
-  language_version?: InputMaybe<Scalars['Int']>;
-  uid: Scalars['String'];
+  external_id?: InputMaybe<Scalars["String"]>;
+  global_version?: InputMaybe<Scalars["Int"]>;
+  language?: InputMaybe<Scalars["String"]>;
+  language_version?: InputMaybe<Scalars["Int"]>;
+  uid: Scalars["String"];
 };
-
 
 export type MutationDeleteImageArgs = {
-  external_id?: InputMaybe<Scalars['String']>;
-  global_version?: InputMaybe<Scalars['Int']>;
-  language?: InputMaybe<Scalars['String']>;
-  language_version?: InputMaybe<Scalars['Int']>;
-  uid: Scalars['String'];
+  external_id?: InputMaybe<Scalars["String"]>;
+  global_version?: InputMaybe<Scalars["Int"]>;
+  language?: InputMaybe<Scalars["String"]>;
+  language_version?: InputMaybe<Scalars["Int"]>;
+  uid: Scalars["String"];
 };
-
 
 export type MutationDeleteMovieArgs = {
-  external_id?: InputMaybe<Scalars['String']>;
-  global_version?: InputMaybe<Scalars['Int']>;
-  language?: InputMaybe<Scalars['String']>;
-  language_version?: InputMaybe<Scalars['Int']>;
-  uid: Scalars['String'];
+  external_id?: InputMaybe<Scalars["String"]>;
+  global_version?: InputMaybe<Scalars["Int"]>;
+  language?: InputMaybe<Scalars["String"]>;
+  language_version?: InputMaybe<Scalars["Int"]>;
+  uid: Scalars["String"];
 };
-
 
 export type MutationDeleteParentalGuidanceArgs = {
-  external_id?: InputMaybe<Scalars['String']>;
-  global_version?: InputMaybe<Scalars['Int']>;
-  language?: InputMaybe<Scalars['String']>;
-  language_version?: InputMaybe<Scalars['Int']>;
-  uid: Scalars['String'];
+  external_id?: InputMaybe<Scalars["String"]>;
+  global_version?: InputMaybe<Scalars["Int"]>;
+  language?: InputMaybe<Scalars["String"]>;
+  language_version?: InputMaybe<Scalars["Int"]>;
+  uid: Scalars["String"];
 };
-
 
 export type MutationDeletePersonArgs = {
-  external_id?: InputMaybe<Scalars['String']>;
-  global_version?: InputMaybe<Scalars['Int']>;
-  language?: InputMaybe<Scalars['String']>;
-  language_version?: InputMaybe<Scalars['Int']>;
-  uid: Scalars['String'];
+  external_id?: InputMaybe<Scalars["String"]>;
+  global_version?: InputMaybe<Scalars["Int"]>;
+  language?: InputMaybe<Scalars["String"]>;
+  language_version?: InputMaybe<Scalars["Int"]>;
+  uid: Scalars["String"];
 };
-
 
 export type MutationDeleteRatingArgs = {
-  external_id?: InputMaybe<Scalars['String']>;
-  global_version?: InputMaybe<Scalars['Int']>;
-  language?: InputMaybe<Scalars['String']>;
-  language_version?: InputMaybe<Scalars['Int']>;
-  uid: Scalars['String'];
+  external_id?: InputMaybe<Scalars["String"]>;
+  global_version?: InputMaybe<Scalars["Int"]>;
+  language?: InputMaybe<Scalars["String"]>;
+  language_version?: InputMaybe<Scalars["Int"]>;
+  uid: Scalars["String"];
 };
-
 
 export type MutationDeleteRoleArgs = {
-  external_id?: InputMaybe<Scalars['String']>;
-  global_version?: InputMaybe<Scalars['Int']>;
-  language?: InputMaybe<Scalars['String']>;
-  language_version?: InputMaybe<Scalars['Int']>;
-  uid: Scalars['String'];
+  external_id?: InputMaybe<Scalars["String"]>;
+  global_version?: InputMaybe<Scalars["Int"]>;
+  language?: InputMaybe<Scalars["String"]>;
+  language_version?: InputMaybe<Scalars["Int"]>;
+  uid: Scalars["String"];
 };
-
 
 export type MutationDeleteSeasonArgs = {
-  external_id?: InputMaybe<Scalars['String']>;
-  global_version?: InputMaybe<Scalars['Int']>;
-  language?: InputMaybe<Scalars['String']>;
-  language_version?: InputMaybe<Scalars['Int']>;
-  uid: Scalars['String'];
+  external_id?: InputMaybe<Scalars["String"]>;
+  global_version?: InputMaybe<Scalars["Int"]>;
+  language?: InputMaybe<Scalars["String"]>;
+  language_version?: InputMaybe<Scalars["Int"]>;
+  uid: Scalars["String"];
 };
-
 
 export type MutationDeleteSetArgs = {
-  external_id?: InputMaybe<Scalars['String']>;
-  global_version?: InputMaybe<Scalars['Int']>;
-  language?: InputMaybe<Scalars['String']>;
-  language_version?: InputMaybe<Scalars['Int']>;
-  uid?: InputMaybe<Scalars['String']>;
+  external_id?: InputMaybe<Scalars["String"]>;
+  global_version?: InputMaybe<Scalars["Int"]>;
+  language?: InputMaybe<Scalars["String"]>;
+  language_version?: InputMaybe<Scalars["Int"]>;
+  uid?: InputMaybe<Scalars["String"]>;
 };
-
 
 export type MutationDeleteTagArgs = {
-  external_id?: InputMaybe<Scalars['String']>;
-  global_version?: InputMaybe<Scalars['Int']>;
-  language?: InputMaybe<Scalars['String']>;
-  language_version?: InputMaybe<Scalars['Int']>;
-  uid: Scalars['String'];
+  external_id?: InputMaybe<Scalars["String"]>;
+  global_version?: InputMaybe<Scalars["Int"]>;
+  language?: InputMaybe<Scalars["String"]>;
+  language_version?: InputMaybe<Scalars["Int"]>;
+  uid: Scalars["String"];
 };
-
 
 export type MutationDeleteThemeArgs = {
-  external_id?: InputMaybe<Scalars['String']>;
-  global_version?: InputMaybe<Scalars['Int']>;
-  language?: InputMaybe<Scalars['String']>;
-  language_version?: InputMaybe<Scalars['Int']>;
-  uid: Scalars['String'];
+  external_id?: InputMaybe<Scalars["String"]>;
+  global_version?: InputMaybe<Scalars["Int"]>;
+  language?: InputMaybe<Scalars["String"]>;
+  language_version?: InputMaybe<Scalars["Int"]>;
+  uid: Scalars["String"];
 };
-
 
 export type MutationUpdateAssetArgs = {
   asset?: InputMaybe<AssetInput>;
-  external_id?: InputMaybe<Scalars['String']>;
-  global_version?: InputMaybe<Scalars['Int']>;
-  language?: InputMaybe<Scalars['String']>;
-  language_version?: InputMaybe<Scalars['Int']>;
-  uid?: InputMaybe<Scalars['String']>;
+  external_id?: InputMaybe<Scalars["String"]>;
+  global_version?: InputMaybe<Scalars["Int"]>;
+  language?: InputMaybe<Scalars["String"]>;
+  language_version?: InputMaybe<Scalars["Int"]>;
+  uid?: InputMaybe<Scalars["String"]>;
 };
-
 
 export type MutationUpdateAvailabilityArgs = {
   availability: AvailabilityInput;
-  external_id?: InputMaybe<Scalars['String']>;
-  uid?: InputMaybe<Scalars['String']>;
+  external_id?: InputMaybe<Scalars["String"]>;
+  uid?: InputMaybe<Scalars["String"]>;
 };
-
 
 export type MutationUpdateBrandArgs = {
   brand?: InputMaybe<BrandInput>;
-  external_id?: InputMaybe<Scalars['String']>;
-  global_version?: InputMaybe<Scalars['Int']>;
-  language?: InputMaybe<Scalars['String']>;
-  language_version?: InputMaybe<Scalars['Int']>;
-  uid?: InputMaybe<Scalars['String']>;
+  external_id?: InputMaybe<Scalars["String"]>;
+  global_version?: InputMaybe<Scalars["Int"]>;
+  language?: InputMaybe<Scalars["String"]>;
+  language_version?: InputMaybe<Scalars["Int"]>;
+  uid?: InputMaybe<Scalars["String"]>;
 };
-
 
 export type MutationUpdateCreditArgs = {
   credit?: InputMaybe<CreditInput>;
-  external_id?: InputMaybe<Scalars['String']>;
-  global_version?: InputMaybe<Scalars['Int']>;
-  language?: InputMaybe<Scalars['String']>;
-  language_version?: InputMaybe<Scalars['Int']>;
-  uid?: InputMaybe<Scalars['String']>;
+  external_id?: InputMaybe<Scalars["String"]>;
+  global_version?: InputMaybe<Scalars["Int"]>;
+  language?: InputMaybe<Scalars["String"]>;
+  language_version?: InputMaybe<Scalars["Int"]>;
+  uid?: InputMaybe<Scalars["String"]>;
 };
-
 
 export type MutationUpdateDimensionArgs = {
   dimension: DimensionInput;
-  dimension_id?: InputMaybe<Scalars['String']>;
-  external_id?: InputMaybe<Scalars['String']>;
+  dimension_id?: InputMaybe<Scalars["String"]>;
+  external_id?: InputMaybe<Scalars["String"]>;
 };
-
 
 export type MutationUpdateDimensionValueArgs = {
-  dimension_id?: InputMaybe<Scalars['String']>;
+  dimension_id?: InputMaybe<Scalars["String"]>;
   dimension_value: DimensionInput;
-  external_id?: InputMaybe<Scalars['String']>;
-  value_external_id?: InputMaybe<Scalars['String']>;
-  value_id?: InputMaybe<Scalars['String']>;
+  external_id?: InputMaybe<Scalars["String"]>;
+  value_external_id?: InputMaybe<Scalars["String"]>;
+  value_id?: InputMaybe<Scalars["String"]>;
 };
-
 
 export type MutationUpdateEpisodeArgs = {
   episode?: InputMaybe<EpisodeInput>;
-  external_id?: InputMaybe<Scalars['String']>;
-  global_version?: InputMaybe<Scalars['Int']>;
-  language?: InputMaybe<Scalars['String']>;
-  language_version?: InputMaybe<Scalars['Int']>;
-  uid?: InputMaybe<Scalars['String']>;
+  external_id?: InputMaybe<Scalars["String"]>;
+  global_version?: InputMaybe<Scalars["Int"]>;
+  language?: InputMaybe<Scalars["String"]>;
+  language_version?: InputMaybe<Scalars["Int"]>;
+  uid?: InputMaybe<Scalars["String"]>;
 };
-
 
 export type MutationUpdateGenreArgs = {
-  external_id?: InputMaybe<Scalars['String']>;
+  external_id?: InputMaybe<Scalars["String"]>;
   genre?: InputMaybe<GenreInput>;
-  global_version?: InputMaybe<Scalars['Int']>;
-  language?: InputMaybe<Scalars['String']>;
-  language_version?: InputMaybe<Scalars['Int']>;
-  uid?: InputMaybe<Scalars['String']>;
+  global_version?: InputMaybe<Scalars["Int"]>;
+  language?: InputMaybe<Scalars["String"]>;
+  language_version?: InputMaybe<Scalars["Int"]>;
+  uid?: InputMaybe<Scalars["String"]>;
 };
-
 
 export type MutationUpdateImageArgs = {
-  external_id?: InputMaybe<Scalars['String']>;
-  global_version?: InputMaybe<Scalars['Int']>;
+  external_id?: InputMaybe<Scalars["String"]>;
+  global_version?: InputMaybe<Scalars["Int"]>;
   image?: InputMaybe<ImageInput>;
-  language?: InputMaybe<Scalars['String']>;
-  language_version?: InputMaybe<Scalars['Int']>;
-  uid?: InputMaybe<Scalars['String']>;
+  language?: InputMaybe<Scalars["String"]>;
+  language_version?: InputMaybe<Scalars["Int"]>;
+  uid?: InputMaybe<Scalars["String"]>;
 };
-
 
 export type MutationUpdateMovieArgs = {
-  external_id?: InputMaybe<Scalars['String']>;
-  global_version?: InputMaybe<Scalars['Int']>;
-  language?: InputMaybe<Scalars['String']>;
-  language_version?: InputMaybe<Scalars['Int']>;
+  external_id?: InputMaybe<Scalars["String"]>;
+  global_version?: InputMaybe<Scalars["Int"]>;
+  language?: InputMaybe<Scalars["String"]>;
+  language_version?: InputMaybe<Scalars["Int"]>;
   movie?: InputMaybe<MovieInput>;
-  uid?: InputMaybe<Scalars['String']>;
+  uid?: InputMaybe<Scalars["String"]>;
 };
-
 
 export type MutationUpdateParentalGuidanceArgs = {
-  external_id?: InputMaybe<Scalars['String']>;
-  global_version?: InputMaybe<Scalars['Int']>;
-  language?: InputMaybe<Scalars['String']>;
-  language_version?: InputMaybe<Scalars['Int']>;
+  external_id?: InputMaybe<Scalars["String"]>;
+  global_version?: InputMaybe<Scalars["Int"]>;
+  language?: InputMaybe<Scalars["String"]>;
+  language_version?: InputMaybe<Scalars["Int"]>;
   parental_guidance?: InputMaybe<ParentalGuidanceInput>;
-  uid?: InputMaybe<Scalars['String']>;
+  uid?: InputMaybe<Scalars["String"]>;
 };
-
 
 export type MutationUpdatePersonArgs = {
-  external_id?: InputMaybe<Scalars['String']>;
-  global_version?: InputMaybe<Scalars['Int']>;
-  language?: InputMaybe<Scalars['String']>;
-  language_version?: InputMaybe<Scalars['Int']>;
+  external_id?: InputMaybe<Scalars["String"]>;
+  global_version?: InputMaybe<Scalars["Int"]>;
+  language?: InputMaybe<Scalars["String"]>;
+  language_version?: InputMaybe<Scalars["Int"]>;
   person?: InputMaybe<PersonInput>;
-  uid?: InputMaybe<Scalars['String']>;
+  uid?: InputMaybe<Scalars["String"]>;
 };
-
 
 export type MutationUpdateRatingArgs = {
-  external_id?: InputMaybe<Scalars['String']>;
-  global_version?: InputMaybe<Scalars['Int']>;
-  language?: InputMaybe<Scalars['String']>;
-  language_version?: InputMaybe<Scalars['Int']>;
+  external_id?: InputMaybe<Scalars["String"]>;
+  global_version?: InputMaybe<Scalars["Int"]>;
+  language?: InputMaybe<Scalars["String"]>;
+  language_version?: InputMaybe<Scalars["Int"]>;
   rating?: InputMaybe<RatingInput>;
-  uid?: InputMaybe<Scalars['String']>;
+  uid?: InputMaybe<Scalars["String"]>;
 };
-
 
 export type MutationUpdateRoleArgs = {
-  external_id?: InputMaybe<Scalars['String']>;
-  global_version?: InputMaybe<Scalars['Int']>;
-  language?: InputMaybe<Scalars['String']>;
-  language_version?: InputMaybe<Scalars['Int']>;
+  external_id?: InputMaybe<Scalars["String"]>;
+  global_version?: InputMaybe<Scalars["Int"]>;
+  language?: InputMaybe<Scalars["String"]>;
+  language_version?: InputMaybe<Scalars["Int"]>;
   role?: InputMaybe<RoleInput>;
-  uid?: InputMaybe<Scalars['String']>;
+  uid?: InputMaybe<Scalars["String"]>;
 };
-
 
 export type MutationUpdateSeasonArgs = {
-  external_id?: InputMaybe<Scalars['String']>;
-  global_version?: InputMaybe<Scalars['Int']>;
-  language?: InputMaybe<Scalars['String']>;
-  language_version?: InputMaybe<Scalars['Int']>;
+  external_id?: InputMaybe<Scalars["String"]>;
+  global_version?: InputMaybe<Scalars["Int"]>;
+  language?: InputMaybe<Scalars["String"]>;
+  language_version?: InputMaybe<Scalars["Int"]>;
   season?: InputMaybe<SeasonInput>;
-  uid?: InputMaybe<Scalars['String']>;
+  uid?: InputMaybe<Scalars["String"]>;
 };
-
 
 export type MutationUpdateSetArgs = {
-  external_id?: InputMaybe<Scalars['String']>;
-  global_version?: InputMaybe<Scalars['Int']>;
-  language?: InputMaybe<Scalars['String']>;
-  language_version?: InputMaybe<Scalars['Int']>;
+  external_id?: InputMaybe<Scalars["String"]>;
+  global_version?: InputMaybe<Scalars["Int"]>;
+  language?: InputMaybe<Scalars["String"]>;
+  language_version?: InputMaybe<Scalars["Int"]>;
   set?: InputMaybe<SetInput>;
-  uid?: InputMaybe<Scalars['String']>;
+  uid?: InputMaybe<Scalars["String"]>;
 };
-
 
 export type MutationUpdateTagArgs = {
-  external_id?: InputMaybe<Scalars['String']>;
-  global_version?: InputMaybe<Scalars['Int']>;
-  language?: InputMaybe<Scalars['String']>;
-  language_version?: InputMaybe<Scalars['Int']>;
+  external_id?: InputMaybe<Scalars["String"]>;
+  global_version?: InputMaybe<Scalars["Int"]>;
+  language?: InputMaybe<Scalars["String"]>;
+  language_version?: InputMaybe<Scalars["Int"]>;
   tag?: InputMaybe<TagInput>;
-  uid?: InputMaybe<Scalars['String']>;
+  uid?: InputMaybe<Scalars["String"]>;
 };
 
-
 export type MutationUpdateThemeArgs = {
-  external_id?: InputMaybe<Scalars['String']>;
-  global_version?: InputMaybe<Scalars['Int']>;
-  language?: InputMaybe<Scalars['String']>;
-  language_version?: InputMaybe<Scalars['Int']>;
+  external_id?: InputMaybe<Scalars["String"]>;
+  global_version?: InputMaybe<Scalars["Int"]>;
+  language?: InputMaybe<Scalars["String"]>;
+  language_version?: InputMaybe<Scalars["Int"]>;
   theme?: InputMaybe<ThemeInput>;
-  uid?: InputMaybe<Scalars['String']>;
+  uid?: InputMaybe<Scalars["String"]>;
 };
 
 export type ObjectDeleteResponse = {
-  __typename?: 'ObjectDeleteResponse';
-  global_version?: Maybe<Scalars['String']>;
-  language?: Maybe<Scalars['String']>;
-  language_version?: Maybe<Scalars['String']>;
-  message?: Maybe<Scalars['String']>;
-  removed_relationships?: Maybe<Array<Maybe<Scalars['String']>>>;
-  uid: Scalars['String'];
+  __typename?: "ObjectDeleteResponse";
+  global_version?: Maybe<Scalars["String"]>;
+  language?: Maybe<Scalars["String"]>;
+  language_version?: Maybe<Scalars["String"]>;
+  message?: Maybe<Scalars["String"]>;
+  removed_relationships?: Maybe<Array<Maybe<Scalars["String"]>>>;
+  uid: Scalars["String"];
 };
 
 export enum OrderDirections {
-  Asc = 'ASC',
-  Desc = 'DESC'
+  Asc = "ASC",
+  Desc = "DESC",
 }
 
 export type ParentalGuidance = Metadata & {
-  __typename?: 'ParentalGuidance';
+  __typename?: "ParentalGuidance";
   _meta?: Maybe<_ParentalGuidanceMeta>;
   assets?: Maybe<AssetListing>;
   availability?: Maybe<AvailabilityListing>;
-  external_id?: Maybe<Scalars['String']>;
+  external_id?: Maybe<Scalars["String"]>;
   ratings?: Maybe<RatingListing>;
-  reason?: Maybe<Scalars['String']>;
-  slug?: Maybe<Scalars['String']>;
-  uid: Scalars['String'];
+  reason?: Maybe<Scalars["String"]>;
+  slug?: Maybe<Scalars["String"]>;
+  uid: Scalars["String"];
 };
-
 
 export type ParentalGuidance_MetaArgs = {
-  global_version?: InputMaybe<Scalars['Int']>;
-  language?: InputMaybe<Scalars['String']>;
-  language_version?: InputMaybe<Scalars['Int']>;
+  global_version?: InputMaybe<Scalars["Int"]>;
+  language?: InputMaybe<Scalars["String"]>;
+  language_version?: InputMaybe<Scalars["Int"]>;
 };
-
 
 export type ParentalGuidanceAssetsArgs = {
-  language?: InputMaybe<Scalars['String']>;
-  limit?: InputMaybe<Scalars['Int']>;
-  next_token?: InputMaybe<Scalars['String']>;
+  language?: InputMaybe<Scalars["String"]>;
+  limit?: InputMaybe<Scalars["Int"]>;
+  next_token?: InputMaybe<Scalars["String"]>;
 };
-
 
 export type ParentalGuidanceAvailabilityArgs = {
-  limit?: InputMaybe<Scalars['Int']>;
-  next_token?: InputMaybe<Scalars['String']>;
+  limit?: InputMaybe<Scalars["Int"]>;
+  next_token?: InputMaybe<Scalars["String"]>;
 };
 
-
 export type ParentalGuidanceRatingsArgs = {
-  language?: InputMaybe<Scalars['String']>;
-  limit?: InputMaybe<Scalars['Int']>;
-  next_token?: InputMaybe<Scalars['String']>;
+  language?: InputMaybe<Scalars["String"]>;
+  limit?: InputMaybe<Scalars["Int"]>;
+  next_token?: InputMaybe<Scalars["String"]>;
 };
 
 export type ParentalGuidanceInput = {
   availability?: InputMaybe<AssignAvailabilityInput>;
-  data_source_fields?: InputMaybe<Array<InputMaybe<Scalars['String']>>>;
-  data_source_id?: InputMaybe<Scalars['String']>;
-  external_id?: InputMaybe<Scalars['String']>;
-  reason?: InputMaybe<Scalars['String']>;
+  data_source_fields?: InputMaybe<Array<InputMaybe<Scalars["String"]>>>;
+  data_source_id?: InputMaybe<Scalars["String"]>;
+  external_id?: InputMaybe<Scalars["String"]>;
+  reason?: InputMaybe<Scalars["String"]>;
   relationships?: InputMaybe<ParentalGuidanceRelationships>;
-  slug?: InputMaybe<Scalars['String']>;
+  slug?: InputMaybe<Scalars["String"]>;
 };
 
 export type ParentalGuidanceListing = Listing & {
-  __typename?: 'ParentalGuidanceListing';
-  count?: Maybe<Scalars['Int']>;
-  next_token?: Maybe<Scalars['String']>;
+  __typename?: "ParentalGuidanceListing";
+  count?: Maybe<Scalars["Int"]>;
+  next_token?: Maybe<Scalars["String"]>;
   objects?: Maybe<Array<Maybe<ParentalGuidance>>>;
 };
 
 export type ParentalGuidanceRelationshipInput = {
   create?: InputMaybe<Array<InputMaybe<ParentalGuidanceInput>>>;
-  link?: InputMaybe<Array<InputMaybe<Scalars['String']>>>;
-  unlink?: InputMaybe<Array<InputMaybe<Scalars['String']>>>;
+  link?: InputMaybe<Array<InputMaybe<Scalars["String"]>>>;
+  unlink?: InputMaybe<Array<InputMaybe<Scalars["String"]>>>;
 };
 
 export type ParentalGuidanceRelationships = {
@@ -1592,90 +1481,85 @@ export type ParentalGuidanceRelationships = {
 };
 
 export type Person = CurationMetadata & {
-  __typename?: 'Person';
+  __typename?: "Person";
   _meta?: Maybe<_PersonMeta>;
-  abbreviation?: Maybe<Scalars['String']>;
-  alias?: Maybe<Scalars['String']>;
+  abbreviation?: Maybe<Scalars["String"]>;
+  alias?: Maybe<Scalars["String"]>;
   availability?: Maybe<AvailabilityListing>;
-  bio_long?: Maybe<Scalars['String']>;
-  bio_medium?: Maybe<Scalars['String']>;
-  bio_short?: Maybe<Scalars['String']>;
+  bio_long?: Maybe<Scalars["String"]>;
+  bio_medium?: Maybe<Scalars["String"]>;
+  bio_short?: Maybe<Scalars["String"]>;
   credits?: Maybe<CreditListing>;
-  date_of_birth?: Maybe<Scalars['AWSDateTime']>;
-  external_id?: Maybe<Scalars['String']>;
-  gender?: Maybe<Scalars['String']>;
+  date_of_birth?: Maybe<Scalars["AWSDateTime"]>;
+  external_id?: Maybe<Scalars["String"]>;
+  gender?: Maybe<Scalars["String"]>;
   images?: Maybe<ImageListing>;
-  name?: Maybe<Scalars['String']>;
-  name_sort?: Maybe<Scalars['String']>;
-  place_of_birth?: Maybe<Scalars['String']>;
+  name?: Maybe<Scalars["String"]>;
+  name_sort?: Maybe<Scalars["String"]>;
+  place_of_birth?: Maybe<Scalars["String"]>;
   sets?: Maybe<SetListing>;
-  slug?: Maybe<Scalars['String']>;
-  uid: Scalars['String'];
+  slug?: Maybe<Scalars["String"]>;
+  uid: Scalars["String"];
 };
-
 
 export type Person_MetaArgs = {
-  global_version?: InputMaybe<Scalars['Int']>;
-  language?: InputMaybe<Scalars['String']>;
-  language_version?: InputMaybe<Scalars['Int']>;
+  global_version?: InputMaybe<Scalars["Int"]>;
+  language?: InputMaybe<Scalars["String"]>;
+  language_version?: InputMaybe<Scalars["Int"]>;
 };
-
 
 export type PersonAvailabilityArgs = {
-  limit?: InputMaybe<Scalars['Int']>;
-  next_token?: InputMaybe<Scalars['String']>;
+  limit?: InputMaybe<Scalars["Int"]>;
+  next_token?: InputMaybe<Scalars["String"]>;
 };
-
 
 export type PersonCreditsArgs = {
-  language?: InputMaybe<Scalars['String']>;
-  limit?: InputMaybe<Scalars['Int']>;
-  next_token?: InputMaybe<Scalars['String']>;
+  language?: InputMaybe<Scalars["String"]>;
+  limit?: InputMaybe<Scalars["Int"]>;
+  next_token?: InputMaybe<Scalars["String"]>;
 };
-
 
 export type PersonImagesArgs = {
-  language?: InputMaybe<Scalars['String']>;
-  limit?: InputMaybe<Scalars['Int']>;
-  next_token?: InputMaybe<Scalars['String']>;
+  language?: InputMaybe<Scalars["String"]>;
+  limit?: InputMaybe<Scalars["Int"]>;
+  next_token?: InputMaybe<Scalars["String"]>;
 };
 
-
 export type PersonSetsArgs = {
-  limit?: InputMaybe<Scalars['Int']>;
-  next_token?: InputMaybe<Scalars['String']>;
+  limit?: InputMaybe<Scalars["Int"]>;
+  next_token?: InputMaybe<Scalars["String"]>;
 };
 
 export type PersonInput = {
-  abbreviation?: InputMaybe<Scalars['String']>;
-  alias?: InputMaybe<Scalars['String']>;
+  abbreviation?: InputMaybe<Scalars["String"]>;
+  alias?: InputMaybe<Scalars["String"]>;
   availability?: InputMaybe<AssignAvailabilityInput>;
-  bio_long?: InputMaybe<Scalars['String']>;
-  bio_medium?: InputMaybe<Scalars['String']>;
-  bio_short?: InputMaybe<Scalars['String']>;
-  data_source_fields?: InputMaybe<Array<InputMaybe<Scalars['String']>>>;
-  data_source_id?: InputMaybe<Scalars['String']>;
-  date_of_birth?: InputMaybe<Scalars['AWSDateTime']>;
-  external_id?: InputMaybe<Scalars['String']>;
-  gender?: InputMaybe<Scalars['String']>;
-  name?: InputMaybe<Scalars['String']>;
-  name_sort?: InputMaybe<Scalars['String']>;
-  place_of_birth?: InputMaybe<Scalars['String']>;
+  bio_long?: InputMaybe<Scalars["String"]>;
+  bio_medium?: InputMaybe<Scalars["String"]>;
+  bio_short?: InputMaybe<Scalars["String"]>;
+  data_source_fields?: InputMaybe<Array<InputMaybe<Scalars["String"]>>>;
+  data_source_id?: InputMaybe<Scalars["String"]>;
+  date_of_birth?: InputMaybe<Scalars["AWSDateTime"]>;
+  external_id?: InputMaybe<Scalars["String"]>;
+  gender?: InputMaybe<Scalars["String"]>;
+  name?: InputMaybe<Scalars["String"]>;
+  name_sort?: InputMaybe<Scalars["String"]>;
+  place_of_birth?: InputMaybe<Scalars["String"]>;
   relationships?: InputMaybe<PersonRelationships>;
-  slug?: InputMaybe<Scalars['String']>;
+  slug?: InputMaybe<Scalars["String"]>;
 };
 
 export type PersonListing = Listing & {
-  __typename?: 'PersonListing';
-  count?: Maybe<Scalars['Int']>;
-  next_token?: Maybe<Scalars['String']>;
+  __typename?: "PersonListing";
+  count?: Maybe<Scalars["Int"]>;
+  next_token?: Maybe<Scalars["String"]>;
   objects?: Maybe<Array<Maybe<Person>>>;
 };
 
 export type PersonRelationshipInput = {
   create?: InputMaybe<Array<InputMaybe<PersonInput>>>;
-  link?: InputMaybe<Array<InputMaybe<Scalars['String']>>>;
-  unlink?: InputMaybe<Array<InputMaybe<Scalars['String']>>>;
+  link?: InputMaybe<Array<InputMaybe<Scalars["String"]>>>;
+  unlink?: InputMaybe<Array<InputMaybe<Scalars["String"]>>>;
 };
 
 export type PersonRelationships = {
@@ -1685,24 +1569,24 @@ export type PersonRelationships = {
 
 export type PersonSetCreate = {
   object?: InputMaybe<PersonInput>;
-  position: Scalars['Int'];
+  position: Scalars["Int"];
 };
 
 export type PersonSetInput = {
   create?: InputMaybe<Array<InputMaybe<PersonSetCreate>>>;
   link?: InputMaybe<Array<InputMaybe<SetLink>>>;
   reposition?: InputMaybe<Array<InputMaybe<SetLink>>>;
-  unlink?: InputMaybe<Array<InputMaybe<Scalars['String']>>>;
+  unlink?: InputMaybe<Array<InputMaybe<Scalars["String"]>>>;
 };
 
 export enum PublishStage {
-  Archive = 'ARCHIVE',
-  Preview = 'PREVIEW',
-  Prod = 'PROD'
+  Archive = "ARCHIVE",
+  Preview = "PREVIEW",
+  Prod = "PROD",
 }
 
 export type Query = {
-  __typename?: 'Query';
+  __typename?: "Query";
   getAsset?: Maybe<Asset>;
   getAvailability?: Maybe<Availability>;
   getBrand?: Maybe<Brand>;
@@ -1739,589 +1623,538 @@ export type Query = {
   listTheme?: Maybe<ThemeListing>;
 };
 
-
 export type QueryGetAssetArgs = {
   dimensions?: InputMaybe<Array<InputMaybe<UserDimension>>>;
-  external_id?: InputMaybe<Scalars['String']>;
-  ignore_availability?: InputMaybe<Scalars['Boolean']>;
-  language?: InputMaybe<Scalars['String']>;
-  time_travel?: InputMaybe<Scalars['AWSDateTime']>;
-  uid?: InputMaybe<Scalars['String']>;
+  external_id?: InputMaybe<Scalars["String"]>;
+  ignore_availability?: InputMaybe<Scalars["Boolean"]>;
+  language?: InputMaybe<Scalars["String"]>;
+  time_travel?: InputMaybe<Scalars["AWSDateTime"]>;
+  uid?: InputMaybe<Scalars["String"]>;
 };
-
 
 export type QueryGetAvailabilityArgs = {
-  external_id?: InputMaybe<Scalars['String']>;
-  uid?: InputMaybe<Scalars['String']>;
+  external_id?: InputMaybe<Scalars["String"]>;
+  uid?: InputMaybe<Scalars["String"]>;
 };
-
 
 export type QueryGetBrandArgs = {
   dimensions?: InputMaybe<Array<InputMaybe<UserDimension>>>;
-  external_id?: InputMaybe<Scalars['String']>;
-  ignore_availability?: InputMaybe<Scalars['Boolean']>;
-  language?: InputMaybe<Scalars['String']>;
-  time_travel?: InputMaybe<Scalars['AWSDateTime']>;
-  uid?: InputMaybe<Scalars['String']>;
+  external_id?: InputMaybe<Scalars["String"]>;
+  ignore_availability?: InputMaybe<Scalars["Boolean"]>;
+  language?: InputMaybe<Scalars["String"]>;
+  time_travel?: InputMaybe<Scalars["AWSDateTime"]>;
+  uid?: InputMaybe<Scalars["String"]>;
 };
-
 
 export type QueryGetCreditArgs = {
   dimensions?: InputMaybe<Array<InputMaybe<UserDimension>>>;
-  external_id?: InputMaybe<Scalars['String']>;
-  ignore_availability?: InputMaybe<Scalars['Boolean']>;
-  language?: InputMaybe<Scalars['String']>;
-  time_travel?: InputMaybe<Scalars['AWSDateTime']>;
-  uid?: InputMaybe<Scalars['String']>;
+  external_id?: InputMaybe<Scalars["String"]>;
+  ignore_availability?: InputMaybe<Scalars["Boolean"]>;
+  language?: InputMaybe<Scalars["String"]>;
+  time_travel?: InputMaybe<Scalars["AWSDateTime"]>;
+  uid?: InputMaybe<Scalars["String"]>;
 };
-
 
 export type QueryGetDimensionArgs = {
-  dimension_id?: InputMaybe<Scalars['String']>;
-  external_id?: InputMaybe<Scalars['String']>;
+  dimension_id?: InputMaybe<Scalars["String"]>;
+  external_id?: InputMaybe<Scalars["String"]>;
 };
-
 
 export type QueryGetEpisodeArgs = {
   dimensions?: InputMaybe<Array<InputMaybe<UserDimension>>>;
-  external_id?: InputMaybe<Scalars['String']>;
-  ignore_availability?: InputMaybe<Scalars['Boolean']>;
-  language?: InputMaybe<Scalars['String']>;
-  time_travel?: InputMaybe<Scalars['AWSDateTime']>;
-  uid?: InputMaybe<Scalars['String']>;
+  external_id?: InputMaybe<Scalars["String"]>;
+  ignore_availability?: InputMaybe<Scalars["Boolean"]>;
+  language?: InputMaybe<Scalars["String"]>;
+  time_travel?: InputMaybe<Scalars["AWSDateTime"]>;
+  uid?: InputMaybe<Scalars["String"]>;
 };
-
 
 export type QueryGetGenreArgs = {
   dimensions?: InputMaybe<Array<InputMaybe<UserDimension>>>;
-  external_id?: InputMaybe<Scalars['String']>;
-  ignore_availability?: InputMaybe<Scalars['Boolean']>;
-  language?: InputMaybe<Scalars['String']>;
-  time_travel?: InputMaybe<Scalars['AWSDateTime']>;
-  uid?: InputMaybe<Scalars['String']>;
+  external_id?: InputMaybe<Scalars["String"]>;
+  ignore_availability?: InputMaybe<Scalars["Boolean"]>;
+  language?: InputMaybe<Scalars["String"]>;
+  time_travel?: InputMaybe<Scalars["AWSDateTime"]>;
+  uid?: InputMaybe<Scalars["String"]>;
 };
-
 
 export type QueryGetImageArgs = {
   dimensions?: InputMaybe<Array<InputMaybe<UserDimension>>>;
-  external_id?: InputMaybe<Scalars['String']>;
-  ignore_availability?: InputMaybe<Scalars['Boolean']>;
-  language?: InputMaybe<Scalars['String']>;
-  time_travel?: InputMaybe<Scalars['AWSDateTime']>;
-  uid?: InputMaybe<Scalars['String']>;
+  external_id?: InputMaybe<Scalars["String"]>;
+  ignore_availability?: InputMaybe<Scalars["Boolean"]>;
+  language?: InputMaybe<Scalars["String"]>;
+  time_travel?: InputMaybe<Scalars["AWSDateTime"]>;
+  uid?: InputMaybe<Scalars["String"]>;
 };
-
 
 export type QueryGetMovieArgs = {
   dimensions?: InputMaybe<Array<InputMaybe<UserDimension>>>;
-  external_id?: InputMaybe<Scalars['String']>;
-  ignore_availability?: InputMaybe<Scalars['Boolean']>;
-  language?: InputMaybe<Scalars['String']>;
-  time_travel?: InputMaybe<Scalars['AWSDateTime']>;
-  uid?: InputMaybe<Scalars['String']>;
+  external_id?: InputMaybe<Scalars["String"]>;
+  ignore_availability?: InputMaybe<Scalars["Boolean"]>;
+  language?: InputMaybe<Scalars["String"]>;
+  time_travel?: InputMaybe<Scalars["AWSDateTime"]>;
+  uid?: InputMaybe<Scalars["String"]>;
 };
-
 
 export type QueryGetParentalGuidanceArgs = {
   dimensions?: InputMaybe<Array<InputMaybe<UserDimension>>>;
-  external_id?: InputMaybe<Scalars['String']>;
-  ignore_availability?: InputMaybe<Scalars['Boolean']>;
-  language?: InputMaybe<Scalars['String']>;
-  time_travel?: InputMaybe<Scalars['AWSDateTime']>;
-  uid?: InputMaybe<Scalars['String']>;
+  external_id?: InputMaybe<Scalars["String"]>;
+  ignore_availability?: InputMaybe<Scalars["Boolean"]>;
+  language?: InputMaybe<Scalars["String"]>;
+  time_travel?: InputMaybe<Scalars["AWSDateTime"]>;
+  uid?: InputMaybe<Scalars["String"]>;
 };
-
 
 export type QueryGetPersonArgs = {
   dimensions?: InputMaybe<Array<InputMaybe<UserDimension>>>;
-  external_id?: InputMaybe<Scalars['String']>;
-  ignore_availability?: InputMaybe<Scalars['Boolean']>;
-  language?: InputMaybe<Scalars['String']>;
-  time_travel?: InputMaybe<Scalars['AWSDateTime']>;
-  uid?: InputMaybe<Scalars['String']>;
+  external_id?: InputMaybe<Scalars["String"]>;
+  ignore_availability?: InputMaybe<Scalars["Boolean"]>;
+  language?: InputMaybe<Scalars["String"]>;
+  time_travel?: InputMaybe<Scalars["AWSDateTime"]>;
+  uid?: InputMaybe<Scalars["String"]>;
 };
-
 
 export type QueryGetRatingArgs = {
   dimensions?: InputMaybe<Array<InputMaybe<UserDimension>>>;
-  external_id?: InputMaybe<Scalars['String']>;
-  ignore_availability?: InputMaybe<Scalars['Boolean']>;
-  language?: InputMaybe<Scalars['String']>;
-  time_travel?: InputMaybe<Scalars['AWSDateTime']>;
-  uid?: InputMaybe<Scalars['String']>;
+  external_id?: InputMaybe<Scalars["String"]>;
+  ignore_availability?: InputMaybe<Scalars["Boolean"]>;
+  language?: InputMaybe<Scalars["String"]>;
+  time_travel?: InputMaybe<Scalars["AWSDateTime"]>;
+  uid?: InputMaybe<Scalars["String"]>;
 };
-
 
 export type QueryGetRoleArgs = {
   dimensions?: InputMaybe<Array<InputMaybe<UserDimension>>>;
-  external_id?: InputMaybe<Scalars['String']>;
-  ignore_availability?: InputMaybe<Scalars['Boolean']>;
-  language?: InputMaybe<Scalars['String']>;
-  time_travel?: InputMaybe<Scalars['AWSDateTime']>;
-  uid?: InputMaybe<Scalars['String']>;
+  external_id?: InputMaybe<Scalars["String"]>;
+  ignore_availability?: InputMaybe<Scalars["Boolean"]>;
+  language?: InputMaybe<Scalars["String"]>;
+  time_travel?: InputMaybe<Scalars["AWSDateTime"]>;
+  uid?: InputMaybe<Scalars["String"]>;
 };
-
 
 export type QueryGetSeasonArgs = {
   dimensions?: InputMaybe<Array<InputMaybe<UserDimension>>>;
-  external_id?: InputMaybe<Scalars['String']>;
-  ignore_availability?: InputMaybe<Scalars['Boolean']>;
-  language?: InputMaybe<Scalars['String']>;
-  time_travel?: InputMaybe<Scalars['AWSDateTime']>;
-  uid?: InputMaybe<Scalars['String']>;
+  external_id?: InputMaybe<Scalars["String"]>;
+  ignore_availability?: InputMaybe<Scalars["Boolean"]>;
+  language?: InputMaybe<Scalars["String"]>;
+  time_travel?: InputMaybe<Scalars["AWSDateTime"]>;
+  uid?: InputMaybe<Scalars["String"]>;
 };
-
 
 export type QueryGetSetArgs = {
   dimensions?: InputMaybe<Array<InputMaybe<UserDimension>>>;
-  external_id?: InputMaybe<Scalars['String']>;
-  ignore_availability?: InputMaybe<Scalars['Boolean']>;
-  language?: InputMaybe<Scalars['String']>;
-  time_travel?: InputMaybe<Scalars['AWSDateTime']>;
-  uid?: InputMaybe<Scalars['String']>;
+  external_id?: InputMaybe<Scalars["String"]>;
+  ignore_availability?: InputMaybe<Scalars["Boolean"]>;
+  language?: InputMaybe<Scalars["String"]>;
+  time_travel?: InputMaybe<Scalars["AWSDateTime"]>;
+  uid?: InputMaybe<Scalars["String"]>;
 };
-
 
 export type QueryGetTagArgs = {
   dimensions?: InputMaybe<Array<InputMaybe<UserDimension>>>;
-  external_id?: InputMaybe<Scalars['String']>;
-  ignore_availability?: InputMaybe<Scalars['Boolean']>;
-  language?: InputMaybe<Scalars['String']>;
-  time_travel?: InputMaybe<Scalars['AWSDateTime']>;
-  uid?: InputMaybe<Scalars['String']>;
+  external_id?: InputMaybe<Scalars["String"]>;
+  ignore_availability?: InputMaybe<Scalars["Boolean"]>;
+  language?: InputMaybe<Scalars["String"]>;
+  time_travel?: InputMaybe<Scalars["AWSDateTime"]>;
+  uid?: InputMaybe<Scalars["String"]>;
 };
-
 
 export type QueryGetThemeArgs = {
   dimensions?: InputMaybe<Array<InputMaybe<UserDimension>>>;
-  external_id?: InputMaybe<Scalars['String']>;
-  ignore_availability?: InputMaybe<Scalars['Boolean']>;
-  language?: InputMaybe<Scalars['String']>;
-  time_travel?: InputMaybe<Scalars['AWSDateTime']>;
-  uid?: InputMaybe<Scalars['String']>;
+  external_id?: InputMaybe<Scalars["String"]>;
+  ignore_availability?: InputMaybe<Scalars["Boolean"]>;
+  language?: InputMaybe<Scalars["String"]>;
+  time_travel?: InputMaybe<Scalars["AWSDateTime"]>;
+  uid?: InputMaybe<Scalars["String"]>;
 };
-
 
 export type QueryListAssetArgs = {
   dimensions?: InputMaybe<Array<InputMaybe<UserDimension>>>;
-  ignore_availability?: InputMaybe<Scalars['Boolean']>;
-  language?: InputMaybe<Scalars['String']>;
-  limit?: InputMaybe<Scalars['Int']>;
-  next_token?: InputMaybe<Scalars['String']>;
-  time_travel?: InputMaybe<Scalars['AWSDateTime']>;
+  ignore_availability?: InputMaybe<Scalars["Boolean"]>;
+  language?: InputMaybe<Scalars["String"]>;
+  limit?: InputMaybe<Scalars["Int"]>;
+  next_token?: InputMaybe<Scalars["String"]>;
+  time_travel?: InputMaybe<Scalars["AWSDateTime"]>;
 };
-
 
 export type QueryListAvailabilityArgs = {
-  limit?: InputMaybe<Scalars['Int']>;
-  next_token?: InputMaybe<Scalars['String']>;
+  limit?: InputMaybe<Scalars["Int"]>;
+  next_token?: InputMaybe<Scalars["String"]>;
 };
-
 
 export type QueryListBrandArgs = {
   dimensions?: InputMaybe<Array<InputMaybe<UserDimension>>>;
-  ignore_availability?: InputMaybe<Scalars['Boolean']>;
-  language?: InputMaybe<Scalars['String']>;
-  limit?: InputMaybe<Scalars['Int']>;
-  next_token?: InputMaybe<Scalars['String']>;
-  time_travel?: InputMaybe<Scalars['AWSDateTime']>;
+  ignore_availability?: InputMaybe<Scalars["Boolean"]>;
+  language?: InputMaybe<Scalars["String"]>;
+  limit?: InputMaybe<Scalars["Int"]>;
+  next_token?: InputMaybe<Scalars["String"]>;
+  time_travel?: InputMaybe<Scalars["AWSDateTime"]>;
 };
-
 
 export type QueryListCreditArgs = {
   dimensions?: InputMaybe<Array<InputMaybe<UserDimension>>>;
-  ignore_availability?: InputMaybe<Scalars['Boolean']>;
-  language?: InputMaybe<Scalars['String']>;
-  limit?: InputMaybe<Scalars['Int']>;
-  next_token?: InputMaybe<Scalars['String']>;
-  time_travel?: InputMaybe<Scalars['AWSDateTime']>;
+  ignore_availability?: InputMaybe<Scalars["Boolean"]>;
+  language?: InputMaybe<Scalars["String"]>;
+  limit?: InputMaybe<Scalars["Int"]>;
+  next_token?: InputMaybe<Scalars["String"]>;
+  time_travel?: InputMaybe<Scalars["AWSDateTime"]>;
 };
-
 
 export type QueryListEpisodeArgs = {
   dimensions?: InputMaybe<Array<InputMaybe<UserDimension>>>;
-  ignore_availability?: InputMaybe<Scalars['Boolean']>;
-  language?: InputMaybe<Scalars['String']>;
-  limit?: InputMaybe<Scalars['Int']>;
-  next_token?: InputMaybe<Scalars['String']>;
-  time_travel?: InputMaybe<Scalars['AWSDateTime']>;
+  ignore_availability?: InputMaybe<Scalars["Boolean"]>;
+  language?: InputMaybe<Scalars["String"]>;
+  limit?: InputMaybe<Scalars["Int"]>;
+  next_token?: InputMaybe<Scalars["String"]>;
+  time_travel?: InputMaybe<Scalars["AWSDateTime"]>;
 };
-
 
 export type QueryListGenreArgs = {
   dimensions?: InputMaybe<Array<InputMaybe<UserDimension>>>;
-  ignore_availability?: InputMaybe<Scalars['Boolean']>;
-  language?: InputMaybe<Scalars['String']>;
-  limit?: InputMaybe<Scalars['Int']>;
-  next_token?: InputMaybe<Scalars['String']>;
-  time_travel?: InputMaybe<Scalars['AWSDateTime']>;
+  ignore_availability?: InputMaybe<Scalars["Boolean"]>;
+  language?: InputMaybe<Scalars["String"]>;
+  limit?: InputMaybe<Scalars["Int"]>;
+  next_token?: InputMaybe<Scalars["String"]>;
+  time_travel?: InputMaybe<Scalars["AWSDateTime"]>;
 };
-
 
 export type QueryListImageArgs = {
   dimensions?: InputMaybe<Array<InputMaybe<UserDimension>>>;
-  ignore_availability?: InputMaybe<Scalars['Boolean']>;
-  language?: InputMaybe<Scalars['String']>;
-  limit?: InputMaybe<Scalars['Int']>;
-  next_token?: InputMaybe<Scalars['String']>;
-  time_travel?: InputMaybe<Scalars['AWSDateTime']>;
+  ignore_availability?: InputMaybe<Scalars["Boolean"]>;
+  language?: InputMaybe<Scalars["String"]>;
+  limit?: InputMaybe<Scalars["Int"]>;
+  next_token?: InputMaybe<Scalars["String"]>;
+  time_travel?: InputMaybe<Scalars["AWSDateTime"]>;
 };
-
 
 export type QueryListMovieArgs = {
   dimensions?: InputMaybe<Array<InputMaybe<UserDimension>>>;
-  ignore_availability?: InputMaybe<Scalars['Boolean']>;
-  language?: InputMaybe<Scalars['String']>;
-  limit?: InputMaybe<Scalars['Int']>;
-  next_token?: InputMaybe<Scalars['String']>;
-  time_travel?: InputMaybe<Scalars['AWSDateTime']>;
+  ignore_availability?: InputMaybe<Scalars["Boolean"]>;
+  language?: InputMaybe<Scalars["String"]>;
+  limit?: InputMaybe<Scalars["Int"]>;
+  next_token?: InputMaybe<Scalars["String"]>;
+  time_travel?: InputMaybe<Scalars["AWSDateTime"]>;
 };
-
 
 export type QueryListParentalGuidanceArgs = {
   dimensions?: InputMaybe<Array<InputMaybe<UserDimension>>>;
-  ignore_availability?: InputMaybe<Scalars['Boolean']>;
-  language?: InputMaybe<Scalars['String']>;
-  limit?: InputMaybe<Scalars['Int']>;
-  next_token?: InputMaybe<Scalars['String']>;
-  time_travel?: InputMaybe<Scalars['AWSDateTime']>;
+  ignore_availability?: InputMaybe<Scalars["Boolean"]>;
+  language?: InputMaybe<Scalars["String"]>;
+  limit?: InputMaybe<Scalars["Int"]>;
+  next_token?: InputMaybe<Scalars["String"]>;
+  time_travel?: InputMaybe<Scalars["AWSDateTime"]>;
 };
-
 
 export type QueryListPersonArgs = {
   dimensions?: InputMaybe<Array<InputMaybe<UserDimension>>>;
-  ignore_availability?: InputMaybe<Scalars['Boolean']>;
-  language?: InputMaybe<Scalars['String']>;
-  limit?: InputMaybe<Scalars['Int']>;
-  next_token?: InputMaybe<Scalars['String']>;
-  time_travel?: InputMaybe<Scalars['AWSDateTime']>;
+  ignore_availability?: InputMaybe<Scalars["Boolean"]>;
+  language?: InputMaybe<Scalars["String"]>;
+  limit?: InputMaybe<Scalars["Int"]>;
+  next_token?: InputMaybe<Scalars["String"]>;
+  time_travel?: InputMaybe<Scalars["AWSDateTime"]>;
 };
-
 
 export type QueryListRatingArgs = {
   dimensions?: InputMaybe<Array<InputMaybe<UserDimension>>>;
-  ignore_availability?: InputMaybe<Scalars['Boolean']>;
-  language?: InputMaybe<Scalars['String']>;
-  limit?: InputMaybe<Scalars['Int']>;
-  next_token?: InputMaybe<Scalars['String']>;
-  time_travel?: InputMaybe<Scalars['AWSDateTime']>;
+  ignore_availability?: InputMaybe<Scalars["Boolean"]>;
+  language?: InputMaybe<Scalars["String"]>;
+  limit?: InputMaybe<Scalars["Int"]>;
+  next_token?: InputMaybe<Scalars["String"]>;
+  time_travel?: InputMaybe<Scalars["AWSDateTime"]>;
 };
-
 
 export type QueryListRoleArgs = {
   dimensions?: InputMaybe<Array<InputMaybe<UserDimension>>>;
-  ignore_availability?: InputMaybe<Scalars['Boolean']>;
-  language?: InputMaybe<Scalars['String']>;
-  limit?: InputMaybe<Scalars['Int']>;
-  next_token?: InputMaybe<Scalars['String']>;
-  time_travel?: InputMaybe<Scalars['AWSDateTime']>;
+  ignore_availability?: InputMaybe<Scalars["Boolean"]>;
+  language?: InputMaybe<Scalars["String"]>;
+  limit?: InputMaybe<Scalars["Int"]>;
+  next_token?: InputMaybe<Scalars["String"]>;
+  time_travel?: InputMaybe<Scalars["AWSDateTime"]>;
 };
-
 
 export type QueryListSeasonArgs = {
   dimensions?: InputMaybe<Array<InputMaybe<UserDimension>>>;
-  ignore_availability?: InputMaybe<Scalars['Boolean']>;
-  language?: InputMaybe<Scalars['String']>;
-  limit?: InputMaybe<Scalars['Int']>;
-  next_token?: InputMaybe<Scalars['String']>;
-  time_travel?: InputMaybe<Scalars['AWSDateTime']>;
+  ignore_availability?: InputMaybe<Scalars["Boolean"]>;
+  language?: InputMaybe<Scalars["String"]>;
+  limit?: InputMaybe<Scalars["Int"]>;
+  next_token?: InputMaybe<Scalars["String"]>;
+  time_travel?: InputMaybe<Scalars["AWSDateTime"]>;
 };
-
 
 export type QueryListSetArgs = {
   dimensions?: InputMaybe<Array<InputMaybe<UserDimension>>>;
-  ignore_availability?: InputMaybe<Scalars['Boolean']>;
-  language?: InputMaybe<Scalars['String']>;
-  limit?: InputMaybe<Scalars['Int']>;
-  next_token?: InputMaybe<Scalars['String']>;
-  time_travel?: InputMaybe<Scalars['AWSDateTime']>;
+  ignore_availability?: InputMaybe<Scalars["Boolean"]>;
+  language?: InputMaybe<Scalars["String"]>;
+  limit?: InputMaybe<Scalars["Int"]>;
+  next_token?: InputMaybe<Scalars["String"]>;
+  time_travel?: InputMaybe<Scalars["AWSDateTime"]>;
 };
-
 
 export type QueryListTagArgs = {
   dimensions?: InputMaybe<Array<InputMaybe<UserDimension>>>;
-  ignore_availability?: InputMaybe<Scalars['Boolean']>;
-  language?: InputMaybe<Scalars['String']>;
-  limit?: InputMaybe<Scalars['Int']>;
-  next_token?: InputMaybe<Scalars['String']>;
-  time_travel?: InputMaybe<Scalars['AWSDateTime']>;
+  ignore_availability?: InputMaybe<Scalars["Boolean"]>;
+  language?: InputMaybe<Scalars["String"]>;
+  limit?: InputMaybe<Scalars["Int"]>;
+  next_token?: InputMaybe<Scalars["String"]>;
+  time_travel?: InputMaybe<Scalars["AWSDateTime"]>;
 };
-
 
 export type QueryListThemeArgs = {
   dimensions?: InputMaybe<Array<InputMaybe<UserDimension>>>;
-  ignore_availability?: InputMaybe<Scalars['Boolean']>;
-  language?: InputMaybe<Scalars['String']>;
-  limit?: InputMaybe<Scalars['Int']>;
-  next_token?: InputMaybe<Scalars['String']>;
-  time_travel?: InputMaybe<Scalars['AWSDateTime']>;
+  ignore_availability?: InputMaybe<Scalars["Boolean"]>;
+  language?: InputMaybe<Scalars["String"]>;
+  limit?: InputMaybe<Scalars["Int"]>;
+  next_token?: InputMaybe<Scalars["String"]>;
+  time_travel?: InputMaybe<Scalars["AWSDateTime"]>;
 };
 
 export type Rating = Metadata & {
-  __typename?: 'Rating';
+  __typename?: "Rating";
   _meta?: Maybe<_RatingMeta>;
   availability?: Maybe<AvailabilityListing>;
-  description?: Maybe<Scalars['String']>;
-  external_id?: Maybe<Scalars['String']>;
+  description?: Maybe<Scalars["String"]>;
+  external_id?: Maybe<Scalars["String"]>;
   parental_guidance?: Maybe<ParentalGuidanceListing>;
   parents?: Maybe<EntertainmentListing>;
-  scheme?: Maybe<Scalars['String']>;
-  slug?: Maybe<Scalars['String']>;
-  title?: Maybe<Scalars['String']>;
-  uid: Scalars['String'];
-  value: Scalars['String'];
+  scheme?: Maybe<Scalars["String"]>;
+  slug?: Maybe<Scalars["String"]>;
+  title?: Maybe<Scalars["String"]>;
+  uid: Scalars["String"];
+  value: Scalars["String"];
 };
-
 
 export type Rating_MetaArgs = {
-  global_version?: InputMaybe<Scalars['Int']>;
-  language?: InputMaybe<Scalars['String']>;
-  language_version?: InputMaybe<Scalars['Int']>;
+  global_version?: InputMaybe<Scalars["Int"]>;
+  language?: InputMaybe<Scalars["String"]>;
+  language_version?: InputMaybe<Scalars["Int"]>;
 };
-
 
 export type RatingAvailabilityArgs = {
-  limit?: InputMaybe<Scalars['Int']>;
-  next_token?: InputMaybe<Scalars['String']>;
+  limit?: InputMaybe<Scalars["Int"]>;
+  next_token?: InputMaybe<Scalars["String"]>;
 };
-
 
 export type RatingParental_GuidanceArgs = {
-  language?: InputMaybe<Scalars['String']>;
-  limit?: InputMaybe<Scalars['Int']>;
-  next_token?: InputMaybe<Scalars['String']>;
+  language?: InputMaybe<Scalars["String"]>;
+  limit?: InputMaybe<Scalars["Int"]>;
+  next_token?: InputMaybe<Scalars["String"]>;
 };
 
-
 export type RatingParentsArgs = {
-  language?: InputMaybe<Scalars['String']>;
-  limit?: InputMaybe<Scalars['Int']>;
-  next_token?: InputMaybe<Scalars['String']>;
+  language?: InputMaybe<Scalars["String"]>;
+  limit?: InputMaybe<Scalars["Int"]>;
+  next_token?: InputMaybe<Scalars["String"]>;
 };
 
 export type RatingInput = {
   availability?: InputMaybe<AssignAvailabilityInput>;
-  data_source_fields?: InputMaybe<Array<InputMaybe<Scalars['String']>>>;
-  data_source_id?: InputMaybe<Scalars['String']>;
-  description?: InputMaybe<Scalars['String']>;
-  external_id?: InputMaybe<Scalars['String']>;
-  scheme?: InputMaybe<Scalars['String']>;
-  slug?: InputMaybe<Scalars['String']>;
-  title?: InputMaybe<Scalars['String']>;
-  value: Scalars['String'];
+  data_source_fields?: InputMaybe<Array<InputMaybe<Scalars["String"]>>>;
+  data_source_id?: InputMaybe<Scalars["String"]>;
+  description?: InputMaybe<Scalars["String"]>;
+  external_id?: InputMaybe<Scalars["String"]>;
+  scheme?: InputMaybe<Scalars["String"]>;
+  slug?: InputMaybe<Scalars["String"]>;
+  title?: InputMaybe<Scalars["String"]>;
+  value: Scalars["String"];
 };
 
 export type RatingListing = Listing & {
-  __typename?: 'RatingListing';
-  count?: Maybe<Scalars['Int']>;
-  next_token?: Maybe<Scalars['String']>;
+  __typename?: "RatingListing";
+  count?: Maybe<Scalars["Int"]>;
+  next_token?: Maybe<Scalars["String"]>;
   objects?: Maybe<Array<Maybe<Rating>>>;
 };
 
 export type RatingRelationshipInput = {
   create?: InputMaybe<Array<InputMaybe<RatingInput>>>;
-  link?: InputMaybe<Array<InputMaybe<Scalars['String']>>>;
-  unlink?: InputMaybe<Array<InputMaybe<Scalars['String']>>>;
+  link?: InputMaybe<Array<InputMaybe<Scalars["String"]>>>;
+  unlink?: InputMaybe<Array<InputMaybe<Scalars["String"]>>>;
 };
 
 export type Role = Metadata & {
-  __typename?: 'Role';
+  __typename?: "Role";
   _meta?: Maybe<_RoleMeta>;
   availability?: Maybe<AvailabilityListing>;
   credits?: Maybe<CreditListing>;
-  external_id?: Maybe<Scalars['String']>;
-  slug?: Maybe<Scalars['String']>;
-  title?: Maybe<Scalars['String']>;
-  uid: Scalars['String'];
+  external_id?: Maybe<Scalars["String"]>;
+  slug?: Maybe<Scalars["String"]>;
+  title?: Maybe<Scalars["String"]>;
+  uid: Scalars["String"];
 };
-
 
 export type Role_MetaArgs = {
-  global_version?: InputMaybe<Scalars['Int']>;
-  language?: InputMaybe<Scalars['String']>;
-  language_version?: InputMaybe<Scalars['Int']>;
+  global_version?: InputMaybe<Scalars["Int"]>;
+  language?: InputMaybe<Scalars["String"]>;
+  language_version?: InputMaybe<Scalars["Int"]>;
 };
-
 
 export type RoleAvailabilityArgs = {
-  limit?: InputMaybe<Scalars['Int']>;
-  next_token?: InputMaybe<Scalars['String']>;
+  limit?: InputMaybe<Scalars["Int"]>;
+  next_token?: InputMaybe<Scalars["String"]>;
 };
 
-
 export type RoleCreditsArgs = {
-  language?: InputMaybe<Scalars['String']>;
-  limit?: InputMaybe<Scalars['Int']>;
-  next_token?: InputMaybe<Scalars['String']>;
+  language?: InputMaybe<Scalars["String"]>;
+  limit?: InputMaybe<Scalars["Int"]>;
+  next_token?: InputMaybe<Scalars["String"]>;
 };
 
 export type RoleInput = {
   availability?: InputMaybe<AssignAvailabilityInput>;
-  data_source_fields?: InputMaybe<Array<InputMaybe<Scalars['String']>>>;
-  data_source_id?: InputMaybe<Scalars['String']>;
-  external_id?: InputMaybe<Scalars['String']>;
+  data_source_fields?: InputMaybe<Array<InputMaybe<Scalars["String"]>>>;
+  data_source_id?: InputMaybe<Scalars["String"]>;
+  external_id?: InputMaybe<Scalars["String"]>;
   relationships?: InputMaybe<RoleRelationships>;
-  title?: InputMaybe<Scalars['String']>;
+  title?: InputMaybe<Scalars["String"]>;
 };
 
 export type RoleListing = Listing & {
-  __typename?: 'RoleListing';
-  count?: Maybe<Scalars['Int']>;
-  next_token?: Maybe<Scalars['String']>;
+  __typename?: "RoleListing";
+  count?: Maybe<Scalars["Int"]>;
+  next_token?: Maybe<Scalars["String"]>;
   objects?: Maybe<Array<Maybe<Role>>>;
 };
 
 export type RoleRelationshipInput = {
   create?: InputMaybe<Array<InputMaybe<RoleInput>>>;
-  link?: InputMaybe<Array<InputMaybe<Scalars['String']>>>;
-  unlink?: InputMaybe<Array<InputMaybe<Scalars['String']>>>;
+  link?: InputMaybe<Array<InputMaybe<Scalars["String"]>>>;
+  unlink?: InputMaybe<Array<InputMaybe<Scalars["String"]>>>;
 };
 
 export type RoleRelationships = {
   credits?: InputMaybe<CreditRelationshipInput>;
 };
 
-export type Season = CurationMetadata & Entertainment & {
-  __typename?: 'Season';
-  _meta?: Maybe<_SeasonMeta>;
-  assets?: Maybe<AssetListing>;
-  availability?: Maybe<AvailabilityListing>;
-  brands?: Maybe<BrandListing>;
-  credits?: Maybe<CreditListing>;
-  episodes?: Maybe<EpisodeListing>;
-  external_id?: Maybe<Scalars['String']>;
-  genres?: Maybe<GenreListing>;
-  images?: Maybe<ImageListing>;
-  number_of_episodes?: Maybe<Scalars['Int']>;
-  ratings?: Maybe<RatingListing>;
-  release_date?: Maybe<Scalars['String']>;
-  season_number?: Maybe<Scalars['Int']>;
-  sets?: Maybe<SetListing>;
-  slug?: Maybe<Scalars['String']>;
-  synopsis_long?: Maybe<Scalars['String']>;
-  synopsis_medium?: Maybe<Scalars['String']>;
-  synopsis_short?: Maybe<Scalars['String']>;
-  tags?: Maybe<TagListing>;
-  themes?: Maybe<ThemeListing>;
-  title?: Maybe<Scalars['String']>;
-  title_long?: Maybe<Scalars['String']>;
-  title_medium?: Maybe<Scalars['String']>;
-  title_short?: Maybe<Scalars['String']>;
-  uid: Scalars['String'];
-};
-
+export type Season = CurationMetadata &
+  Entertainment & {
+    __typename?: "Season";
+    _meta?: Maybe<_SeasonMeta>;
+    assets?: Maybe<AssetListing>;
+    availability?: Maybe<AvailabilityListing>;
+    brands?: Maybe<BrandListing>;
+    credits?: Maybe<CreditListing>;
+    episodes?: Maybe<EpisodeListing>;
+    external_id?: Maybe<Scalars["String"]>;
+    genres?: Maybe<GenreListing>;
+    images?: Maybe<ImageListing>;
+    number_of_episodes?: Maybe<Scalars["Int"]>;
+    ratings?: Maybe<RatingListing>;
+    release_date?: Maybe<Scalars["String"]>;
+    season_number?: Maybe<Scalars["Int"]>;
+    sets?: Maybe<SetListing>;
+    slug?: Maybe<Scalars["String"]>;
+    synopsis_long?: Maybe<Scalars["String"]>;
+    synopsis_medium?: Maybe<Scalars["String"]>;
+    synopsis_short?: Maybe<Scalars["String"]>;
+    tags?: Maybe<TagListing>;
+    themes?: Maybe<ThemeListing>;
+    title?: Maybe<Scalars["String"]>;
+    title_long?: Maybe<Scalars["String"]>;
+    title_medium?: Maybe<Scalars["String"]>;
+    title_short?: Maybe<Scalars["String"]>;
+    uid: Scalars["String"];
+  };
 
 export type Season_MetaArgs = {
-  global_version?: InputMaybe<Scalars['Int']>;
-  language?: InputMaybe<Scalars['String']>;
-  language_version?: InputMaybe<Scalars['Int']>;
+  global_version?: InputMaybe<Scalars["Int"]>;
+  language?: InputMaybe<Scalars["String"]>;
+  language_version?: InputMaybe<Scalars["Int"]>;
 };
-
 
 export type SeasonAssetsArgs = {
-  language?: InputMaybe<Scalars['String']>;
-  limit?: InputMaybe<Scalars['Int']>;
-  next_token?: InputMaybe<Scalars['String']>;
+  language?: InputMaybe<Scalars["String"]>;
+  limit?: InputMaybe<Scalars["Int"]>;
+  next_token?: InputMaybe<Scalars["String"]>;
 };
-
 
 export type SeasonAvailabilityArgs = {
-  limit?: InputMaybe<Scalars['Int']>;
-  next_token?: InputMaybe<Scalars['String']>;
+  limit?: InputMaybe<Scalars["Int"]>;
+  next_token?: InputMaybe<Scalars["String"]>;
 };
-
 
 export type SeasonBrandsArgs = {
-  language?: InputMaybe<Scalars['String']>;
-  limit?: InputMaybe<Scalars['Int']>;
-  next_token?: InputMaybe<Scalars['String']>;
+  language?: InputMaybe<Scalars["String"]>;
+  limit?: InputMaybe<Scalars["Int"]>;
+  next_token?: InputMaybe<Scalars["String"]>;
 };
-
 
 export type SeasonCreditsArgs = {
-  language?: InputMaybe<Scalars['String']>;
-  limit?: InputMaybe<Scalars['Int']>;
-  next_token?: InputMaybe<Scalars['String']>;
+  language?: InputMaybe<Scalars["String"]>;
+  limit?: InputMaybe<Scalars["Int"]>;
+  next_token?: InputMaybe<Scalars["String"]>;
 };
-
 
 export type SeasonEpisodesArgs = {
-  language?: InputMaybe<Scalars['String']>;
-  limit?: InputMaybe<Scalars['Int']>;
-  next_token?: InputMaybe<Scalars['String']>;
+  language?: InputMaybe<Scalars["String"]>;
+  limit?: InputMaybe<Scalars["Int"]>;
+  next_token?: InputMaybe<Scalars["String"]>;
 };
-
 
 export type SeasonGenresArgs = {
-  language?: InputMaybe<Scalars['String']>;
-  limit?: InputMaybe<Scalars['Int']>;
-  next_token?: InputMaybe<Scalars['String']>;
+  language?: InputMaybe<Scalars["String"]>;
+  limit?: InputMaybe<Scalars["Int"]>;
+  next_token?: InputMaybe<Scalars["String"]>;
 };
-
 
 export type SeasonImagesArgs = {
-  language?: InputMaybe<Scalars['String']>;
-  limit?: InputMaybe<Scalars['Int']>;
-  next_token?: InputMaybe<Scalars['String']>;
+  language?: InputMaybe<Scalars["String"]>;
+  limit?: InputMaybe<Scalars["Int"]>;
+  next_token?: InputMaybe<Scalars["String"]>;
 };
-
 
 export type SeasonRatingsArgs = {
-  language?: InputMaybe<Scalars['String']>;
-  limit?: InputMaybe<Scalars['Int']>;
-  next_token?: InputMaybe<Scalars['String']>;
+  language?: InputMaybe<Scalars["String"]>;
+  limit?: InputMaybe<Scalars["Int"]>;
+  next_token?: InputMaybe<Scalars["String"]>;
 };
-
 
 export type SeasonSetsArgs = {
-  limit?: InputMaybe<Scalars['Int']>;
-  next_token?: InputMaybe<Scalars['String']>;
+  limit?: InputMaybe<Scalars["Int"]>;
+  next_token?: InputMaybe<Scalars["String"]>;
 };
-
 
 export type SeasonTagsArgs = {
-  language?: InputMaybe<Scalars['String']>;
-  limit?: InputMaybe<Scalars['Int']>;
-  next_token?: InputMaybe<Scalars['String']>;
+  language?: InputMaybe<Scalars["String"]>;
+  limit?: InputMaybe<Scalars["Int"]>;
+  next_token?: InputMaybe<Scalars["String"]>;
 };
 
-
 export type SeasonThemesArgs = {
-  language?: InputMaybe<Scalars['String']>;
-  limit?: InputMaybe<Scalars['Int']>;
-  next_token?: InputMaybe<Scalars['String']>;
+  language?: InputMaybe<Scalars["String"]>;
+  limit?: InputMaybe<Scalars["Int"]>;
+  next_token?: InputMaybe<Scalars["String"]>;
 };
 
 export type SeasonInput = {
   availability?: InputMaybe<AssignAvailabilityInput>;
-  data_source_fields?: InputMaybe<Array<InputMaybe<Scalars['String']>>>;
-  data_source_id?: InputMaybe<Scalars['String']>;
-  external_id?: InputMaybe<Scalars['String']>;
-  number_of_episodes?: InputMaybe<Scalars['Int']>;
+  data_source_fields?: InputMaybe<Array<InputMaybe<Scalars["String"]>>>;
+  data_source_id?: InputMaybe<Scalars["String"]>;
+  external_id?: InputMaybe<Scalars["String"]>;
+  number_of_episodes?: InputMaybe<Scalars["Int"]>;
   relationships?: InputMaybe<SeasonRelationships>;
-  release_date?: InputMaybe<Scalars['String']>;
-  season_number?: InputMaybe<Scalars['Int']>;
-  slug?: InputMaybe<Scalars['String']>;
-  synopsis_long?: InputMaybe<Scalars['String']>;
-  synopsis_medium?: InputMaybe<Scalars['String']>;
-  synopsis_short?: InputMaybe<Scalars['String']>;
-  title?: InputMaybe<Scalars['String']>;
-  title_long?: InputMaybe<Scalars['String']>;
-  title_medium?: InputMaybe<Scalars['String']>;
-  title_short?: InputMaybe<Scalars['String']>;
+  release_date?: InputMaybe<Scalars["String"]>;
+  season_number?: InputMaybe<Scalars["Int"]>;
+  slug?: InputMaybe<Scalars["String"]>;
+  synopsis_long?: InputMaybe<Scalars["String"]>;
+  synopsis_medium?: InputMaybe<Scalars["String"]>;
+  synopsis_short?: InputMaybe<Scalars["String"]>;
+  title?: InputMaybe<Scalars["String"]>;
+  title_long?: InputMaybe<Scalars["String"]>;
+  title_medium?: InputMaybe<Scalars["String"]>;
+  title_short?: InputMaybe<Scalars["String"]>;
 };
 
 export type SeasonListing = Listing & {
-  __typename?: 'SeasonListing';
-  count?: Maybe<Scalars['Int']>;
-  next_token?: Maybe<Scalars['String']>;
+  __typename?: "SeasonListing";
+  count?: Maybe<Scalars["Int"]>;
+  next_token?: Maybe<Scalars["String"]>;
   objects?: Maybe<Array<Maybe<Season>>>;
 };
 
 export type SeasonRelationshipInput = {
   create?: InputMaybe<Array<InputMaybe<SeasonInput>>>;
-  link?: InputMaybe<Array<InputMaybe<Scalars['String']>>>;
-  unlink?: InputMaybe<Array<InputMaybe<Scalars['String']>>>;
+  link?: InputMaybe<Array<InputMaybe<Scalars["String"]>>>;
+  unlink?: InputMaybe<Array<InputMaybe<Scalars["String"]>>>;
 };
 
 export type SeasonRelationships = {
@@ -2338,124 +2171,114 @@ export type SeasonRelationships = {
 
 export type SeasonSetCreate = {
   object?: InputMaybe<SeasonInput>;
-  position: Scalars['Int'];
+  position: Scalars["Int"];
 };
 
 export type SeasonSetInput = {
   create?: InputMaybe<Array<InputMaybe<SeasonSetCreate>>>;
   link?: InputMaybe<Array<InputMaybe<SetLink>>>;
   reposition?: InputMaybe<Array<InputMaybe<SetLink>>>;
-  unlink?: InputMaybe<Array<InputMaybe<Scalars['String']>>>;
+  unlink?: InputMaybe<Array<InputMaybe<Scalars["String"]>>>;
 };
 
-export type Set = CurationMetadata & Entertainment & {
-  __typename?: 'Set';
-  _meta?: Maybe<_SetMeta>;
-  assets?: Maybe<AssetListing>;
-  availability?: Maybe<AvailabilityListing>;
-  content?: Maybe<CurationMetadataListing>;
-  credits?: Maybe<CreditListing>;
-  description?: Maybe<Scalars['String']>;
-  external_id?: Maybe<Scalars['String']>;
-  genres?: Maybe<GenreListing>;
-  images?: Maybe<ImageListing>;
-  ratings?: Maybe<RatingListing>;
-  release_date?: Maybe<Scalars['String']>;
-  sets?: Maybe<SetListing>;
-  slug?: Maybe<Scalars['String']>;
-  synopsis_long?: Maybe<Scalars['String']>;
-  synopsis_medium?: Maybe<Scalars['String']>;
-  synopsis_short?: Maybe<Scalars['String']>;
-  tags?: Maybe<TagListing>;
-  themes?: Maybe<ThemeListing>;
-  title?: Maybe<Scalars['String']>;
-  title_long?: Maybe<Scalars['String']>;
-  title_medium?: Maybe<Scalars['String']>;
-  title_short?: Maybe<Scalars['String']>;
-  type?: Maybe<Scalars['String']>;
-  uid: Scalars['String'];
-};
-
+export type Set = CurationMetadata &
+  Entertainment & {
+    __typename?: "Set";
+    _meta?: Maybe<_SetMeta>;
+    assets?: Maybe<AssetListing>;
+    availability?: Maybe<AvailabilityListing>;
+    content?: Maybe<CurationMetadataListing>;
+    credits?: Maybe<CreditListing>;
+    description?: Maybe<Scalars["String"]>;
+    external_id?: Maybe<Scalars["String"]>;
+    genres?: Maybe<GenreListing>;
+    images?: Maybe<ImageListing>;
+    ratings?: Maybe<RatingListing>;
+    release_date?: Maybe<Scalars["String"]>;
+    sets?: Maybe<SetListing>;
+    slug?: Maybe<Scalars["String"]>;
+    synopsis_long?: Maybe<Scalars["String"]>;
+    synopsis_medium?: Maybe<Scalars["String"]>;
+    synopsis_short?: Maybe<Scalars["String"]>;
+    tags?: Maybe<TagListing>;
+    themes?: Maybe<ThemeListing>;
+    title?: Maybe<Scalars["String"]>;
+    title_long?: Maybe<Scalars["String"]>;
+    title_medium?: Maybe<Scalars["String"]>;
+    title_short?: Maybe<Scalars["String"]>;
+    type?: Maybe<Scalars["String"]>;
+    uid: Scalars["String"];
+  };
 
 export type Set_MetaArgs = {
-  global_version?: InputMaybe<Scalars['Int']>;
-  language?: InputMaybe<Scalars['String']>;
-  language_version?: InputMaybe<Scalars['Int']>;
+  global_version?: InputMaybe<Scalars["Int"]>;
+  language?: InputMaybe<Scalars["String"]>;
+  language_version?: InputMaybe<Scalars["Int"]>;
 };
-
 
 export type SetAssetsArgs = {
-  language?: InputMaybe<Scalars['String']>;
-  limit?: InputMaybe<Scalars['Int']>;
-  next_token?: InputMaybe<Scalars['String']>;
+  language?: InputMaybe<Scalars["String"]>;
+  limit?: InputMaybe<Scalars["Int"]>;
+  next_token?: InputMaybe<Scalars["String"]>;
 };
-
 
 export type SetAvailabilityArgs = {
-  limit?: InputMaybe<Scalars['Int']>;
-  next_token?: InputMaybe<Scalars['String']>;
+  limit?: InputMaybe<Scalars["Int"]>;
+  next_token?: InputMaybe<Scalars["String"]>;
 };
 
-
 export type SetContentArgs = {
-  language?: InputMaybe<Scalars['String']>;
-  limit?: InputMaybe<Scalars['Int']>;
-  next_token?: InputMaybe<Scalars['String']>;
+  language?: InputMaybe<Scalars["String"]>;
+  limit?: InputMaybe<Scalars["Int"]>;
+  next_token?: InputMaybe<Scalars["String"]>;
   order?: InputMaybe<OrderDirections>;
 };
 
-
 export type SetCreditsArgs = {
-  language?: InputMaybe<Scalars['String']>;
-  limit?: InputMaybe<Scalars['Int']>;
-  next_token?: InputMaybe<Scalars['String']>;
+  language?: InputMaybe<Scalars["String"]>;
+  limit?: InputMaybe<Scalars["Int"]>;
+  next_token?: InputMaybe<Scalars["String"]>;
 };
-
 
 export type SetGenresArgs = {
-  language?: InputMaybe<Scalars['String']>;
-  limit?: InputMaybe<Scalars['Int']>;
-  next_token?: InputMaybe<Scalars['String']>;
+  language?: InputMaybe<Scalars["String"]>;
+  limit?: InputMaybe<Scalars["Int"]>;
+  next_token?: InputMaybe<Scalars["String"]>;
 };
-
 
 export type SetImagesArgs = {
-  language?: InputMaybe<Scalars['String']>;
-  limit?: InputMaybe<Scalars['Int']>;
-  next_token?: InputMaybe<Scalars['String']>;
+  language?: InputMaybe<Scalars["String"]>;
+  limit?: InputMaybe<Scalars["Int"]>;
+  next_token?: InputMaybe<Scalars["String"]>;
 };
-
 
 export type SetRatingsArgs = {
-  language?: InputMaybe<Scalars['String']>;
-  limit?: InputMaybe<Scalars['Int']>;
-  next_token?: InputMaybe<Scalars['String']>;
+  language?: InputMaybe<Scalars["String"]>;
+  limit?: InputMaybe<Scalars["Int"]>;
+  next_token?: InputMaybe<Scalars["String"]>;
 };
-
 
 export type SetSetsArgs = {
-  limit?: InputMaybe<Scalars['Int']>;
-  next_token?: InputMaybe<Scalars['String']>;
+  limit?: InputMaybe<Scalars["Int"]>;
+  next_token?: InputMaybe<Scalars["String"]>;
 };
-
 
 export type SetTagsArgs = {
-  language?: InputMaybe<Scalars['String']>;
-  limit?: InputMaybe<Scalars['Int']>;
-  next_token?: InputMaybe<Scalars['String']>;
+  language?: InputMaybe<Scalars["String"]>;
+  limit?: InputMaybe<Scalars["Int"]>;
+  next_token?: InputMaybe<Scalars["String"]>;
 };
 
-
 export type SetThemesArgs = {
-  language?: InputMaybe<Scalars['String']>;
-  limit?: InputMaybe<Scalars['Int']>;
-  next_token?: InputMaybe<Scalars['String']>;
+  language?: InputMaybe<Scalars["String"]>;
+  limit?: InputMaybe<Scalars["Int"]>;
+  next_token?: InputMaybe<Scalars["String"]>;
 };
 
 export type SetContent = {
-  __typename?: 'SetContent';
+  __typename?: "SetContent";
   object?: Maybe<CurationMetadata>;
-  position?: Maybe<Scalars['Int']>;
+  position?: Maybe<Scalars["Int"]>;
 };
 
 export type SetContentRelationships = {
@@ -2472,32 +2295,32 @@ export type SetContentRelationships = {
 export type SetInput = {
   availability?: InputMaybe<AssignAvailabilityInput>;
   content?: InputMaybe<SetContentRelationships>;
-  data_source_fields?: InputMaybe<Array<InputMaybe<Scalars['String']>>>;
-  data_source_id?: InputMaybe<Scalars['String']>;
-  description?: InputMaybe<Scalars['String']>;
-  external_id?: InputMaybe<Scalars['String']>;
+  data_source_fields?: InputMaybe<Array<InputMaybe<Scalars["String"]>>>;
+  data_source_id?: InputMaybe<Scalars["String"]>;
+  description?: InputMaybe<Scalars["String"]>;
+  external_id?: InputMaybe<Scalars["String"]>;
   relationships?: InputMaybe<SetRelationships>;
-  release_date?: InputMaybe<Scalars['String']>;
-  slug?: InputMaybe<Scalars['String']>;
-  synopsis_long?: InputMaybe<Scalars['String']>;
-  synopsis_medium?: InputMaybe<Scalars['String']>;
-  synopsis_short?: InputMaybe<Scalars['String']>;
-  title?: InputMaybe<Scalars['String']>;
-  title_long?: InputMaybe<Scalars['String']>;
-  title_medium?: InputMaybe<Scalars['String']>;
-  title_short?: InputMaybe<Scalars['String']>;
+  release_date?: InputMaybe<Scalars["String"]>;
+  slug?: InputMaybe<Scalars["String"]>;
+  synopsis_long?: InputMaybe<Scalars["String"]>;
+  synopsis_medium?: InputMaybe<Scalars["String"]>;
+  synopsis_short?: InputMaybe<Scalars["String"]>;
+  title?: InputMaybe<Scalars["String"]>;
+  title_long?: InputMaybe<Scalars["String"]>;
+  title_medium?: InputMaybe<Scalars["String"]>;
+  title_short?: InputMaybe<Scalars["String"]>;
   type?: InputMaybe<SetType>;
 };
 
 export type SetLink = {
-  position: Scalars['Int'];
-  uid: Scalars['String'];
+  position: Scalars["Int"];
+  uid: Scalars["String"];
 };
 
 export type SetListing = {
-  __typename?: 'SetListing';
-  count?: Maybe<Scalars['Int']>;
-  next_token?: Maybe<Scalars['String']>;
+  __typename?: "SetListing";
+  count?: Maybe<Scalars["Int"]>;
+  next_token?: Maybe<Scalars["String"]>;
   objects?: Maybe<Array<Maybe<Set>>>;
 };
 
@@ -2512,196 +2335,189 @@ export type SetRelationships = {
 };
 
 export enum SetType {
-  Collection = 'COLLECTION',
-  Page = 'PAGE',
-  Rail = 'RAIL',
-  Slider = 'SLIDER'
+  Collection = "COLLECTION",
+  Page = "PAGE",
+  Rail = "RAIL",
+  Slider = "SLIDER",
 }
 
 export type SubsetCreate = {
   object?: InputMaybe<SetInput>;
-  position: Scalars['Int'];
+  position: Scalars["Int"];
 };
 
 export type SubsetInput = {
   create?: InputMaybe<Array<InputMaybe<SubsetCreate>>>;
   link?: InputMaybe<Array<InputMaybe<SetLink>>>;
   reposition?: InputMaybe<Array<InputMaybe<SetLink>>>;
-  unlink?: InputMaybe<Array<InputMaybe<Scalars['String']>>>;
+  unlink?: InputMaybe<Array<InputMaybe<Scalars["String"]>>>;
 };
 
 export type Tag = Metadata & {
-  __typename?: 'Tag';
+  __typename?: "Tag";
   _meta?: Maybe<_TagMeta>;
   availability?: Maybe<AvailabilityListing>;
-  external_id?: Maybe<Scalars['String']>;
-  name?: Maybe<Scalars['String']>;
+  external_id?: Maybe<Scalars["String"]>;
+  name?: Maybe<Scalars["String"]>;
   parents?: Maybe<EntertainmentListing>;
-  slug?: Maybe<Scalars['String']>;
-  tag_category?: Maybe<Scalars['String']>;
-  uid: Scalars['String'];
+  slug?: Maybe<Scalars["String"]>;
+  tag_category?: Maybe<Scalars["String"]>;
+  uid: Scalars["String"];
 };
-
 
 export type Tag_MetaArgs = {
-  global_version?: InputMaybe<Scalars['Int']>;
-  language?: InputMaybe<Scalars['String']>;
-  language_version?: InputMaybe<Scalars['Int']>;
+  global_version?: InputMaybe<Scalars["Int"]>;
+  language?: InputMaybe<Scalars["String"]>;
+  language_version?: InputMaybe<Scalars["Int"]>;
 };
-
 
 export type TagAvailabilityArgs = {
-  limit?: InputMaybe<Scalars['Int']>;
-  next_token?: InputMaybe<Scalars['String']>;
+  limit?: InputMaybe<Scalars["Int"]>;
+  next_token?: InputMaybe<Scalars["String"]>;
 };
 
-
 export type TagParentsArgs = {
-  language?: InputMaybe<Scalars['String']>;
-  limit?: InputMaybe<Scalars['Int']>;
-  next_token?: InputMaybe<Scalars['String']>;
+  language?: InputMaybe<Scalars["String"]>;
+  limit?: InputMaybe<Scalars["Int"]>;
+  next_token?: InputMaybe<Scalars["String"]>;
 };
 
 export type TagInput = {
   availability?: InputMaybe<AssignAvailabilityInput>;
-  data_source_fields?: InputMaybe<Array<InputMaybe<Scalars['String']>>>;
-  data_source_id?: InputMaybe<Scalars['String']>;
-  external_id?: InputMaybe<Scalars['String']>;
-  name?: InputMaybe<Scalars['String']>;
-  slug?: InputMaybe<Scalars['String']>;
-  tag_category?: InputMaybe<Scalars['String']>;
+  data_source_fields?: InputMaybe<Array<InputMaybe<Scalars["String"]>>>;
+  data_source_id?: InputMaybe<Scalars["String"]>;
+  external_id?: InputMaybe<Scalars["String"]>;
+  name?: InputMaybe<Scalars["String"]>;
+  slug?: InputMaybe<Scalars["String"]>;
+  tag_category?: InputMaybe<Scalars["String"]>;
 };
 
 export type TagListing = Listing & {
-  __typename?: 'TagListing';
-  count?: Maybe<Scalars['Int']>;
-  next_token?: Maybe<Scalars['String']>;
+  __typename?: "TagListing";
+  count?: Maybe<Scalars["Int"]>;
+  next_token?: Maybe<Scalars["String"]>;
   objects?: Maybe<Array<Maybe<Tag>>>;
 };
 
 export type TagRelationshipInput = {
   create?: InputMaybe<Array<InputMaybe<TagInput>>>;
-  link?: InputMaybe<Array<InputMaybe<Scalars['String']>>>;
-  unlink?: InputMaybe<Array<InputMaybe<Scalars['String']>>>;
+  link?: InputMaybe<Array<InputMaybe<Scalars["String"]>>>;
+  unlink?: InputMaybe<Array<InputMaybe<Scalars["String"]>>>;
 };
 
 export type TagSetCreate = {
   object?: InputMaybe<TagInput>;
-  position: Scalars['Int'];
+  position: Scalars["Int"];
 };
 
 export type TagSetInput = {
   create?: InputMaybe<Array<InputMaybe<TagSetCreate>>>;
   link?: InputMaybe<Array<InputMaybe<SetLink>>>;
   reposition?: InputMaybe<Array<InputMaybe<SetLink>>>;
-  unlink?: InputMaybe<Array<InputMaybe<Scalars['String']>>>;
+  unlink?: InputMaybe<Array<InputMaybe<Scalars["String"]>>>;
 };
 
 export type Theme = CurationMetadata & {
-  __typename?: 'Theme';
+  __typename?: "Theme";
   _meta?: Maybe<_ThemeMeta>;
   availability?: Maybe<AvailabilityListing>;
-  external_id?: Maybe<Scalars['String']>;
-  metadata_source?: Maybe<Scalars['String']>;
-  name?: Maybe<Scalars['String']>;
+  external_id?: Maybe<Scalars["String"]>;
+  metadata_source?: Maybe<Scalars["String"]>;
+  name?: Maybe<Scalars["String"]>;
   parents?: Maybe<EntertainmentListing>;
   sets?: Maybe<SetListing>;
-  slug?: Maybe<Scalars['String']>;
-  uid: Scalars['String'];
+  slug?: Maybe<Scalars["String"]>;
+  uid: Scalars["String"];
 };
-
 
 export type Theme_MetaArgs = {
-  global_version?: InputMaybe<Scalars['Int']>;
-  language?: InputMaybe<Scalars['String']>;
-  language_version?: InputMaybe<Scalars['Int']>;
+  global_version?: InputMaybe<Scalars["Int"]>;
+  language?: InputMaybe<Scalars["String"]>;
+  language_version?: InputMaybe<Scalars["Int"]>;
 };
-
 
 export type ThemeAvailabilityArgs = {
-  limit?: InputMaybe<Scalars['Int']>;
-  next_token?: InputMaybe<Scalars['String']>;
+  limit?: InputMaybe<Scalars["Int"]>;
+  next_token?: InputMaybe<Scalars["String"]>;
 };
-
 
 export type ThemeParentsArgs = {
-  language?: InputMaybe<Scalars['String']>;
-  limit?: InputMaybe<Scalars['Int']>;
-  next_token?: InputMaybe<Scalars['String']>;
+  language?: InputMaybe<Scalars["String"]>;
+  limit?: InputMaybe<Scalars["Int"]>;
+  next_token?: InputMaybe<Scalars["String"]>;
 };
 
-
 export type ThemeSetsArgs = {
-  limit?: InputMaybe<Scalars['Int']>;
-  next_token?: InputMaybe<Scalars['String']>;
+  limit?: InputMaybe<Scalars["Int"]>;
+  next_token?: InputMaybe<Scalars["String"]>;
 };
 
 export type ThemeInput = {
   availability?: InputMaybe<AssignAvailabilityInput>;
-  data_source_fields?: InputMaybe<Array<InputMaybe<Scalars['String']>>>;
-  data_source_id?: InputMaybe<Scalars['String']>;
-  external_id?: InputMaybe<Scalars['String']>;
-  metadata_source?: InputMaybe<Scalars['String']>;
-  name?: InputMaybe<Scalars['String']>;
-  slug?: InputMaybe<Scalars['String']>;
+  data_source_fields?: InputMaybe<Array<InputMaybe<Scalars["String"]>>>;
+  data_source_id?: InputMaybe<Scalars["String"]>;
+  external_id?: InputMaybe<Scalars["String"]>;
+  metadata_source?: InputMaybe<Scalars["String"]>;
+  name?: InputMaybe<Scalars["String"]>;
+  slug?: InputMaybe<Scalars["String"]>;
 };
 
 export type ThemeListing = Listing & {
-  __typename?: 'ThemeListing';
-  count?: Maybe<Scalars['Int']>;
-  next_token?: Maybe<Scalars['String']>;
+  __typename?: "ThemeListing";
+  count?: Maybe<Scalars["Int"]>;
+  next_token?: Maybe<Scalars["String"]>;
   objects?: Maybe<Array<Maybe<Theme>>>;
 };
 
 export type ThemeRelationshipInput = {
   create?: InputMaybe<Array<InputMaybe<ThemeInput>>>;
-  link?: InputMaybe<Array<InputMaybe<Scalars['String']>>>;
-  unlink?: InputMaybe<Array<InputMaybe<Scalars['String']>>>;
+  link?: InputMaybe<Array<InputMaybe<Scalars["String"]>>>;
+  unlink?: InputMaybe<Array<InputMaybe<Scalars["String"]>>>;
 };
 
 export type ThemeSetCreate = {
   object?: InputMaybe<ThemeInput>;
-  position: Scalars['Int'];
+  position: Scalars["Int"];
 };
 
 export type ThemeSetInput = {
   create?: InputMaybe<Array<InputMaybe<ThemeSetCreate>>>;
   link?: InputMaybe<Array<InputMaybe<SetLink>>>;
   reposition?: InputMaybe<Array<InputMaybe<SetLink>>>;
-  unlink?: InputMaybe<Array<InputMaybe<Scalars['String']>>>;
+  unlink?: InputMaybe<Array<InputMaybe<Scalars["String"]>>>;
 };
 
 export type UserDimension = {
-  dimension: Scalars['String'];
-  value: Scalars['String'];
+  dimension: Scalars["String"];
+  value: Scalars["String"];
 };
 
 export type _AssetGlobal = _Global & {
-  __typename?: '_AssetGlobal';
-  asset_url?: Maybe<Scalars['String']>;
+  __typename?: "_AssetGlobal";
+  asset_url?: Maybe<Scalars["String"]>;
   created?: Maybe<_Audit>;
   history?: Maybe<Array<Maybe<_AssetGlobal>>>;
   modified?: Maybe<_Audit>;
   publish_stage?: Maybe<PublishStage>;
-  version?: Maybe<Scalars['Int']>;
+  version?: Maybe<Scalars["Int"]>;
 };
 
 export type _AssetLanguage = _Language & {
-  __typename?: '_AssetLanguage';
+  __typename?: "_AssetLanguage";
   created?: Maybe<_Audit>;
   history?: Maybe<Array<Maybe<_AssetLanguage>>>;
-  language?: Maybe<Scalars['String']>;
+  language?: Maybe<Scalars["String"]>;
   modified?: Maybe<_Audit>;
   publish_stage?: Maybe<PublishStage>;
-  slug?: Maybe<Scalars['String']>;
-  title?: Maybe<Scalars['String']>;
-  type?: Maybe<Scalars['String']>;
-  version?: Maybe<Scalars['Int']>;
+  slug?: Maybe<Scalars["String"]>;
+  title?: Maybe<Scalars["String"]>;
+  type?: Maybe<Scalars["String"]>;
+  version?: Maybe<Scalars["Int"]>;
 };
 
 export type _AssetMeta = {
-  __typename?: '_AssetMeta';
-  available_languages?: Maybe<Array<Maybe<Scalars['String']>>>;
+  __typename?: "_AssetMeta";
+  available_languages?: Maybe<Array<Maybe<Scalars["String"]>>>;
   created?: Maybe<_Audit>;
   data_source?: Maybe<Asset>;
   field_config?: Maybe<Array<Maybe<_FieldConfig>>>;
@@ -2712,49 +2528,49 @@ export type _AssetMeta = {
 };
 
 export type _Audit = {
-  __typename?: '_Audit';
-  account?: Maybe<Scalars['String']>;
-  date?: Maybe<Scalars['String']>;
-  user?: Maybe<Scalars['String']>;
+  __typename?: "_Audit";
+  account?: Maybe<Scalars["String"]>;
+  date?: Maybe<Scalars["String"]>;
+  user?: Maybe<Scalars["String"]>;
 };
 
 export type _AvailabilityMeta = {
-  __typename?: '_AvailabilityMeta';
+  __typename?: "_AvailabilityMeta";
   created?: Maybe<_Audit>;
   modified?: Maybe<_Audit>;
 };
 
 export type _BrandGlobal = _Global & {
-  __typename?: '_BrandGlobal';
+  __typename?: "_BrandGlobal";
   created?: Maybe<_Audit>;
   history?: Maybe<Array<Maybe<_BrandGlobal>>>;
   modified?: Maybe<_Audit>;
   publish_stage?: Maybe<PublishStage>;
-  version?: Maybe<Scalars['Int']>;
+  version?: Maybe<Scalars["Int"]>;
 };
 
 export type _BrandLanguage = _Language & {
-  __typename?: '_BrandLanguage';
+  __typename?: "_BrandLanguage";
   created?: Maybe<_Audit>;
   history?: Maybe<Array<Maybe<_BrandLanguage>>>;
-  language?: Maybe<Scalars['String']>;
+  language?: Maybe<Scalars["String"]>;
   modified?: Maybe<_Audit>;
   publish_stage?: Maybe<PublishStage>;
-  release_date?: Maybe<Scalars['String']>;
-  slug?: Maybe<Scalars['String']>;
-  synopsis_long?: Maybe<Scalars['String']>;
-  synopsis_medium?: Maybe<Scalars['String']>;
-  synopsis_short?: Maybe<Scalars['String']>;
-  title?: Maybe<Scalars['String']>;
-  title_long?: Maybe<Scalars['String']>;
-  title_medium?: Maybe<Scalars['String']>;
-  title_short?: Maybe<Scalars['String']>;
-  version?: Maybe<Scalars['Int']>;
+  release_date?: Maybe<Scalars["String"]>;
+  slug?: Maybe<Scalars["String"]>;
+  synopsis_long?: Maybe<Scalars["String"]>;
+  synopsis_medium?: Maybe<Scalars["String"]>;
+  synopsis_short?: Maybe<Scalars["String"]>;
+  title?: Maybe<Scalars["String"]>;
+  title_long?: Maybe<Scalars["String"]>;
+  title_medium?: Maybe<Scalars["String"]>;
+  title_short?: Maybe<Scalars["String"]>;
+  version?: Maybe<Scalars["Int"]>;
 };
 
 export type _BrandMeta = {
-  __typename?: '_BrandMeta';
-  available_languages?: Maybe<Array<Maybe<Scalars['String']>>>;
+  __typename?: "_BrandMeta";
+  available_languages?: Maybe<Array<Maybe<Scalars["String"]>>>;
   created?: Maybe<_Audit>;
   data_source?: Maybe<Brand>;
   field_config?: Maybe<Array<Maybe<_FieldConfig>>>;
@@ -2765,30 +2581,30 @@ export type _BrandMeta = {
 };
 
 export type _CreditGlobal = _Global & {
-  __typename?: '_CreditGlobal';
+  __typename?: "_CreditGlobal";
   created?: Maybe<_Audit>;
   history?: Maybe<Array<Maybe<_CreditGlobal>>>;
   modified?: Maybe<_Audit>;
-  position?: Maybe<Scalars['Int']>;
+  position?: Maybe<Scalars["Int"]>;
   publish_stage?: Maybe<PublishStage>;
-  version?: Maybe<Scalars['Int']>;
+  version?: Maybe<Scalars["Int"]>;
 };
 
 export type _CreditLanguage = _Language & {
-  __typename?: '_CreditLanguage';
-  character?: Maybe<Scalars['String']>;
+  __typename?: "_CreditLanguage";
+  character?: Maybe<Scalars["String"]>;
   created?: Maybe<_Audit>;
   history?: Maybe<Array<Maybe<_CreditLanguage>>>;
-  language?: Maybe<Scalars['String']>;
+  language?: Maybe<Scalars["String"]>;
   modified?: Maybe<_Audit>;
   publish_stage?: Maybe<PublishStage>;
-  slug?: Maybe<Scalars['String']>;
-  version?: Maybe<Scalars['Int']>;
+  slug?: Maybe<Scalars["String"]>;
+  version?: Maybe<Scalars["Int"]>;
 };
 
 export type _CreditMeta = {
-  __typename?: '_CreditMeta';
-  available_languages?: Maybe<Array<Maybe<Scalars['String']>>>;
+  __typename?: "_CreditMeta";
+  available_languages?: Maybe<Array<Maybe<Scalars["String"]>>>;
   created?: Maybe<_Audit>;
   data_source?: Maybe<Credit>;
   field_config?: Maybe<Array<Maybe<_FieldConfig>>>;
@@ -2799,50 +2615,50 @@ export type _CreditMeta = {
 };
 
 export type _DimensionMeta = {
-  __typename?: '_DimensionMeta';
+  __typename?: "_DimensionMeta";
   created?: Maybe<_Audit>;
   modified?: Maybe<_Audit>;
   values?: Maybe<Array<Maybe<DimensionValue>>>;
 };
 
 export type _DimensionValueMeta = {
-  __typename?: '_DimensionValueMeta';
+  __typename?: "_DimensionValueMeta";
   created?: Maybe<_Audit>;
   modified?: Maybe<_Audit>;
 };
 
 export type _EpisodeGlobal = _Global & {
-  __typename?: '_EpisodeGlobal';
+  __typename?: "_EpisodeGlobal";
   created?: Maybe<_Audit>;
-  episode_number?: Maybe<Scalars['Int']>;
+  episode_number?: Maybe<Scalars["Int"]>;
   history?: Maybe<Array<Maybe<_EpisodeGlobal>>>;
   modified?: Maybe<_Audit>;
   publish_stage?: Maybe<PublishStage>;
-  version?: Maybe<Scalars['Int']>;
+  version?: Maybe<Scalars["Int"]>;
 };
 
 export type _EpisodeLanguage = _Language & {
-  __typename?: '_EpisodeLanguage';
+  __typename?: "_EpisodeLanguage";
   created?: Maybe<_Audit>;
   history?: Maybe<Array<Maybe<_EpisodeLanguage>>>;
-  language?: Maybe<Scalars['String']>;
+  language?: Maybe<Scalars["String"]>;
   modified?: Maybe<_Audit>;
   publish_stage?: Maybe<PublishStage>;
-  release_date?: Maybe<Scalars['String']>;
-  slug?: Maybe<Scalars['String']>;
-  synopsis_long?: Maybe<Scalars['String']>;
-  synopsis_medium?: Maybe<Scalars['String']>;
-  synopsis_short?: Maybe<Scalars['String']>;
-  title?: Maybe<Scalars['String']>;
-  title_long?: Maybe<Scalars['String']>;
-  title_medium?: Maybe<Scalars['String']>;
-  title_short?: Maybe<Scalars['String']>;
-  version?: Maybe<Scalars['Int']>;
+  release_date?: Maybe<Scalars["String"]>;
+  slug?: Maybe<Scalars["String"]>;
+  synopsis_long?: Maybe<Scalars["String"]>;
+  synopsis_medium?: Maybe<Scalars["String"]>;
+  synopsis_short?: Maybe<Scalars["String"]>;
+  title?: Maybe<Scalars["String"]>;
+  title_long?: Maybe<Scalars["String"]>;
+  title_medium?: Maybe<Scalars["String"]>;
+  title_short?: Maybe<Scalars["String"]>;
+  version?: Maybe<Scalars["Int"]>;
 };
 
 export type _EpisodeMeta = {
-  __typename?: '_EpisodeMeta';
-  available_languages?: Maybe<Array<Maybe<Scalars['String']>>>;
+  __typename?: "_EpisodeMeta";
+  available_languages?: Maybe<Array<Maybe<Scalars["String"]>>>;
   created?: Maybe<_Audit>;
   data_source?: Maybe<Episode>;
   field_config?: Maybe<Array<Maybe<_FieldConfig>>>;
@@ -2853,37 +2669,37 @@ export type _EpisodeMeta = {
 };
 
 export type _FieldConfig = {
-  __typename?: '_FieldConfig';
-  name: Scalars['String'];
-  use_data_source?: Maybe<Scalars['Boolean']>;
+  __typename?: "_FieldConfig";
+  name: Scalars["String"];
+  use_data_source?: Maybe<Scalars["Boolean"]>;
 };
 
 export type _GenreGlobal = _Global & {
-  __typename?: '_GenreGlobal';
+  __typename?: "_GenreGlobal";
   created?: Maybe<_Audit>;
   history?: Maybe<Array<Maybe<_GenreGlobal>>>;
   modified?: Maybe<_Audit>;
   publish_stage?: Maybe<PublishStage>;
-  version?: Maybe<Scalars['Int']>;
+  version?: Maybe<Scalars["Int"]>;
 };
 
 export type _GenreLanguage = _Language & {
-  __typename?: '_GenreLanguage';
+  __typename?: "_GenreLanguage";
   created?: Maybe<_Audit>;
   history?: Maybe<Array<Maybe<_GenreLanguage>>>;
-  language?: Maybe<Scalars['String']>;
-  metadata_source?: Maybe<Scalars['String']>;
+  language?: Maybe<Scalars["String"]>;
+  metadata_source?: Maybe<Scalars["String"]>;
   modified?: Maybe<_Audit>;
-  name?: Maybe<Scalars['String']>;
+  name?: Maybe<Scalars["String"]>;
   parents?: Maybe<Array<Maybe<Metadata>>>;
   publish_stage?: Maybe<PublishStage>;
-  slug?: Maybe<Scalars['String']>;
-  version?: Maybe<Scalars['Int']>;
+  slug?: Maybe<Scalars["String"]>;
+  version?: Maybe<Scalars["Int"]>;
 };
 
 export type _GenreMeta = {
-  __typename?: '_GenreMeta';
-  available_languages?: Maybe<Array<Maybe<Scalars['String']>>>;
+  __typename?: "_GenreMeta";
+  available_languages?: Maybe<Array<Maybe<Scalars["String"]>>>;
   created?: Maybe<_Audit>;
   data_source?: Maybe<Genre>;
   field_config?: Maybe<Array<Maybe<_FieldConfig>>>;
@@ -2898,36 +2714,36 @@ export type _Global = {
   history?: Maybe<Array<Maybe<_Global>>>;
   modified?: Maybe<_Audit>;
   publish_stage?: Maybe<PublishStage>;
-  version?: Maybe<Scalars['Int']>;
+  version?: Maybe<Scalars["Int"]>;
 };
 
 export type _ImageGlobal = _Global & {
-  __typename?: '_ImageGlobal';
+  __typename?: "_ImageGlobal";
   created?: Maybe<_Audit>;
   history?: Maybe<Array<Maybe<_ImageGlobal>>>;
   modified?: Maybe<_Audit>;
   publish_stage?: Maybe<PublishStage>;
-  type?: Maybe<Scalars['String']>;
-  url?: Maybe<Scalars['String']>;
-  version?: Maybe<Scalars['Int']>;
+  type?: Maybe<Scalars["String"]>;
+  url?: Maybe<Scalars["String"]>;
+  version?: Maybe<Scalars["Int"]>;
 };
 
 export type _ImageLanguage = _Language & {
-  __typename?: '_ImageLanguage';
+  __typename?: "_ImageLanguage";
   created?: Maybe<_Audit>;
-  description?: Maybe<Scalars['String']>;
+  description?: Maybe<Scalars["String"]>;
   history?: Maybe<Array<Maybe<_ImageLanguage>>>;
-  language?: Maybe<Scalars['String']>;
+  language?: Maybe<Scalars["String"]>;
   modified?: Maybe<_Audit>;
   publish_stage?: Maybe<PublishStage>;
-  slug?: Maybe<Scalars['String']>;
-  title?: Maybe<Scalars['String']>;
-  version?: Maybe<Scalars['Int']>;
+  slug?: Maybe<Scalars["String"]>;
+  title?: Maybe<Scalars["String"]>;
+  version?: Maybe<Scalars["Int"]>;
 };
 
 export type _ImageMeta = {
-  __typename?: '_ImageMeta';
-  available_languages?: Maybe<Array<Maybe<Scalars['String']>>>;
+  __typename?: "_ImageMeta";
+  available_languages?: Maybe<Array<Maybe<Scalars["String"]>>>;
   created?: Maybe<_Audit>;
   data_source?: Maybe<Image>;
   field_config?: Maybe<Array<Maybe<_FieldConfig>>>;
@@ -2940,45 +2756,45 @@ export type _ImageMeta = {
 export type _Language = {
   created?: Maybe<_Audit>;
   history?: Maybe<Array<Maybe<_Language>>>;
-  language?: Maybe<Scalars['String']>;
+  language?: Maybe<Scalars["String"]>;
   modified?: Maybe<_Audit>;
   publish_stage?: Maybe<PublishStage>;
-  slug?: Maybe<Scalars['String']>;
-  version?: Maybe<Scalars['Int']>;
+  slug?: Maybe<Scalars["String"]>;
+  version?: Maybe<Scalars["Int"]>;
 };
 
 export type _MovieGlobal = _Global & {
-  __typename?: '_MovieGlobal';
+  __typename?: "_MovieGlobal";
   created?: Maybe<_Audit>;
   history?: Maybe<Array<Maybe<_MovieGlobal>>>;
   modified?: Maybe<_Audit>;
   publish_stage?: Maybe<PublishStage>;
-  version?: Maybe<Scalars['Int']>;
-  year_of_release?: Maybe<Scalars['Int']>;
+  version?: Maybe<Scalars["Int"]>;
+  year_of_release?: Maybe<Scalars["Int"]>;
 };
 
 export type _MovieLanguage = _Language & {
-  __typename?: '_MovieLanguage';
+  __typename?: "_MovieLanguage";
   created?: Maybe<_Audit>;
   history?: Maybe<Array<Maybe<_MovieLanguage>>>;
-  language?: Maybe<Scalars['String']>;
+  language?: Maybe<Scalars["String"]>;
   modified?: Maybe<_Audit>;
   publish_stage?: Maybe<PublishStage>;
-  release_date?: Maybe<Scalars['String']>;
-  slug?: Maybe<Scalars['String']>;
-  synopsis_long?: Maybe<Scalars['String']>;
-  synopsis_medium?: Maybe<Scalars['String']>;
-  synopsis_short?: Maybe<Scalars['String']>;
-  title?: Maybe<Scalars['String']>;
-  title_long?: Maybe<Scalars['String']>;
-  title_medium?: Maybe<Scalars['String']>;
-  title_short?: Maybe<Scalars['String']>;
-  version?: Maybe<Scalars['Int']>;
+  release_date?: Maybe<Scalars["String"]>;
+  slug?: Maybe<Scalars["String"]>;
+  synopsis_long?: Maybe<Scalars["String"]>;
+  synopsis_medium?: Maybe<Scalars["String"]>;
+  synopsis_short?: Maybe<Scalars["String"]>;
+  title?: Maybe<Scalars["String"]>;
+  title_long?: Maybe<Scalars["String"]>;
+  title_medium?: Maybe<Scalars["String"]>;
+  title_short?: Maybe<Scalars["String"]>;
+  version?: Maybe<Scalars["Int"]>;
 };
 
 export type _MovieMeta = {
-  __typename?: '_MovieMeta';
-  available_languages?: Maybe<Array<Maybe<Scalars['String']>>>;
+  __typename?: "_MovieMeta";
+  available_languages?: Maybe<Array<Maybe<Scalars["String"]>>>;
   created?: Maybe<_Audit>;
   data_source?: Maybe<Movie>;
   field_config?: Maybe<Array<Maybe<_FieldConfig>>>;
@@ -2989,29 +2805,29 @@ export type _MovieMeta = {
 };
 
 export type _ParentalGuidanceGlobal = _Global & {
-  __typename?: '_ParentalGuidanceGlobal';
+  __typename?: "_ParentalGuidanceGlobal";
   created?: Maybe<_Audit>;
   history?: Maybe<Array<Maybe<_ParentalGuidanceGlobal>>>;
   modified?: Maybe<_Audit>;
   publish_stage?: Maybe<PublishStage>;
-  version?: Maybe<Scalars['Int']>;
+  version?: Maybe<Scalars["Int"]>;
 };
 
 export type _ParentalGuidanceLanguage = _Language & {
-  __typename?: '_ParentalGuidanceLanguage';
+  __typename?: "_ParentalGuidanceLanguage";
   created?: Maybe<_Audit>;
   history?: Maybe<Array<Maybe<_ParentalGuidanceLanguage>>>;
-  language?: Maybe<Scalars['String']>;
+  language?: Maybe<Scalars["String"]>;
   modified?: Maybe<_Audit>;
   publish_stage?: Maybe<PublishStage>;
-  reason?: Maybe<Scalars['String']>;
-  slug?: Maybe<Scalars['String']>;
-  version?: Maybe<Scalars['Int']>;
+  reason?: Maybe<Scalars["String"]>;
+  slug?: Maybe<Scalars["String"]>;
+  version?: Maybe<Scalars["Int"]>;
 };
 
 export type _ParentalGuidanceMeta = {
-  __typename?: '_ParentalGuidanceMeta';
-  available_languages?: Maybe<Array<Maybe<Scalars['String']>>>;
+  __typename?: "_ParentalGuidanceMeta";
+  available_languages?: Maybe<Array<Maybe<Scalars["String"]>>>;
   created?: Maybe<_Audit>;
   data_source?: Maybe<ParentalGuidance>;
   field_config?: Maybe<Array<Maybe<_FieldConfig>>>;
@@ -3022,38 +2838,38 @@ export type _ParentalGuidanceMeta = {
 };
 
 export type _PersonGlobal = _Global & {
-  __typename?: '_PersonGlobal';
+  __typename?: "_PersonGlobal";
   created?: Maybe<_Audit>;
-  date_of_birth?: Maybe<Scalars['AWSDateTime']>;
+  date_of_birth?: Maybe<Scalars["AWSDateTime"]>;
   history?: Maybe<Array<Maybe<_PersonGlobal>>>;
   modified?: Maybe<_Audit>;
   publish_stage?: Maybe<PublishStage>;
-  version?: Maybe<Scalars['Int']>;
+  version?: Maybe<Scalars["Int"]>;
 };
 
 export type _PersonLanguage = _Language & {
-  __typename?: '_PersonLanguage';
-  abbreviation?: Maybe<Scalars['String']>;
-  alias?: Maybe<Scalars['String']>;
-  bio_long?: Maybe<Scalars['String']>;
-  bio_medium?: Maybe<Scalars['String']>;
-  bio_short?: Maybe<Scalars['String']>;
+  __typename?: "_PersonLanguage";
+  abbreviation?: Maybe<Scalars["String"]>;
+  alias?: Maybe<Scalars["String"]>;
+  bio_long?: Maybe<Scalars["String"]>;
+  bio_medium?: Maybe<Scalars["String"]>;
+  bio_short?: Maybe<Scalars["String"]>;
   created?: Maybe<_Audit>;
-  gender?: Maybe<Scalars['String']>;
+  gender?: Maybe<Scalars["String"]>;
   history?: Maybe<Array<Maybe<_PersonLanguage>>>;
-  language?: Maybe<Scalars['String']>;
+  language?: Maybe<Scalars["String"]>;
   modified?: Maybe<_Audit>;
-  name?: Maybe<Scalars['String']>;
-  name_sort?: Maybe<Scalars['String']>;
-  place_of_birth?: Maybe<Scalars['String']>;
+  name?: Maybe<Scalars["String"]>;
+  name_sort?: Maybe<Scalars["String"]>;
+  place_of_birth?: Maybe<Scalars["String"]>;
   publish_stage?: Maybe<PublishStage>;
-  slug?: Maybe<Scalars['String']>;
-  version?: Maybe<Scalars['Int']>;
+  slug?: Maybe<Scalars["String"]>;
+  version?: Maybe<Scalars["Int"]>;
 };
 
 export type _PersonMeta = {
-  __typename?: '_PersonMeta';
-  available_languages?: Maybe<Array<Maybe<Scalars['String']>>>;
+  __typename?: "_PersonMeta";
+  available_languages?: Maybe<Array<Maybe<Scalars["String"]>>>;
   created?: Maybe<_Audit>;
   data_source?: Maybe<Person>;
   field_config?: Maybe<Array<Maybe<_FieldConfig>>>;
@@ -3064,31 +2880,31 @@ export type _PersonMeta = {
 };
 
 export type _RatingGlobal = _Global & {
-  __typename?: '_RatingGlobal';
+  __typename?: "_RatingGlobal";
   created?: Maybe<_Audit>;
   history?: Maybe<Array<Maybe<_RatingGlobal>>>;
   modified?: Maybe<_Audit>;
   publish_stage?: Maybe<PublishStage>;
-  scheme?: Maybe<Scalars['String']>;
-  value: Scalars['String'];
-  version?: Maybe<Scalars['Int']>;
+  scheme?: Maybe<Scalars["String"]>;
+  value: Scalars["String"];
+  version?: Maybe<Scalars["Int"]>;
 };
 
 export type _RatingLanguage = _Language & {
-  __typename?: '_RatingLanguage';
+  __typename?: "_RatingLanguage";
   created?: Maybe<_Audit>;
-  description?: Maybe<Scalars['String']>;
+  description?: Maybe<Scalars["String"]>;
   history?: Maybe<Array<Maybe<_RatingLanguage>>>;
-  language?: Maybe<Scalars['String']>;
+  language?: Maybe<Scalars["String"]>;
   modified?: Maybe<_Audit>;
   publish_stage?: Maybe<PublishStage>;
-  slug?: Maybe<Scalars['String']>;
-  version?: Maybe<Scalars['Int']>;
+  slug?: Maybe<Scalars["String"]>;
+  version?: Maybe<Scalars["Int"]>;
 };
 
 export type _RatingMeta = {
-  __typename?: '_RatingMeta';
-  available_languages?: Maybe<Array<Maybe<Scalars['String']>>>;
+  __typename?: "_RatingMeta";
+  available_languages?: Maybe<Array<Maybe<Scalars["String"]>>>;
   created?: Maybe<_Audit>;
   data_source?: Maybe<Rating>;
   field_config?: Maybe<Array<Maybe<_FieldConfig>>>;
@@ -3099,29 +2915,29 @@ export type _RatingMeta = {
 };
 
 export type _RoleGlobal = _Global & {
-  __typename?: '_RoleGlobal';
+  __typename?: "_RoleGlobal";
   created?: Maybe<_Audit>;
   history?: Maybe<Array<Maybe<_RoleGlobal>>>;
   modified?: Maybe<_Audit>;
   publish_stage?: Maybe<PublishStage>;
-  version?: Maybe<Scalars['Int']>;
+  version?: Maybe<Scalars["Int"]>;
 };
 
 export type _RoleLanguage = _Language & {
-  __typename?: '_RoleLanguage';
+  __typename?: "_RoleLanguage";
   created?: Maybe<_Audit>;
   history?: Maybe<Array<Maybe<_RoleLanguage>>>;
-  language?: Maybe<Scalars['String']>;
+  language?: Maybe<Scalars["String"]>;
   modified?: Maybe<_Audit>;
   publish_stage?: Maybe<PublishStage>;
-  slug?: Maybe<Scalars['String']>;
-  title?: Maybe<Scalars['String']>;
-  version?: Maybe<Scalars['Int']>;
+  slug?: Maybe<Scalars["String"]>;
+  title?: Maybe<Scalars["String"]>;
+  version?: Maybe<Scalars["Int"]>;
 };
 
 export type _RoleMeta = {
-  __typename?: '_RoleMeta';
-  available_languages?: Maybe<Array<Maybe<Scalars['String']>>>;
+  __typename?: "_RoleMeta";
+  available_languages?: Maybe<Array<Maybe<Scalars["String"]>>>;
   created?: Maybe<_Audit>;
   data_source?: Maybe<Role>;
   field_config?: Maybe<Array<Maybe<_FieldConfig>>>;
@@ -3132,38 +2948,38 @@ export type _RoleMeta = {
 };
 
 export type _SeasonGlobal = _Global & {
-  __typename?: '_SeasonGlobal';
+  __typename?: "_SeasonGlobal";
   created?: Maybe<_Audit>;
   history?: Maybe<Array<Maybe<_SeasonGlobal>>>;
   modified?: Maybe<_Audit>;
-  number_of_episodes?: Maybe<Scalars['Int']>;
+  number_of_episodes?: Maybe<Scalars["Int"]>;
   publish_stage?: Maybe<PublishStage>;
-  season_number?: Maybe<Scalars['Int']>;
-  version?: Maybe<Scalars['Int']>;
+  season_number?: Maybe<Scalars["Int"]>;
+  version?: Maybe<Scalars["Int"]>;
 };
 
 export type _SeasonLanguage = _Language & {
-  __typename?: '_SeasonLanguage';
+  __typename?: "_SeasonLanguage";
   created?: Maybe<_Audit>;
   history?: Maybe<Array<Maybe<_EpisodeLanguage>>>;
-  language?: Maybe<Scalars['String']>;
+  language?: Maybe<Scalars["String"]>;
   modified?: Maybe<_Audit>;
   publish_stage?: Maybe<PublishStage>;
-  release_date?: Maybe<Scalars['String']>;
-  slug?: Maybe<Scalars['String']>;
-  synopsis_long?: Maybe<Scalars['String']>;
-  synopsis_medium?: Maybe<Scalars['String']>;
-  synopsis_short?: Maybe<Scalars['String']>;
-  title?: Maybe<Scalars['String']>;
-  title_long?: Maybe<Scalars['String']>;
-  title_medium?: Maybe<Scalars['String']>;
-  title_short?: Maybe<Scalars['String']>;
-  version?: Maybe<Scalars['Int']>;
+  release_date?: Maybe<Scalars["String"]>;
+  slug?: Maybe<Scalars["String"]>;
+  synopsis_long?: Maybe<Scalars["String"]>;
+  synopsis_medium?: Maybe<Scalars["String"]>;
+  synopsis_short?: Maybe<Scalars["String"]>;
+  title?: Maybe<Scalars["String"]>;
+  title_long?: Maybe<Scalars["String"]>;
+  title_medium?: Maybe<Scalars["String"]>;
+  title_short?: Maybe<Scalars["String"]>;
+  version?: Maybe<Scalars["Int"]>;
 };
 
 export type _SeasonMeta = {
-  __typename?: '_SeasonMeta';
-  available_languages?: Maybe<Array<Maybe<Scalars['String']>>>;
+  __typename?: "_SeasonMeta";
+  available_languages?: Maybe<Array<Maybe<Scalars["String"]>>>;
   created?: Maybe<_Audit>;
   data_source?: Maybe<Season>;
   field_config?: Maybe<Array<Maybe<_FieldConfig>>>;
@@ -3174,38 +2990,38 @@ export type _SeasonMeta = {
 };
 
 export type _SetGlobal = _Global & {
-  __typename?: '_SetGlobal';
+  __typename?: "_SetGlobal";
   created?: Maybe<_Audit>;
   history?: Maybe<Array<Maybe<_SetGlobal>>>;
   modified?: Maybe<_Audit>;
   publish_stage?: Maybe<PublishStage>;
-  type?: Maybe<Scalars['String']>;
-  version?: Maybe<Scalars['Int']>;
+  type?: Maybe<Scalars["String"]>;
+  version?: Maybe<Scalars["Int"]>;
 };
 
 export type _SetLanguage = _Language & {
-  __typename?: '_SetLanguage';
+  __typename?: "_SetLanguage";
   created?: Maybe<_Audit>;
-  description?: Maybe<Scalars['String']>;
+  description?: Maybe<Scalars["String"]>;
   history?: Maybe<Array<Maybe<_SetLanguage>>>;
-  language?: Maybe<Scalars['String']>;
+  language?: Maybe<Scalars["String"]>;
   modified?: Maybe<_Audit>;
   publish_stage?: Maybe<PublishStage>;
-  release_date?: Maybe<Scalars['String']>;
-  slug?: Maybe<Scalars['String']>;
-  synopsis_long?: Maybe<Scalars['String']>;
-  synopsis_medium?: Maybe<Scalars['String']>;
-  synopsis_short?: Maybe<Scalars['String']>;
-  title?: Maybe<Scalars['String']>;
-  title_long?: Maybe<Scalars['String']>;
-  title_medium?: Maybe<Scalars['String']>;
-  title_short?: Maybe<Scalars['String']>;
-  version?: Maybe<Scalars['Int']>;
+  release_date?: Maybe<Scalars["String"]>;
+  slug?: Maybe<Scalars["String"]>;
+  synopsis_long?: Maybe<Scalars["String"]>;
+  synopsis_medium?: Maybe<Scalars["String"]>;
+  synopsis_short?: Maybe<Scalars["String"]>;
+  title?: Maybe<Scalars["String"]>;
+  title_long?: Maybe<Scalars["String"]>;
+  title_medium?: Maybe<Scalars["String"]>;
+  title_short?: Maybe<Scalars["String"]>;
+  version?: Maybe<Scalars["Int"]>;
 };
 
 export type _SetMeta = {
-  __typename?: '_SetMeta';
-  available_languages?: Maybe<Array<Maybe<Scalars['String']>>>;
+  __typename?: "_SetMeta";
+  available_languages?: Maybe<Array<Maybe<Scalars["String"]>>>;
   created?: Maybe<_Audit>;
   data_source?: Maybe<Set>;
   field_config?: Maybe<Array<Maybe<_FieldConfig>>>;
@@ -3216,30 +3032,30 @@ export type _SetMeta = {
 };
 
 export type _TagGlobal = _Global & {
-  __typename?: '_TagGlobal';
+  __typename?: "_TagGlobal";
   created?: Maybe<_Audit>;
   history?: Maybe<Array<Maybe<_TagGlobal>>>;
   modified?: Maybe<_Audit>;
   publish_stage?: Maybe<PublishStage>;
-  tag_category?: Maybe<Scalars['String']>;
-  version?: Maybe<Scalars['Int']>;
+  tag_category?: Maybe<Scalars["String"]>;
+  version?: Maybe<Scalars["Int"]>;
 };
 
 export type _TagLanguage = _Language & {
-  __typename?: '_TagLanguage';
+  __typename?: "_TagLanguage";
   created?: Maybe<_Audit>;
   history?: Maybe<Array<Maybe<_TagLanguage>>>;
-  language?: Maybe<Scalars['String']>;
+  language?: Maybe<Scalars["String"]>;
   modified?: Maybe<_Audit>;
-  name?: Maybe<Scalars['String']>;
+  name?: Maybe<Scalars["String"]>;
   publish_stage?: Maybe<PublishStage>;
-  slug?: Maybe<Scalars['String']>;
-  version?: Maybe<Scalars['Int']>;
+  slug?: Maybe<Scalars["String"]>;
+  version?: Maybe<Scalars["Int"]>;
 };
 
 export type _TagMeta = {
-  __typename?: '_TagMeta';
-  available_languages?: Maybe<Array<Maybe<Scalars['String']>>>;
+  __typename?: "_TagMeta";
+  available_languages?: Maybe<Array<Maybe<Scalars["String"]>>>;
   created?: Maybe<_Audit>;
   data_source?: Maybe<Tag>;
   field_config?: Maybe<Array<Maybe<_FieldConfig>>>;
@@ -3250,30 +3066,30 @@ export type _TagMeta = {
 };
 
 export type _ThemeGlobal = _Global & {
-  __typename?: '_ThemeGlobal';
+  __typename?: "_ThemeGlobal";
   created?: Maybe<_Audit>;
   history?: Maybe<Array<Maybe<_ThemeGlobal>>>;
   modified?: Maybe<_Audit>;
   publish_stage?: Maybe<PublishStage>;
-  version?: Maybe<Scalars['Int']>;
+  version?: Maybe<Scalars["Int"]>;
 };
 
 export type _ThemeLanguage = _Language & {
-  __typename?: '_ThemeLanguage';
+  __typename?: "_ThemeLanguage";
   created?: Maybe<_Audit>;
   history?: Maybe<Array<Maybe<_ThemeLanguage>>>;
-  language?: Maybe<Scalars['String']>;
-  metadata_source?: Maybe<Scalars['String']>;
+  language?: Maybe<Scalars["String"]>;
+  metadata_source?: Maybe<Scalars["String"]>;
   modified?: Maybe<_Audit>;
-  name?: Maybe<Scalars['String']>;
+  name?: Maybe<Scalars["String"]>;
   publish_stage?: Maybe<PublishStage>;
-  slug?: Maybe<Scalars['String']>;
-  version?: Maybe<Scalars['Int']>;
+  slug?: Maybe<Scalars["String"]>;
+  version?: Maybe<Scalars["Int"]>;
 };
 
 export type _ThemeMeta = {
-  __typename?: '_ThemeMeta';
-  available_languages?: Maybe<Array<Maybe<Scalars['String']>>>;
+  __typename?: "_ThemeMeta";
+  available_languages?: Maybe<Array<Maybe<Scalars["String"]>>>;
   created?: Maybe<_Audit>;
   data_source?: Maybe<Theme>;
   field_config?: Maybe<Array<Maybe<_FieldConfig>>>;


### PR DESCRIPTION
<!-- Enter a very brief description of change -->
<!-- Add any optional commentary which may help the code reviewer. -->
- Adds an additional `useSingleObjectRelationships` hook which separately fetches the relationships for a requested object.
- We do it this say so that the initial request for the object is as fast as possible by only requesting basic metadata (no relationships)

<!-- Please tick all relevant change types this PR commits -->
<!-- Delete non-relevant lines -->
* [x] Feature
* [x] Refactoring (no functional changes, no API changes)

