### PR TITLE
[SL-2296] SL8 Ingestor create only and check missing modes

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -14,8 +14,22 @@
       "type": "node",
       "env": {
         "CREATE_SETS": "true",
+        "INGEST_TO_SAAS_SKYLARK": "false"
+      }
+    },
+    {
+      "name": "Debug ingestor - Classic (CREATE_ONLY)",
+      "request": "launch",
+      "cwd": "${workspaceFolder}/packages/ingestor",
+      "runtimeArgs": ["ingest"],
+      "runtimeExecutable": "yarn",
+      "skipFiles": ["<node_internals>/**"],
+      "type": "node",
+      "env": {
+        "CREATE_SETS": "false",
         "INGEST_TO_SAAS_SKYLARK": "false",
-        "CREATE_ONLY": "true"
+        "CREATE_ONLY": "true",
+        "CHECK_MISSING": "false"
       }
     },
     {

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -14,7 +14,8 @@
       "type": "node",
       "env": {
         "CREATE_SETS": "true",
-        "INGEST_TO_SAAS_SKYLARK": "false"
+        "INGEST_TO_SAAS_SKYLARK": "false",
+        "CREATE_ONLY": "true"
       }
     },
     {

--- a/packages/ingestor/src/lib/constants.ts
+++ b/packages/ingestor/src/lib/constants.ts
@@ -12,3 +12,5 @@ export const AIRTABLE_API_KEY = process.env.AIRTABLE_API_KEY as string;
 export const AIRTABLE_BASE_ID = process.env.AIRTABLE_BASE_ID as string;
 export const UNLICENSED_BY_DEFAULT =
   (process.env.DEFAULT_UNLICENSED as string) === "true";
+export const CREATE_ONLY = process.env.CREATE_ONLY === "true";
+export const CHECK_MISSING = (process.env.CHECK_MISSING as string) === "true";

--- a/packages/ingestor/src/lib/interfaces/classic.ts
+++ b/packages/ingestor/src/lib/interfaces/classic.ts
@@ -12,6 +12,7 @@ import {
   ApiThemeGenre,
 } from "@skylark-reference-apps/lib";
 import { Record, FieldSet } from "airtable";
+import { Method } from "axios";
 
 export interface ApiEntertainmentObjectWithAirtableId
   extends ApiEntertainmentObject {
@@ -54,3 +55,10 @@ export interface Metadata {
     viewingContext: (ApiDimension & ApiAirtableFields)[];
   };
 }
+
+export type APIBatchRequestData = {
+  id: string;
+  method: Method;
+  url: string;
+  data?: string;
+}[];

--- a/packages/ingestor/src/lib/skylark/classic/api.test.ts
+++ b/packages/ingestor/src/lib/skylark/classic/api.test.ts
@@ -49,7 +49,10 @@ describe("skylark.api", () => {
         title: "title",
         slug: "slug",
       };
-      await authenticatedSkylarkRequest("/api/episodes", { data });
+      await authenticatedSkylarkRequest("/api/episodes", {
+        method: "PUT",
+        data,
+      });
 
       expect(axiosRequest).toBeCalledWith({
         headers: {
@@ -57,6 +60,7 @@ describe("skylark.api", () => {
           "Cache-Control": "no-cache",
         },
         url: "https://skylarkplatform.io/api/episodes",
+        method: "PUT",
         data,
       });
     });
@@ -76,7 +80,9 @@ describe("skylark.api", () => {
       axiosRequest.mockImplementation(() => ({ data }));
 
       // Act.
-      await batchSkylarkRequest([{ data: "data" }]);
+      await batchSkylarkRequest([
+        { id: "batch-1", url: "/api/episode", method: "PUT", data: "data" },
+      ]);
 
       // Assert.
       expect(axiosRequest).toBeCalledWith({
@@ -86,7 +92,9 @@ describe("skylark.api", () => {
         },
         url: "https://skylarkplatform.io/api/batch/",
         method: "POST",
-        data: [{ data: "data" }],
+        data: [
+          { id: "batch-1", url: "/api/episode", method: "PUT", data: "data" },
+        ],
       });
     });
 
@@ -103,7 +111,11 @@ describe("skylark.api", () => {
       axiosRequest.mockImplementation(() => ({ data }));
 
       // Act.
-      await expect(batchSkylarkRequest([{ data: "data" }])).rejects.toThrow(
+      await expect(
+        batchSkylarkRequest([
+          { id: "batch-1", url: "/api/episode", method: "PUT", data: "data" },
+        ])
+      ).rejects.toThrow(
         `Batch request "request-id" failed with 500. Response body: {}`
       );
     });

--- a/packages/ingestor/src/lib/skylark/classic/availability.test.ts
+++ b/packages/ingestor/src/lib/skylark/classic/availability.test.ts
@@ -14,6 +14,10 @@ jest.mock("@aws-amplify/auth");
 jest.mock("@skylark-reference-apps/lib", () => ({
   SKYLARK_API: "https://skylarkplatform.io",
 }));
+jest.mock("./logging", () => ({
+  logFoundAndMissingObjects: jest.fn(),
+  logFoundObject: jest.fn(),
+}));
 
 const dimensions = [
   "affiliates",

--- a/packages/ingestor/src/lib/skylark/classic/availability.ts
+++ b/packages/ingestor/src/lib/skylark/classic/availability.ts
@@ -46,6 +46,10 @@ export const getAlwaysSchedule = async (): Promise<ApiSchedule> => {
  * @returns all dimensions from a given table
  */
 const createOrUpdateDimensions = async (table: Record<FieldSet>[]) => {
+  if (table.length === 0) {
+    return [];
+  }
+
   const objectData = table.map(({ fields, id }) => ({
     uid: "",
     self: "",

--- a/packages/ingestor/src/lib/skylark/classic/content-types.test.ts
+++ b/packages/ingestor/src/lib/skylark/classic/content-types.test.ts
@@ -9,6 +9,9 @@ jest.mock("@aws-amplify/auth");
 jest.mock("@skylark-reference-apps/lib", () => ({
   SKYLARK_API: "https://skylarkplatform.io",
 }));
+jest.mock("./logging", () => ({
+  logFoundAndMissingObjects: jest.fn(),
+}));
 
 const alwaysSchedule = {
   uid: "1",

--- a/packages/ingestor/src/lib/skylark/classic/content-types.ts
+++ b/packages/ingestor/src/lib/skylark/classic/content-types.ts
@@ -42,6 +42,12 @@ export const createOrUpdateContentTypes = async <T extends ApiBaseObject>(
   const existingTypes = await getContentTypes<T>(type);
   const existingSlugs = existingTypes?.map(({ slug }) => slug);
 
+  // Array of types that match data we want to import (rather than just all types in Skylark)
+  const recordSlugs = records.map(({ fields }) => fields.slug);
+  const existingImportedTypes = existingTypes
+    ? existingTypes.filter(({ slug }) => recordSlugs.includes(slug))
+    : [];
+
   const existingObjectsWithAirtableId = existingTypes
     ? existingTypes.map((object) => {
         const matchingRecord = records.find(
@@ -55,15 +61,9 @@ export const createOrUpdateContentTypes = async <T extends ApiBaseObject>(
       })
     : [];
 
-  logFoundAndMissingObjects(type, records.length, existingTypes?.length || 0);
+  logFoundAndMissingObjects(type, records.length, existingImportedTypes.length);
 
   if (CHECK_MISSING) {
-    const allRecordsExist = records.every(({ fields: { slug } }) =>
-      existingSlugs?.includes((slug as string) || "")
-    );
-    if (!allRecordsExist || !existingTypes) {
-      process.exit(1);
-    }
     return existingObjectsWithAirtableId;
   }
 

--- a/packages/ingestor/src/lib/skylark/classic/content-types.ts
+++ b/packages/ingestor/src/lib/skylark/classic/content-types.ts
@@ -4,6 +4,8 @@ import { authenticatedSkylarkRequest } from "./api";
 import { convertAirtableFieldsToSkylarkObject } from "./create";
 import { ApiAirtableFields, Metadata } from "../../interfaces";
 import { ApiContentObjectType } from "../../types";
+import { CHECK_MISSING, CREATE_ONLY } from "../../constants";
+import { logFoundAndMissingObjects } from "./logging";
 
 /**
  * getContentTypes - retrieves all content types of the given type from Skylark
@@ -32,35 +34,77 @@ export const createOrUpdateContentTypes = async <T extends ApiBaseObject>(
   type: ApiContentObjectType,
   records: Record<FieldSet>[],
   metadata: Metadata
-) => {
+): Promise<(T & ApiAirtableFields)[]> => {
+  if (records.length === 0) {
+    return [];
+  }
+
   const existingTypes = await getContentTypes<T>(type);
+  const existingSlugs = existingTypes?.map(({ slug }) => slug);
+
+  const existingObjectsWithAirtableId = existingTypes
+    ? existingTypes.map((object) => {
+        const matchingRecord = records.find(
+          ({ fields: { slug } }) => slug === object.slug
+        );
+        const airtableId = matchingRecord ? matchingRecord.id : "";
+        return {
+          ...object,
+          airtableId,
+        };
+      })
+    : [];
+
+  logFoundAndMissingObjects(type, records.length, existingTypes?.length || 0);
+
+  if (CHECK_MISSING) {
+    const allRecordsExist = records.every(({ fields: { slug } }) =>
+      existingSlugs?.includes((slug as string) || "")
+    );
+    if (!allRecordsExist || !existingTypes) {
+      process.exit(1);
+    }
+    return existingObjectsWithAirtableId;
+  }
+
+  const recordsToCreateUpdate = CREATE_ONLY
+    ? records.filter(
+        ({ fields: { slug } }) => !existingSlugs?.includes(slug as string)
+      )
+    : records;
+
   const contentTypes = await Promise.all(
-    records.map(async (record): Promise<T & ApiAirtableFields> => {
-      const existingContentObject = existingTypes?.find(
-        (existingType) => existingType.slug === record.fields.slug
-      );
+    recordsToCreateUpdate.map(
+      async (record): Promise<T & ApiAirtableFields> => {
+        const existingContentObject = existingTypes?.find(
+          (existingType) => existingType.slug === record.fields.slug
+        );
 
-      const contentTypeObject = convertAirtableFieldsToSkylarkObject(
-        record.id,
-        record.fields,
-        metadata
-      );
+        const contentTypeObject = convertAirtableFieldsToSkylarkObject(
+          record.id,
+          record.fields,
+          metadata
+        );
 
-      const url = existingContentObject
-        ? `/api/${type}/${existingContentObject.uid}`
-        : `/api/${type}/`;
-      const { data: contentType } = await authenticatedSkylarkRequest<T>(url, {
-        method: existingContentObject ? "PUT" : "POST",
-        data: {
-          ...existingContentObject,
-          ...contentTypeObject,
-          uid: existingContentObject?.uid || "",
-          self: existingContentObject?.self || "",
-        },
-      });
+        const url = existingContentObject
+          ? `/api/${type}/${existingContentObject.uid}`
+          : `/api/${type}/`;
+        const { data: contentType } = await authenticatedSkylarkRequest<T>(
+          url,
+          {
+            method: existingContentObject ? "PUT" : "POST",
+            data: {
+              ...existingContentObject,
+              ...contentTypeObject,
+              uid: existingContentObject?.uid || "",
+              self: existingContentObject?.self || "",
+            },
+          }
+        );
 
-      return { ...contentType, airtableId: record.id };
-    })
+        return { ...contentType, airtableId: record.id };
+      }
+    )
   );
-  return contentTypes as (T & ApiAirtableFields)[];
+  return [...existingObjectsWithAirtableId, ...contentTypes];
 };

--- a/packages/ingestor/src/lib/skylark/classic/create.test.ts
+++ b/packages/ingestor/src/lib/skylark/classic/create.test.ts
@@ -31,6 +31,11 @@ jest.mock("@aws-amplify/auth");
 jest.mock("@skylark-reference-apps/lib", () => ({
   SKYLARK_API: "https://skylarkplatform.io",
 }));
+jest.mock("./logging", () => ({
+  logFoundAndMissingObjects: jest.fn(),
+  logFoundObject: jest.fn(),
+  logMediaObjectsUploaded: jest.fn(),
+}));
 
 const alwaysSchedule = {
   uid: "1",

--- a/packages/ingestor/src/lib/skylark/classic/create.ts
+++ b/packages/ingestor/src/lib/skylark/classic/create.ts
@@ -7,8 +7,19 @@ import {
   ApiPerson,
 } from "@skylark-reference-apps/lib";
 import { Attachment, FieldSet, Records, Record } from "airtable";
-import { compact, flatten, has, isArray, isEmpty, isString } from "lodash";
+import { Method } from "axios";
 import {
+  compact,
+  flatten,
+  has,
+  isArray,
+  isEmpty,
+  isString,
+  uniqBy,
+} from "lodash";
+import { CHECK_MISSING, CREATE_ONLY } from "../../constants";
+import {
+  APIBatchRequestData,
   ApiEntertainmentObjectWithAirtableId,
   DynamicObjectConfig,
   Metadata,
@@ -16,6 +27,12 @@ import {
 import { ApiSkylarkObjectWithAllPotentialFields } from "../../types";
 import { authenticatedSkylarkRequest, batchSkylarkRequest } from "./api";
 import { getResourceByDataSourceId, getResourceByProperty } from "./get";
+import {
+  logFoundObject,
+  logFoundAndMissingObjects,
+  logMissingObject,
+  logMediaObjectsUploaded,
+} from "./logging";
 import {
   getScheduleUrlsFromMetadata,
   removeUndefinedPropertiesFromObject,
@@ -42,10 +59,24 @@ export const createOrUpdateObject = async <T extends ApiBaseObject>(
       ? await getResourceByDataSourceId<T>(type, lookup.value)
       : await getResourceByProperty<T>(type, lookup.property, lookup.value);
 
+  if (existingObject) logFoundObject(type, lookup.value, lookup.property);
+
+  if (CHECK_MISSING) {
+    if (!existingObject) {
+      logMissingObject(type, lookup.value, lookup.property);
+      process.exit(1);
+    }
+    return existingObject;
+  }
+
+  if (CREATE_ONLY && existingObject) {
+    return existingObject;
+  }
+
   // Patch method is safer when updating objects, but the /api/images endpoint doesn't implement it
   const updateMethod = type === "images" ? "PUT" : "PATCH";
 
-  let method = existingObject ? updateMethod : "POST";
+  let method: Method = existingObject ? updateMethod : "POST";
   let url = `/api/${type}/${existingObject?.uid || ""}`;
 
   if (lookup.property === "data_source_id") {
@@ -76,16 +107,17 @@ export const bulkCreateOrUpdateObjectsWithLookup = async <
   objects: ApiSkylarkObjectWithAllPotentialFields[],
   objectTypes: { [id: string]: string },
   lookupMethod: "slug" | "title"
-) => {
+): Promise<T[]> => {
   const getBatchRequestData = objects.map((object) => {
     const type = objectTypes[object.data_source_id];
 
     const lookupValue = object[lookupMethod] as string;
     const url = `/api/${type}/?${lookupMethod}=${lookupValue}`;
 
+    const method: Method = "GET";
     return {
       id: object.data_source_id,
-      method: "GET",
+      method,
       url,
     };
   });
@@ -94,42 +126,75 @@ export const bulkCreateOrUpdateObjectsWithLookup = async <
     { ignore404s: true }
   );
 
-  const createOrUpdateBatchRequestData = objects.map(({ ...object }) => {
-    const matchingBatchResponse = getBatchResponseData.find(
-      ({ batchRequestId }) => batchRequestId === object.data_source_id
+  const foundObjects = getBatchResponseData
+    .map(({ data }) => data?.objects?.[0])
+    .filter((object) => object) as T[];
+  const foundObjectDataSourceIds = foundObjects.map(
+    ({ data_source_id }) => data_source_id
+  );
+  logFoundAndMissingObjects(objectTypes, objects.length, foundObjects.length);
+
+  if (CHECK_MISSING) {
+    const allObjectsExist = objects.every(({ data_source_id }) =>
+      foundObjectDataSourceIds.includes(data_source_id)
     );
 
-    const existingObject = matchingBatchResponse?.data.objects?.[0];
-    const type = objectTypes[object.data_source_id];
-    const url = existingObject ? existingObject.self : `/api/${type}/`;
-    const method = existingObject ? "PATCH" : "POST";
-    return {
-      id: object.data_source_id,
-      method,
-      url,
-      data: JSON.stringify({
-        ...existingObject,
-        ...object,
-        uid: existingObject?.uid || "",
-        self: existingObject?.self || "",
-      }),
-    };
-  });
+    if (!allObjectsExist) {
+      process.exit(1);
+    }
+    return foundObjects;
+  }
+
+  // In CREATE_ONLY mode, filter out objects that already exist
+  const objectsToCreateUpdate = CREATE_ONLY
+    ? objects.filter(
+        ({ data_source_id }) =>
+          !foundObjectDataSourceIds.includes(data_source_id)
+      )
+    : objects;
+
+  const createOrUpdateBatchRequestData = objectsToCreateUpdate.map(
+    ({ ...object }) => {
+      const matchingBatchResponse = getBatchResponseData.find(
+        ({ batchRequestId }) => batchRequestId === object.data_source_id
+      );
+
+      const existingObject = matchingBatchResponse?.data.objects?.[0];
+      const type = objectTypes[object.data_source_id];
+      const url = existingObject ? existingObject.self : `/api/${type}/`;
+      const method: Method = existingObject ? "PATCH" : "POST";
+      return {
+        id: object.data_source_id,
+        method,
+        url,
+        data: JSON.stringify({
+          ...existingObject,
+          ...object,
+          uid: existingObject?.uid || "",
+          self: existingObject?.self || "",
+        }),
+      };
+    }
+  );
   const createOrUpdateBatchResponseData = await batchSkylarkRequest<T>(
     createOrUpdateBatchRequestData
   );
 
-  return createOrUpdateBatchResponseData.map(({ data, batchRequestId }) => {
-    if (!data.data_source_id) {
-      // Add data_source_id when one isn't returned (bugfix for roles)
-      return {
-        ...data,
-        data_source_id: batchRequestId,
-      };
-    }
+  const createUpdatedObjects = createOrUpdateBatchResponseData.map(
+    ({ data, batchRequestId }) => {
+      if (!data.data_source_id) {
+        // Add data_source_id when one isn't returned (bugfix for roles)
+        return {
+          ...data,
+          data_source_id: batchRequestId,
+        };
+      }
 
-    return data;
-  });
+      return data;
+    }
+  );
+
+  return uniqBy([...foundObjects, ...createUpdatedObjects], "uid");
 };
 
 /**
@@ -143,15 +208,16 @@ export const bulkCreateOrUpdateObjectsUsingDataSourceId = async <
 >(
   objects: ApiSkylarkObjectWithAllPotentialFields[],
   objectTypes: { [id: string]: string }
-) => {
+): Promise<T[]> => {
   const getBatchRequestData = objects.map((object) => {
     const type = objectTypes[object.data_source_id];
 
     const url = `/api/${type}/versions/data-source/${object.data_source_id}/`;
 
+    const method: Method = "GET";
     return {
       id: object.data_source_id,
-      method: "GET",
+      method,
       url,
     };
   });
@@ -161,33 +227,68 @@ export const bulkCreateOrUpdateObjectsUsingDataSourceId = async <
     { ignore404s: true }
   );
 
-  const createOrUpdateBatchRequestData = objects.map(({ ...object }) => {
-    const matchingBatchResponse = getBatchResponseData.find(
-      ({ batchRequestId }) => batchRequestId === object.data_source_id
+  const foundObjects = getBatchResponseData
+    .map(({ data }) => data)
+    .filter((object) => object);
+  const foundObjectDataSourceIds = foundObjects.map(
+    ({ data_source_id }) => data_source_id
+  );
+  logFoundAndMissingObjects(objectTypes, objects.length, foundObjects.length);
+
+  if (CHECK_MISSING) {
+    const allObjectsExist = objects.every(({ data_source_id }) =>
+      foundObjectDataSourceIds.includes(data_source_id)
     );
 
-    const existingObject =
-      matchingBatchResponse?.code !== 404 ? matchingBatchResponse?.data : null;
-    const type = objectTypes[object.data_source_id];
-    const url = `/api/${type}/versions/data-source/${object.data_source_id}/`;
-    const method = "PUT";
-    return {
-      id: `${method}-${url}`,
-      method,
-      url,
-      data: JSON.stringify({
-        ...existingObject,
-        ...object,
-        uid: existingObject?.uid || "",
-        self: existingObject?.self || "",
-      }),
-    };
-  });
+    if (!allObjectsExist) {
+      process.exit(1);
+    }
+    return foundObjects;
+  }
+
+  // In CREATE_ONLY mode, filter out objects that already exist
+  const objectsToCreateUpdate = CREATE_ONLY
+    ? objects.filter(
+        ({ data_source_id }) =>
+          !foundObjectDataSourceIds.includes(data_source_id)
+      )
+    : objects;
+
+  const createOrUpdateBatchRequestData = objectsToCreateUpdate.map(
+    ({ ...object }) => {
+      const matchingBatchResponse = getBatchResponseData.find(
+        ({ batchRequestId }) => batchRequestId === object.data_source_id
+      );
+
+      const existingObject =
+        matchingBatchResponse?.code !== 404
+          ? matchingBatchResponse?.data
+          : null;
+      const type = objectTypes[object.data_source_id];
+      const url = `/api/${type}/versions/data-source/${object.data_source_id}/`;
+      const method: Method = "PUT";
+      return {
+        id: `${method}-${url}`,
+        method,
+        url,
+        data: JSON.stringify({
+          ...existingObject,
+          ...object,
+          uid: existingObject?.uid || "",
+          self: existingObject?.self || "",
+        }),
+      };
+    }
+  );
   const createOrUpdateBatchResponseData = await batchSkylarkRequest<T>(
     createOrUpdateBatchRequestData
   );
 
-  return createOrUpdateBatchResponseData.map(({ data }) => data);
+  const createUpdatedObjects = createOrUpdateBatchResponseData.map(
+    ({ data }) => data
+  );
+
+  return uniqBy([...foundObjects, ...createUpdatedObjects], "uid");
 };
 
 /**
@@ -490,7 +591,7 @@ export const updateCredits = async <T extends ApiBaseObject>(
     }
 
     const url = object.self;
-    const method = "PATCH"; // PATCH to not update other fields
+    const method: Method = "PATCH"; // PATCH to not update other fields
     const credits =
       getCreditsFromField(record.fields.credits as string[], metadata) || [];
 
@@ -536,6 +637,10 @@ export const createOrUpdateAirtableObjectsInSkylark = async <
     objectTypes[id] = (fields.skylark_object_type as string) || _table.name;
   });
 
+  if (airtableRecords.length === 0) {
+    return [];
+  }
+
   const createOrUpdateBatchResponseData =
     await bulkCreateOrUpdateObjectsUsingDataSourceId<T>(
       objectData,
@@ -545,7 +650,10 @@ export const createOrUpdateAirtableObjectsInSkylark = async <
   const hasCredits = createOrUpdateBatchResponseData.some((object) =>
     has(object, "credits")
   );
-  if (hasCredits) {
+
+  // When CHECK_MISSING or CREATE_ONLY mode is enabled, don't update credits or images
+
+  if (hasCredits && !CHECK_MISSING && !CREATE_ONLY) {
     await updateCredits<T>(
       createOrUpdateBatchResponseData,
       airtableRecords,
@@ -559,13 +667,14 @@ export const createOrUpdateAirtableObjectsInSkylark = async <
         const airtableFields = airtableRecords.find(
           ({ id }) => id === data.data_source_id
         );
-        const imageUrls = airtableFields?.fields?.images
-          ? await parseAirtableImagesAndUploadToSkylark<T>(
-              airtableFields.fields.images as string[],
-              data,
-              metadata
-            )
-          : [];
+        const imageUrls =
+          !CHECK_MISSING && !CREATE_ONLY && airtableFields?.fields?.images
+            ? await parseAirtableImagesAndUploadToSkylark<T>(
+                airtableFields.fields.images as string[],
+                data,
+                metadata
+              )
+            : [];
 
         return {
           ...data,
@@ -631,9 +740,9 @@ export const createOrUpdateAirtableObjectsInSkylarkWithParentsInSameTable =
         );
 
       createdMediaObjects.push(...objs);
-      // eslint-disable-next-line no-console
-      console.log(
-        `Media objects uploaded: ${createdMediaObjects.length}/${airtableRecords.length}`
+      logMediaObjectsUploaded(
+        createdMediaObjects.length,
+        airtableRecords.length
       );
     }
 
@@ -699,8 +808,9 @@ export const createTranslationsForObjects = async (
       });
 
     const languages = fields.languages as string[];
+    const method: Method = "PATCH";
     return languages.map((languageAirtableId) => ({
-      method: "PATCH",
+      method,
       url: object.self,
       headers: {
         "Accept-Language": languageCodes[languageAirtableId],
@@ -734,6 +844,10 @@ export const connectExternallyCreatedAssetToMediaObject = async (
   createdMediaObjects: ApiEntertainmentObjectWithAirtableId[],
   metadata: Metadata
 ) => {
+  if (CHECK_MISSING) {
+    return [];
+  }
+
   const recordsWithExternalAsset = records.filter(
     ({ fields }) =>
       has(fields, "external_asset_data_source_id") &&
@@ -745,9 +859,10 @@ export const connectExternallyCreatedAssetToMediaObject = async (
       fields.external_asset_data_source_id as string
     }/`;
 
+    const method: Method = "GET";
     return {
       id: `GET-${fields.external_asset_data_source_id as string}`,
-      method: "GET",
+      method,
       url,
     };
   });
@@ -774,7 +889,7 @@ export const connectExternallyCreatedAssetToMediaObject = async (
       );
 
       if (!assetParent || asset?.parent_url === assetParent.self) {
-        return {};
+        return null;
       }
 
       const data: Partial<ApiEntertainmentObjectWithAirtableId> = {
@@ -793,7 +908,7 @@ export const connectExternallyCreatedAssetToMediaObject = async (
 
       // Filter out any objects which already have the correct parent_url
     })
-    .filter((request) => !isEmpty(request));
+    .filter((request) => request) as APIBatchRequestData;
 
   const batchResponseData =
     await batchSkylarkRequest<ApiEntertainmentObjectWithAirtableId>(

--- a/packages/ingestor/src/lib/skylark/classic/get.ts
+++ b/packages/ingestor/src/lib/skylark/classic/get.ts
@@ -14,7 +14,8 @@ import { authenticatedSkylarkRequest } from "./api";
  */
 export const getResources = async <T>(resource: string): Promise<T[]> => {
   const res = await authenticatedSkylarkRequest<{ objects?: T[] }>(
-    `/api/${resource}/`
+    `/api/${resource}/`,
+    { method: "GET" }
   );
   return res.data?.objects || [];
 };

--- a/packages/ingestor/src/lib/skylark/classic/logging.ts
+++ b/packages/ingestor/src/lib/skylark/classic/logging.ts
@@ -10,7 +10,7 @@ export const logFoundAndMissingObjects = (
     : [...new Set(Object.values(objectTypes))].join(", ");
   // eslint-disable-next-line no-console
   console.log(
-    `[${uniqueTypes}] Found ${totalExistingObjects}, ${
+    `[${uniqueTypes}] Found ${totalExistingObjects}, expected ${totalObjects}, ${
       totalObjects - totalExistingObjects
     } missing`
   );

--- a/packages/ingestor/src/lib/skylark/classic/logging.ts
+++ b/packages/ingestor/src/lib/skylark/classic/logging.ts
@@ -1,0 +1,48 @@
+import { isString } from "lodash";
+
+export const logFoundAndMissingObjects = (
+  objectTypes: { [id: string]: string } | string,
+  totalObjects: number,
+  totalExistingObjects: number
+) => {
+  const uniqueTypes = isString(objectTypes)
+    ? objectTypes
+    : [...new Set(Object.values(objectTypes))].join(", ");
+  // eslint-disable-next-line no-console
+  console.log(
+    `[${uniqueTypes}] Found ${totalExistingObjects}, ${
+      totalObjects - totalExistingObjects
+    } missing`
+  );
+};
+
+export const logFoundObject = (
+  objectType: string,
+  lookupValue: string,
+  lookupProperty: string
+) => {
+  // eslint-disable-next-line no-console
+  console.log(`[${objectType}] Found "${lookupValue}" (${lookupProperty})`);
+};
+
+export const logMissingObject = (
+  objectType: string,
+  lookupValue: string,
+  lookupProperty: string
+) => {
+  // eslint-disable-next-line no-console
+  console.log(`[${objectType}] Missing "${lookupValue}" (${lookupProperty})`);
+};
+
+export const logMediaObjectsUploaded = (
+  currentAmount: number,
+  totalAmount: number
+) => {
+  // eslint-disable-next-line no-console
+  console.log(`Media objects uploaded: ${currentAmount}/${totalAmount}`);
+};
+
+export const logUpdatingSetsNotImplemented = () => {
+  // eslint-disable-next-line no-console
+  console.warn("Updating sets is not implemented");
+};

--- a/packages/ingestor/src/lib/skylark/saas/sets.test.ts
+++ b/packages/ingestor/src/lib/skylark/saas/sets.test.ts
@@ -9,6 +9,9 @@ import { ApiObjectType } from "../../types";
 import { createOrUpdateGraphQLSet } from "./sets";
 
 jest.mock("@skylark-reference-apps/lib");
+jest.mock("../classic/logging", () => ({
+  logUpdatingSetsNotImplemented: jest.fn(),
+}));
 
 describe("saas/sets.ts", () => {
   let graphQlRequest: jest.Mock;

--- a/packages/ingestor/src/lib/skylark/saas/sets.ts
+++ b/packages/ingestor/src/lib/skylark/saas/sets.ts
@@ -20,6 +20,7 @@ import {
   getLanguageCodesFromAirtable,
 } from "./utils";
 import { getMediaObjectRelationships } from "./create";
+import { logUpdatingSetsNotImplemented } from "../classic/logging";
 
 interface SetItem {
   uid: string;
@@ -201,8 +202,7 @@ export const createOrUpdateGraphQLSet = async (
   const setExists =
     (await getExistingObjects("Set", [set.externalId])).length > 0;
   if (setExists) {
-    // eslint-disable-next-line no-console
-    console.warn("Updating sets is not implemented");
+    logUpdatingSetsNotImplemented();
     return {} as GraphQLBaseObject;
   }
 

--- a/packages/ingestor/src/main.ts
+++ b/packages/ingestor/src/main.ts
@@ -49,7 +49,11 @@ import {
   signInToCognito,
   uploadToWorkflowServiceWatchBucket,
 } from "./lib/amplify";
-import { UNLICENSED_BY_DEFAULT } from "./lib/constants";
+import {
+  CHECK_MISSING,
+  CREATE_ONLY,
+  UNLICENSED_BY_DEFAULT,
+} from "./lib/constants";
 import {
   createGraphQLMediaObjects,
   createOrUpdateGraphQLCredits,
@@ -403,6 +407,12 @@ const main = async () => {
   } else {
     // eslint-disable-next-line no-console
     console.log(`Starting ingest to V8 Skylark: ${SKYLARK_API}`);
+    // eslint-disable-next-line no-console
+    if (CHECK_MISSING)
+      console.log("CHECK_MISSING mode ENABLED (will not create or update)");
+    // eslint-disable-next-line no-console
+    if (CREATE_ONLY)
+      console.log("CREATE_ONLY mode ENABLED (will not create or update)");
 
     configureAmplify();
 


### PR DESCRIPTION
<!-- Enter a very brief description of change -->
<!-- Add any optional commentary which may help the code reviewer. -->
Adds two new modes to run the SL8 ingestor:
- `CREATE_ONLY` mode which will only create new objects and not update anything (aside from images)
- `CHECK_MISSING` mode will check for any missing object compared to the Airtable, if one is found it exits.

<!-- Please tick all relevant change types this PR commits -->
<!-- Delete non-relevant lines -->
* [x] Feature

#### Jira
<!-- Line separated list of relevant Jira ticket links -->
https://skylarkplatform.atlassian.net/browse/SL-2296
