### PR TITLE
feat: Use external ID to update availability on objects

### DIFF
--- a/packages/ingestor/src/lib/interfaces/saas.ts
+++ b/packages/ingestor/src/lib/interfaces/saas.ts
@@ -15,8 +15,8 @@ export interface GraphQLMetadata {
   tags: GraphQLBaseObject[];
   credits: GraphQLBaseObject[];
   availability: {
-    default?: GraphQLBaseObject;
-    all: GraphQLBaseObject[];
+    default?: string;
+    all: string[];
   };
   dimensions: {
     affiliates: GraphQLBaseObject[];

--- a/packages/ingestor/src/lib/skylark/saas/availability.ts
+++ b/packages/ingestor/src/lib/skylark/saas/availability.ts
@@ -242,12 +242,18 @@ export const createOrUpdateAvailability = async (
   const existingObjects = await getExistingObjects("Availability", externalIds);
 
   if (existingObjects.length > 0) {
-    throw new Error(
-      "Updating Availability is currently broken\nWorkaround: use a new account-id\n  1. Pagination is broken (SL-2259)\n  2. Updates timeout as all objects have to be updated with the new schedule (SL-2260)"
+    // eslint-disable-next-line no-console
+    console.warn(
+      "Updating Availability is currently broken\n  1. Pagination is broken (SL-2259)\n  2. Updates timeout as all objects have to be updated with the new schedule (SL-2260)\nWill create any new availabilities, but won't update existing ones."
     );
   }
 
-  const operations = schedules.reduce(
+  const schedulesToCreate = schedules.filter(({ id }) => !existingObjects.includes(id));
+  if(schedulesToCreate.length === 0) {
+    return;
+  }
+
+  const operations = schedulesToCreate.reduce(
     (previousOperations, { id, ...record }) => {
       const fields = record.fields as AvailabilityTableFields;
 
@@ -351,10 +357,8 @@ export const createOrUpdateAvailability = async (
     {} as { [key: string]: object }
   );
 
-  const arr = await mutateMultipleObjects<GraphQLBaseObject>(
+  await mutateMultipleObjects<GraphQLBaseObject>(
     "createOrUpdateAvailability",
     operations
   );
-
-  return arr;
 };

--- a/packages/ingestor/src/lib/skylark/saas/availability.ts
+++ b/packages/ingestor/src/lib/skylark/saas/availability.ts
@@ -244,12 +244,14 @@ export const createOrUpdateAvailability = async (
   if (existingObjects.length > 0) {
     // eslint-disable-next-line no-console
     console.warn(
-      "Updating Availability is currently broken\n  1. Pagination is broken (SL-2259)\n  2. Updates timeout as all objects have to be updated with the new schedule (SL-2260)\nWill create any new availabilities, but won't update existing ones."
+      "Updating Availability is currently broken\n  1. Updates timeout as all objects have to be updated with the new schedule (SL-2260)\nWill create any new availabilities, but won't update existing ones."
     );
   }
 
-  const schedulesToCreate = schedules.filter(({ id }) => !existingObjects.includes(id));
-  if(schedulesToCreate.length === 0) {
+  const schedulesToCreate = schedules.filter(
+    ({ id }) => !existingObjects.includes(id)
+  );
+  if (schedulesToCreate.length === 0) {
     return;
   }
 

--- a/packages/ingestor/src/lib/skylark/saas/create.test.ts
+++ b/packages/ingestor/src/lib/skylark/saas/create.test.ts
@@ -136,16 +136,12 @@ describe("saas/create.ts", () => {
         records as Records<FieldSet>,
         {
           all: [],
-          default: {
-            uid: "default-uid-1",
-            external_id: "default-external-id-1",
-            slug: "default-slug-1",
-          },
+          default: "default-external-id-1",
         }
       );
       expect(graphQLClient.request).toHaveBeenNthCalledWith(
         3,
-        'mutation createOrUpdateBrands { updateBrandbrand_1: updateBrand (external_id: "brand_1", brand: {title: "Brand 1", availability: {link: ["default-uid-1"]}}) { uid slug external_id } }'
+        'mutation createOrUpdateBrands { updateBrandbrand_1: updateBrand (external_id: "brand_1", brand: {title: "Brand 1", availability: {link: ["default-external-id-1"]}}) { uid slug external_id } }'
       );
     });
   });

--- a/packages/ingestor/src/lib/skylark/saas/sets.test.ts
+++ b/packages/ingestor/src/lib/skylark/saas/sets.test.ts
@@ -53,11 +53,7 @@ describe("saas/sets.ts", () => {
   const metadata: Partial<GraphQLMetadata> = {
     availability: {
       all: [],
-      default: {
-        uid: "availability-1",
-        external_id: "availability-1",
-        slug: "availability-1",
-      },
+      default: "availability-1",
     },
   };
 

--- a/packages/ingestor/src/lib/skylark/saas/utils.test.ts
+++ b/packages/ingestor/src/lib/skylark/saas/utils.test.ts
@@ -165,23 +165,11 @@ describe("saas/utils.ts", () => {
   describe("getGraphQLObjectAvailability", () => {
     const availability: GraphQLMetadata["availability"] = {
       all: [
-        {
-          uid: "availability-1-uid",
-          external_id: "availability-1-ext-id",
-          slug: "availability-1-slug",
-        },
-        {
-          uid: "availability-2-uid",
-          external_id: "availability-2-ext-id",
-          slug: "availability-2-slug",
-        },
-        {
-          uid: "availability-3-uid",
-          external_id: "availability-3-ext-id",
-          slug: "availability-3-slug",
-        },
+        "availability-1-ext-id",
+        "availability-2-ext-id",
+        "availability-3-ext-id",
       ],
-      default: { uid: "default-uid", external_id: "default", slug: "default" },
+      default: "default-ext-id",
     };
 
     it("returns an empty link array when availabilityField is empty and no default is given", () => {
@@ -193,17 +181,17 @@ describe("saas/utils.ts", () => {
     it("returns the default when no availabilityField is empty and a default is given", () => {
       const got = getGraphQLObjectAvailability(availability);
 
-      expect(got).toEqual({ link: ["default-uid"] });
+      expect(got).toEqual({ link: ["default-ext-id"] });
     });
 
     it("returns the availabilities in availabilityFields", () => {
       const got = getGraphQLObjectAvailability(availability, [
-        availability.all[0].external_id,
-        availability.all[2].external_id,
+        availability.all[0],
+        availability.all[2],
       ]);
 
       expect(got).toEqual({
-        link: [availability.all[0].uid, availability.all[2].uid],
+        link: [availability.all[0], availability.all[2]],
       });
     });
   });

--- a/packages/ingestor/src/lib/skylark/saas/utils.ts
+++ b/packages/ingestor/src/lib/skylark/saas/utils.ts
@@ -150,13 +150,12 @@ export const getGraphQLObjectAvailability = (
   availabilityMetadata: GraphQLMetadata["availability"],
   availabilityField?: string[]
 ): { link: string[] } => {
-  const { all, default: defaultAvailability } = availabilityMetadata;
+  const { default: defaultAvailability } = availabilityMetadata;
   if (!availabilityField || availabilityField.length === 0) {
-    return { link: defaultAvailability ? [defaultAvailability.uid] : [] };
+    return { link: defaultAvailability ? [defaultAvailability] : [] };
   }
 
-  const uids = getUidsFromField(availabilityField, all);
-  return { link: uids || [] };
+  return { link: availabilityField || [] };
 };
 
 export const getLanguageCodesFromAirtable = (

--- a/packages/ingestor/src/main.ts
+++ b/packages/ingestor/src/main.ts
@@ -267,20 +267,14 @@ const main = async () => {
       airtable.dimensions
     );
 
-    const availability = await createOrUpdateAvailability(
+    await createOrUpdateAvailability(
       airtable.availability,
       dimensions
     );
 
-    const defaultAvailabilityAirtable = airtable.availability.find(
+    const defaultSchedule = airtable.availability.find(
       ({ fields }) =>
         has(fields, "default") && fields.default && has(fields, "slug")
-    );
-    // Attempt to use the schedule marked as default in Airtable, if not use the always-license one
-    const defaultSchedule = availability.find(({ slug }) =>
-      defaultAvailabilityAirtable
-        ? slug === defaultAvailabilityAirtable.fields.slug
-        : slug === "always-license"
     );
 
     // eslint-disable-next-line no-console
@@ -288,13 +282,14 @@ const main = async () => {
       `Default license: ${
         UNLICENSED_BY_DEFAULT || !defaultSchedule
           ? "undefined"
-          : `${defaultSchedule.slug} (${defaultSchedule.external_id})`
+          : `${defaultSchedule.fields.slug as string} (${defaultSchedule.id})`
       }`
     );
 
     const metadataAvailability: GraphQLMetadata["availability"] = {
-      all: availability,
-      default: UNLICENSED_BY_DEFAULT ? undefined : defaultSchedule,
+      // We use the Airtable IDs (external_id within Skylark) for Availability
+      all: airtable.availability.map(({ id }) => id),
+      default: UNLICENSED_BY_DEFAULT ? undefined : defaultSchedule?.id,
     };
 
     const metadata: GraphQLMetadata = {

--- a/packages/ingestor/src/main.ts
+++ b/packages/ingestor/src/main.ts
@@ -267,10 +267,7 @@ const main = async () => {
       airtable.dimensions
     );
 
-    await createOrUpdateAvailability(
-      airtable.availability,
-      dimensions
-    );
+    await createOrUpdateAvailability(airtable.availability, dimensions);
 
     const defaultSchedule = airtable.availability.find(
       ({ fields }) =>


### PR DESCRIPTION
<!-- Enter a very brief description of change -->
<!-- Add any optional commentary which may help the code reviewer. -->
Modifies the ingestor to use the Availability external ID when creating/updating objects. Doing this as currently updating availability can time out when updating lots of objects so we're not updating availability, only creating it.

This allows us to:
- re-run the ingestor if it fails for the `external_id` cannot be found issue.
- Run the ingestor again to update any object aside from Availability


Expected output on an update is now:
```
Additional StreamTV sets / dynamic objects creation enabled
packages/ingestor/src/main.ts:249
Starting ingest to SaaS Skylark: https://2btehl56qbff7hvrdsltp2kwoi.appsync-api.eu-west-1.amazonaws.com/graphql (account: test1)
packages/ingestor/src/main.ts:260
Updating Availability is currently broken
  1. Updates timeout as all objects have to be updated with the new schedule (SL-2260)
Will create any new availabilities, but won't update existing ones.
packages/ingestor/src/lib/skylark/saas/availability.ts:246
Default license: always-all-devices-all-customer-types (recXNjJNyc6nKQIYa)
packages/ingestor/src/main.ts:281
Metadata objects created
packages/ingestor/src/main.ts:349
Media objects created
packages/ingestor/src/main.ts:363
6
Updating sets is not implemented
packages/ingestor/src/lib/skylark/saas/sets.ts:205
Additional objects created
packages/ingestor/src/main.ts:385
Completed in:: 204422.09716796875ms
packages/ingestor/src/main.ts:426
Completed in:: 3:24.506 (m:ss.mmm)
packages/ingestor/src/main.ts:426
great success
```


<!-- Please tick all relevant change types this PR commits -->
<!-- Delete non-relevant lines -->
* [x] Feature
* [x] Refactoring (no functional changes, no API changes)

#### Jira
<!-- Line separated list of relevant Jira ticket links -->
https://ostmodern.atlassian.net/browse/SL-2264

