### PR TITLE
feat: Add Skylark Legacy Ingestor + improve error handling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,10 +26,12 @@ yarn-debug.log*
 yarn-error.log*
 
 # local env files
+.env.*
 .env.local
 .env.development.local
 .env.test.local
 .env.production.local
+.env.legacy
 
 # vercel
 .vercel

--- a/.prettierignore
+++ b/.prettierignore
@@ -4,4 +4,5 @@ build
 cdk.out
 dist
 outputs
+backup_outputs
 .vercel

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -36,7 +36,9 @@
       "runtimeExecutable": "yarn",
       "skipFiles": ["<node_internals>/**"],
       "type": "node",
-      "env": {}
+      "env": {
+        "LEGACY_DATA_LAST_MONTH_ONLY": "true"
+      }
     },
     {
       "name": "[LEGACY - FROM DISK] Ingest from Legacy to Skylark",
@@ -46,7 +48,9 @@
       "runtimeExecutable": "yarn",
       "skipFiles": ["<node_internals>/**"],
       "type": "node",
-      "env": {}
+      "env": {
+        "LEGACY_DATA_LAST_MONTH_ONLY": "false"
+      }
     }
   ]
 }

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -27,6 +27,16 @@
       "env": {
         "CREATE_SLX_DEMO_SETS": "true"
       }
+    },
+    {
+      "name": "[LEGACY] Debug ingest from Legacy to Skylark",
+      "request": "launch",
+      "cwd": "${workspaceFolder}/packages/ingestor",
+      "runtimeArgs": ["ingest:legacy-to-skylark"],
+      "runtimeExecutable": "yarn",
+      "skipFiles": ["<node_internals>/**"],
+      "type": "node",
+      "env": {}
     }
   ]
 }

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -29,10 +29,20 @@
       }
     },
     {
-      "name": "[LEGACY] Debug ingest from Legacy to Skylark",
+      "name": "[LEGACY] Ingest from Legacy to Skylark",
       "request": "launch",
       "cwd": "${workspaceFolder}/packages/ingestor",
       "runtimeArgs": ["ingest:legacy-to-skylark"],
+      "runtimeExecutable": "yarn",
+      "skipFiles": ["<node_internals>/**"],
+      "type": "node",
+      "env": {}
+    },
+    {
+      "name": "[LEGACY - FROM DISK] Ingest from Legacy to Skylark",
+      "request": "launch",
+      "cwd": "${workspaceFolder}/packages/ingestor",
+      "runtimeArgs": ["ingest:legacy-to-skylark-from-disk"],
       "runtimeExecutable": "yarn",
       "skipFiles": ["<node_internals>/**"],
       "type": "node",

--- a/packages/ingestor/.gitignore
+++ b/packages/ingestor/.gitignore
@@ -1,2 +1,3 @@
 dist/
 outputs/
+backup_outputs/

--- a/packages/ingestor/package.json
+++ b/packages/ingestor/package.json
@@ -35,6 +35,7 @@
     "ingest:saas": "cross-env yarn ingest",
     "ingest:saas:with-sets": "cross-env CREATE_SETS=true yarn ingest",
     "test": "jest --config=jest.config.js",
-    "lint": "eslint -c .eslintrc.js ."
+    "lint": "eslint -c .eslintrc.js .",
+    "ingest:legacy-to-skylark": "ts-node src/lib/ingestLegacyObjectsToSkylark/main.ts"
   }
 }

--- a/packages/ingestor/package.json
+++ b/packages/ingestor/package.json
@@ -23,7 +23,8 @@
     "@skylark-reference-apps/lib": "*",
     "@types/lodash": "^4.14.182",
     "airtable": "^0.11.4",
-    "axios": "^0.27.2",
+    "axios": "^1.4.0",
+    "axios-retry": "^3.5.1",
     "dotenv": "^16.0.1",
     "fs-extra": "^11.1.1",
     "graphql": "^16.6.0",
@@ -40,5 +41,8 @@
     "lint": "eslint -c .eslintrc.js .",
     "ingest:legacy-to-skylark": "ts-node src/lib/ingestLegacyObjectsToSkylark/main.ts",
     "ingest:legacy-to-skylark-from-disk": "cross-env READ_LEGACY_OBJECTS_FROM_DISK=true yarn ingest:legacy-to-skylark"
+  },
+  "resolutions": {
+    "axios": "1.4.0"
   }
 }

--- a/packages/ingestor/package.json
+++ b/packages/ingestor/package.json
@@ -6,6 +6,7 @@
   "license": "MIT",
   "devDependencies": {
     "@tsconfig/node16": "^1.0.3",
+    "@types/fs-extra": "^11.0.1",
     "@types/jest": "^29.5.0",
     "@types/node": "^17.0.43",
     "cross-env": "^7.0.3",
@@ -24,6 +25,7 @@
     "airtable": "^0.11.4",
     "axios": "^0.27.2",
     "dotenv": "^16.0.1",
+    "fs-extra": "^11.1.1",
     "graphql": "^16.6.0",
     "graphql-request": "^5.0.0",
     "json-to-graphql-query": "^2.2.4",
@@ -36,6 +38,7 @@
     "ingest:saas:with-sets": "cross-env CREATE_SETS=true yarn ingest",
     "test": "jest --config=jest.config.js",
     "lint": "eslint -c .eslintrc.js .",
-    "ingest:legacy-to-skylark": "ts-node src/lib/ingestLegacyObjectsToSkylark/main.ts"
+    "ingest:legacy-to-skylark": "ts-node src/lib/ingestLegacyObjectsToSkylark/main.ts",
+    "ingest:legacy-to-skylark-from-disk": "cross-env READ_LEGACY_OBJECTS_FROM_DISK=true yarn ingest:legacy-to-skylark"
   }
 }

--- a/packages/ingestor/src/lib/ingestLegacyObjectsToSkylark/README.md
+++ b/packages/ingestor/src/lib/ingestLegacyObjectsToSkylark/README.md
@@ -1,0 +1,23 @@
+# Skylark Legacy to Skylark Ingestor
+
+This directory contains code specifically used to migrate data from Skylark Legacy (REST API) to new Skylark (GraphQL).
+
+It is not designed to handle all data models. Instead you need to modify it to fit the layout of your data model, i.e modify the code in this directory.
+
+## Get Started
+
+Create a `packages/ingestor/.env.legacy` file containing:
+
+```
+LEGACY_API_URL=""
+LEGACY_SKYLARK_TOKEN=""
+```
+
+Where:
+
+- `LEGACY_API_URL` is the API URL of the Skylark Legacy instance.
+- `LEGACY_SKYLARK_TOKEN` is an admin access token (you can get this by using the CMS and inspecting the network tab in your browser).
+
+## Outputs
+
+When running, it will record all the objects from Legacy Skylark so that you can read them from disk in future ingests.

--- a/packages/ingestor/src/lib/ingestLegacyObjectsToSkylark/constants.ts
+++ b/packages/ingestor/src/lib/ingestLegacyObjectsToSkylark/constants.ts
@@ -1,0 +1,24 @@
+export const USED_LANGUAGES = [
+  "EN",
+  "BG",
+  "ES",
+  "HR",
+  "HU",
+  "ID",
+  "IT",
+  "KO",
+  "MK",
+  "PL",
+  "PT",
+  "RO",
+  "RU",
+  "SL",
+  "SR",
+  "TR",
+  "UK",
+  "VI",
+  "ZH",
+  "MN",
+];
+
+export const ASSET_TYPES_TO_IGNORE = ["audiobook"];

--- a/packages/ingestor/src/lib/ingestLegacyObjectsToSkylark/constants.ts
+++ b/packages/ingestor/src/lib/ingestLegacyObjectsToSkylark/constants.ts
@@ -1,3 +1,5 @@
+import { LegacyObjectType } from "./types/legacySkylark";
+
 export const USED_LANGUAGES = [
   "EN",
   "BG",
@@ -25,3 +27,9 @@ export const ASSET_TYPES_TO_IGNORE = ["audiobook"];
 
 export const ALWAYS_FOREVER_AVAILABILITY_EXT_ID =
   "skylark_legacy_ingest_availability";
+
+export const OBJECT_TYPES_WITHOUT_LAST_MONTH_MODE = [
+  LegacyObjectType.TagCategories,
+  LegacyObjectType.Tags,
+];
+export const LAST_MONTH_MODE_DATE = "2023-06-01T00:00:00";

--- a/packages/ingestor/src/lib/ingestLegacyObjectsToSkylark/constants.ts
+++ b/packages/ingestor/src/lib/ingestLegacyObjectsToSkylark/constants.ts
@@ -22,3 +22,6 @@ export const USED_LANGUAGES = [
 ];
 
 export const ASSET_TYPES_TO_IGNORE = ["audiobook"];
+
+export const ALWAYS_FOREVER_AVAILABILITY_EXT_ID =
+  "skylark_legacy_ingest_availability";

--- a/packages/ingestor/src/lib/ingestLegacyObjectsToSkylark/env.ts
+++ b/packages/ingestor/src/lib/ingestLegacyObjectsToSkylark/env.ts
@@ -1,0 +1,5 @@
+import { resolve } from "path";
+import { config } from "dotenv";
+
+// Load env vars
+config({ path: resolve(__dirname, "../../../.env.legacy") });

--- a/packages/ingestor/src/lib/ingestLegacyObjectsToSkylark/fs.ts
+++ b/packages/ingestor/src/lib/ingestLegacyObjectsToSkylark/fs.ts
@@ -1,0 +1,185 @@
+/* eslint-disable no-console */
+import {
+  ensureDir,
+  ensureFile,
+  exists,
+  outputFile,
+  readFile,
+  readJson,
+  readdir,
+  writeFile,
+} from "fs-extra";
+import { join } from "path";
+import { LegacyObjectType, LegacyObjects } from "./types/legacySkylark";
+import { USED_LANGUAGES } from "./constants";
+import { calculateTotalObjects } from "./utils";
+
+export const writeError = async (err: unknown) => {
+  const errorFile = join(__dirname, "outputs", "ingest_errors.md");
+
+  await ensureFile(errorFile);
+
+  const contents = await readFile(errorFile, "utf8");
+
+  const dateStamp = new Date().toISOString();
+  const readFromDisk = process.env.READ_LEGACY_OBJECTS_FROM_DISK === "true";
+
+  const newContents = `${contents}\n---\n\n## ${dateStamp} (${
+    readFromDisk ? "Data from disk" : "Data from Skylark"
+  })\n\n\`\`\`\n${err as string}\n\`\`\`\n`;
+
+  await outputFile(errorFile, newContents);
+};
+
+const generateEnvIdentifier = () => {
+  const onlyDataCreatedInLastMonth =
+    process.env.LEGACY_DATA_LAST_MONTH_ONLY === "true";
+
+  const env = process.env.LEGACY_API_URL
+    ? process.env.LEGACY_API_URL.replace("https://", "")
+        .replaceAll(".", "_")
+        .replaceAll("-", "_")
+    : "unknown";
+
+  if (onlyDataCreatedInLastMonth) {
+    return `${env}_last_month_only`;
+  }
+
+  return env;
+};
+
+const generateLegacyObjectsDir = () => {
+  const env = generateEnvIdentifier();
+
+  const dir = join(__dirname, "outputs", "legacy_data", env);
+  return dir;
+};
+
+export const getMostRecentLegacyObjectsDir = async () => {
+  const parentDir = generateLegacyObjectsDir();
+  await ensureDir(parentDir);
+
+  const objectDirs = (await readdir(parentDir)).filter(
+    (dir) => dir !== "stats.md"
+  );
+
+  const [mostRecentDir] = objectDirs.sort(
+    (a, b) => +new Date(b) - +new Date(a)
+  );
+
+  return join(parentDir, mostRecentDir);
+};
+
+export const createLegacyObjectsTimeStampedDir = async () => {
+  const dateStamp = new Date().toISOString();
+
+  const dir = join(generateLegacyObjectsDir(), dateStamp);
+
+  await ensureDir(dir);
+
+  return dir;
+};
+
+export const writeLegacyObjectsToDisk = async <T>(
+  dir: string,
+  obj: {
+    type: LegacyObjectType;
+    objects: Record<string, T[]>;
+    totalFound: number;
+  }
+) => {
+  try {
+    await writeFile(
+      join(dir, `${obj.type}.json`),
+      JSON.stringify(obj, null, 4)
+    );
+  } catch (err) {
+    console.error(
+      `[writeLegacyObjectsToDisk] Failed to write ${obj.type} data`
+    );
+  }
+};
+
+export const writeAllLegacyObjectsToDisk = async (
+  objects: Record<
+    string,
+    {
+      type: LegacyObjectType;
+      objects: Record<string, LegacyObjects>;
+      totalFound: number;
+    }
+  >
+) => {
+  try {
+    const dir = await createLegacyObjectsTimeStampedDir();
+
+    await Promise.all(
+      Object.values(objects).map((value) =>
+        writeLegacyObjectsToDisk<LegacyObjects[0]>(dir, value)
+      )
+    );
+  } catch (err) {
+    console.error("[writeAllLegacyObjectsToDisk] Failed to write data");
+  }
+};
+
+export const writeStatsForLegacyObjectsToDisk = async (
+  legacyObjects: Record<
+    string,
+    {
+      type: LegacyObjectType;
+      objects: Record<string, LegacyObjects>;
+      totalFound: number;
+    }
+  >
+) => {
+  try {
+    const env = generateEnvIdentifier();
+    const file = join(generateLegacyObjectsDir(), "stats.md");
+
+    await ensureFile(file);
+
+    const totalObjectsFound = calculateTotalObjects(legacyObjects);
+
+    let contents = `# Stats for ${env}\n\nTotal objects across ${USED_LANGUAGES.length} languages: ${totalObjectsFound}`;
+
+    Object.values(legacyObjects).forEach(({ type, objects, totalFound }) => {
+      contents += `\n\n## ${type} (${totalFound} total)\n`;
+
+      Object.entries(objects).forEach(([language, objs]) => {
+        contents += `  - \`${language.toLowerCase()}\`: \`${objs.length}\`\n`;
+      });
+
+      contents += "\n---";
+    });
+
+    await writeFile(file, contents);
+  } catch (err) {
+    console.error("[writeAllLegacyObjectsToDisk] Failed to write data");
+  }
+};
+
+export const readObjectsFromFile = async <T>(
+  dir: string,
+  type: LegacyObjectType
+) => {
+  const file = join(dir, `${type}.json`);
+
+  if (!(await exists(file))) {
+    return {
+      type,
+      objects: {},
+      totalFound: 0,
+    };
+  }
+
+  const data = (await readJson(file)) as {
+    type: LegacyObjectType;
+    objects: Record<string, T[]>;
+    totalFound: number;
+  };
+
+  return data;
+};
+
+/* eslint-enable no-console */

--- a/packages/ingestor/src/lib/ingestLegacyObjectsToSkylark/legacy.ts
+++ b/packages/ingestor/src/lib/ingestLegacyObjectsToSkylark/legacy.ts
@@ -1,0 +1,144 @@
+/* eslint-disable no-console */
+import { hasProperty } from "@skylark-reference-apps/lib";
+import { Axios } from "axios";
+import { chunk } from "lodash";
+import {
+  LegacyCommonObject,
+  LegacyObjectType,
+  LegacyResponseListObjectsData,
+} from "./types/legacySkylark";
+import { USED_LANGUAGES } from "./constants";
+
+const createLegacyAxios = (language: string) => {
+  const legacyApiUrl = process.env.LEGACY_API_URL;
+  const legacyToken = process.env.LEGACY_SKYLARK_TOKEN;
+
+  const legacyAxios = new Axios({
+    baseURL: legacyApiUrl,
+    headers: {
+      Authorization: legacyToken as string,
+      "Content-Type": "application/json",
+      "Accept-Language": language,
+      "Cache-Control": "no-cache, no-store, must-revalidate, max-age=0",
+    },
+  });
+
+  return { legacyAxios };
+};
+
+const getAllObjectsOfType = async <T extends LegacyCommonObject>(
+  type: LegacyObjectType,
+  language: string
+): Promise<{ type: LegacyObjectType; objects: T[] }> => {
+  const { legacyAxios } = createLegacyAxios(language);
+
+  const limit = 25;
+
+  let numberOfRequests = 0;
+  let count = 0;
+
+  try {
+    const countResponse = await legacyAxios.get<string>(
+      `/api/${type}/count/?all=true`
+    );
+    if (countResponse.status < 200 || countResponse.status >= 300) {
+      throw new Error("Unexpected response from count endpoint");
+    }
+
+    const { count: c } = JSON.parse(countResponse.data) as { count: number };
+    numberOfRequests = Math.ceil(c / limit);
+    count = c;
+  } catch (err) {
+    console.log("[getAllObjectsOfType] Failed to fetch count for", type);
+    throw err;
+  }
+
+  const offsetArr = Array.from(
+    { length: numberOfRequests },
+    (_, index) => index * limit
+  );
+
+  const chunkedOffsetArr = chunk(offsetArr, 2); // Apparently 24 connections at once crashed it
+
+  const dataArr: T[][] = [];
+
+  // eslint-disable-next-line no-restricted-syntax
+  for (const offsets of chunkedOffsetArr) {
+    // eslint-disable-next-line no-await-in-loop
+    const dArr = await Promise.all(
+      offsets.map(async (offset) => {
+        try {
+          const query = ["all=true", `limit=${limit}`, `start=${offset}`];
+          if (type === LegacyObjectType.Assets) {
+            query.push("fields_to_expand=asset_type_url");
+          }
+
+          const listObjectsResponse = await legacyAxios.get<string>(
+            `/api/${type}/?${query.join("&")}`
+          );
+
+          const data = JSON.parse(
+            listObjectsResponse.data
+          ) as LegacyResponseListObjectsData<T>;
+
+          if (!hasProperty(data, "objects")) {
+            throw new Error(
+              `[getAllObjectsOfType] Unexpected response format for ${type}`
+            );
+          }
+
+          const { objects } = data;
+
+          return objects;
+        } catch (err) {
+          console.log("[getAllObjectsOfType] Failed to parse JSON for", type);
+          throw err;
+        }
+      })
+    );
+
+    dataArr.push(dArr.flatMap((d) => d));
+  }
+
+  const objects: T[] = dataArr.flatMap((data) => data);
+
+  if (count !== objects.length)
+    console.log(
+      type,
+      count,
+      objects.length,
+      `- Missing objects ${count - objects.length}`
+    );
+
+  return { type, objects };
+};
+
+export const fetchObjectsFromLegacySkylark = async <
+  T extends LegacyCommonObject
+>(
+  type: LegacyObjectType
+): Promise<{ type: LegacyObjectType; objects: Record<string, T[]> }> => {
+  const allObjects: Record<string, T[]> = {};
+
+  // eslint-disable-next-line no-restricted-syntax
+  for (const language of USED_LANGUAGES) {
+    // eslint-disable-next-line no-await-in-loop
+    const { objects } = await getAllObjectsOfType<T>(type, language);
+
+    // Add the _type to the object to be used later
+    const objectsWithType = objects.map((obj) => ({
+      ...obj,
+      _type: type,
+    }));
+
+    if (objects.length > 0) {
+      allObjects[language] = objectsWithType;
+    }
+  }
+
+  return {
+    type,
+    objects: allObjects,
+  };
+};
+/* eslint-enable no-console */

--- a/packages/ingestor/src/lib/ingestLegacyObjectsToSkylark/main.ts
+++ b/packages/ingestor/src/lib/ingestLegacyObjectsToSkylark/main.ts
@@ -1,0 +1,164 @@
+import "../../env";
+import "./env";
+import { SAAS_API_ENDPOINT, SAAS_API_KEY } from "@skylark-reference-apps/lib";
+import { fetchObjectsFromLegacySkylark } from "./legacy";
+import { createObjectsInSkylark } from "./skylark";
+import {
+  LegacyAsset,
+  LegacyBrand,
+  LegacyEpisode,
+  LegacyObjectType,
+  LegacySeason,
+  LegacyTag,
+  LegacyTagCategory,
+} from "./types/legacySkylark";
+import { CreatedSkylarkObjects } from "./types/skylark";
+import { setAccountConfiguration } from "../skylark/saas/account";
+import {
+  activateConfigurationVersion,
+  updateEnumTypes,
+  waitForUpdatingSchema,
+} from "../skylark/saas/schema";
+
+/* eslint-disable no-console */
+// For Macademia
+// - Miro: https://miro.com/app/board/uXjVMDOKvio=/
+
+// const objectTypes = [
+//   "Brand",
+//   "Season",
+//   "Episode",
+//   "Asset",
+//   "Availability", // Not in use / make everything always available (No dimensions)
+//   "Tags", // Game/App only
+//   "Imagery", // Ignore
+//   "Ratings", // Ignore
+// ];
+
+const checkEnvVars = () => {
+  const legacyApiUrl = process.env.LEGACY_API_URL;
+  const legacyToken = process.env.LEGACY_SKYLARK_TOKEN;
+
+  if (!legacyApiUrl)
+    throw new Error("process.env.LEGACY_API_URL cannot be undefined");
+
+  if (!legacyToken)
+    throw new Error("process.env.LEGACY_SKYLARK_TOKEN cannot be undefined");
+
+  if (!SAAS_API_ENDPOINT)
+    throw new Error("process.env.SAAS_API_ENDPOINT cannot be undefined");
+
+  if (!SAAS_API_KEY)
+    throw new Error("process.env.SAAS_API_KEY cannot be undefined");
+
+  console.log("Legacy API URL:", legacyApiUrl);
+  console.log("Skylark API URL:", SAAS_API_ENDPOINT);
+};
+
+const updateSkylarkSchema = async ({
+  assetTypes,
+}: {
+  assetTypes: string[];
+}) => {
+  const initialVersion = await waitForUpdatingSchema();
+  console.log("--- initial schema version:", initialVersion);
+
+  const { version: updatedVersion } = await updateEnumTypes(
+    "AssetType",
+    assetTypes,
+    initialVersion
+  );
+
+  if (updatedVersion !== initialVersion) {
+    console.log("--- activating schema version:", updatedVersion);
+    await activateConfigurationVersion(updatedVersion);
+    await waitForUpdatingSchema(updatedVersion);
+  }
+};
+
+const fetchLegacyObjects = async () => {
+  const tagCategories = await fetchObjectsFromLegacySkylark<LegacyTagCategory>(
+    LegacyObjectType.TagCategories
+  );
+
+  const tags = await fetchObjectsFromLegacySkylark<LegacyTag>(
+    LegacyObjectType.Tags
+  );
+
+  const assets = await fetchObjectsFromLegacySkylark<LegacyAsset>(
+    LegacyObjectType.Assets
+  );
+
+  const episodes = await fetchObjectsFromLegacySkylark<LegacyEpisode>(
+    LegacyObjectType.Episodes
+  );
+
+  const seasons = await fetchObjectsFromLegacySkylark<LegacySeason>(
+    LegacyObjectType.Seasons
+  );
+
+  const brands = await fetchObjectsFromLegacySkylark<LegacyBrand>(
+    LegacyObjectType.Brands
+  );
+
+  return {
+    tagCategories,
+    tags,
+    assets,
+    episodes,
+    seasons,
+    brands,
+  };
+};
+
+const main = async () => {
+  checkEnvVars();
+
+  console.log("\nFetching Objects from Legacy Skylark...");
+  const legacyObjects = await fetchLegacyObjects();
+
+  const assetTypes = [
+    ...new Set(
+      Object.values(legacyObjects.assets.objects)
+        .flatMap((arr) => arr)
+        .map(({ asset_type_url }) => asset_type_url?.name)
+    ),
+  ].filter((name): name is string => !!name);
+  console.log("--- required asset type enums:", assetTypes.join(", "));
+
+  console.log("\nUpdating Skylark Schema...");
+  await updateSkylarkSchema({ assetTypes });
+
+  console.log("\nUpdating Skylark Account...");
+  await setAccountConfiguration({ defaultLanguage: "en" });
+
+  console.log("\nCreating Legacy Objects in Skylark...");
+
+  const skylarkObjects: CreatedSkylarkObjects = {
+    tagCategories: [],
+    tags: [],
+    assets: [],
+    episodes: [],
+    seasons: [],
+    brands: [],
+  };
+
+  skylarkObjects.tagCategories = await createObjectsInSkylark(
+    legacyObjects.tagCategories,
+    skylarkObjects
+  );
+
+  skylarkObjects.tagCategories = await createObjectsInSkylark(
+    legacyObjects.tags,
+    skylarkObjects
+  );
+
+  await createObjectsInSkylark(legacyObjects.assets, skylarkObjects);
+
+  // await createObjectsInSkylark(legacyObjects.seasons);
+
+  console.log("\nObjects Created Successfully.");
+};
+
+main().catch(console.error);
+/* eslint-enable no-console */

--- a/packages/ingestor/src/lib/ingestLegacyObjectsToSkylark/main.ts
+++ b/packages/ingestor/src/lib/ingestLegacyObjectsToSkylark/main.ts
@@ -72,10 +72,10 @@ const updateSkylarkSchema = async ({
     initialVersion
   );
 
-  if (updatedVersion !== initialVersion) {
+  if (updatedVersion && updatedVersion !== initialVersion) {
     console.log("--- Activating Schema version:", updatedVersion);
     await activateConfigurationVersion(updatedVersion);
-    await waitForUpdatingSchema(updatedVersion);
+    await waitForUpdatingSchema();
   }
 };
 

--- a/packages/ingestor/src/lib/ingestLegacyObjectsToSkylark/main.ts
+++ b/packages/ingestor/src/lib/ingestLegacyObjectsToSkylark/main.ts
@@ -148,14 +148,30 @@ const main = async () => {
     skylarkObjects
   );
 
-  skylarkObjects.tagCategories = await createObjectsInSkylark(
+  skylarkObjects.tags = await createObjectsInSkylark(
     legacyObjects.tags,
     skylarkObjects
   );
 
-  await createObjectsInSkylark(legacyObjects.assets, skylarkObjects);
+  skylarkObjects.assets = await createObjectsInSkylark(
+    legacyObjects.assets,
+    skylarkObjects
+  );
 
-  // await createObjectsInSkylark(legacyObjects.seasons);
+  skylarkObjects.episodes = await createObjectsInSkylark(
+    legacyObjects.episodes,
+    skylarkObjects
+  );
+
+  skylarkObjects.seasons = await createObjectsInSkylark(
+    legacyObjects.seasons,
+    skylarkObjects
+  );
+
+  skylarkObjects.brands = await createObjectsInSkylark(
+    legacyObjects.brands,
+    skylarkObjects
+  );
 
   console.log("\nObjects Created Successfully.");
 };

--- a/packages/ingestor/src/lib/ingestLegacyObjectsToSkylark/main.ts
+++ b/packages/ingestor/src/lib/ingestLegacyObjectsToSkylark/main.ts
@@ -2,7 +2,6 @@ import "../../env";
 import "./env";
 import { SAAS_API_ENDPOINT, SAAS_API_KEY } from "@skylark-reference-apps/lib";
 import { fetchObjectsFromLegacySkylark } from "./legacy";
-import { createObjectsInSkylark } from "./skylark";
 import {
   LegacyAsset,
   LegacyBrand,
@@ -19,6 +18,9 @@ import {
   updateEnumTypes,
   waitForUpdatingSchema,
 } from "../skylark/saas/schema";
+import { ALWAYS_FOREVER_AVAILABILITY_EXT_ID } from "./constants";
+import { createAlwaysAndForeverAvailability } from "../skylark/saas/availability";
+import { createObjectsInSkylark } from "./skylark";
 
 /* eslint-disable no-console */
 // For Macademia
@@ -132,6 +134,11 @@ const main = async () => {
   console.log("\nUpdating Skylark Account...");
   await setAccountConfiguration({ defaultLanguage: "en" });
 
+  console.log("\nCreating Always & Forever Availability");
+  const alwaysAvailability = await createAlwaysAndForeverAvailability(
+    ALWAYS_FOREVER_AVAILABILITY_EXT_ID
+  );
+
   console.log("\nCreating Legacy Objects in Skylark...");
 
   const skylarkObjects: CreatedSkylarkObjects = {
@@ -145,32 +152,38 @@ const main = async () => {
 
   skylarkObjects.tagCategories = await createObjectsInSkylark(
     legacyObjects.tagCategories,
-    skylarkObjects
+    skylarkObjects,
+    alwaysAvailability
   );
 
   skylarkObjects.tags = await createObjectsInSkylark(
     legacyObjects.tags,
-    skylarkObjects
+    skylarkObjects,
+    alwaysAvailability
   );
 
   skylarkObjects.assets = await createObjectsInSkylark(
     legacyObjects.assets,
-    skylarkObjects
+    skylarkObjects,
+    alwaysAvailability
   );
 
   skylarkObjects.episodes = await createObjectsInSkylark(
     legacyObjects.episodes,
-    skylarkObjects
+    skylarkObjects,
+    alwaysAvailability
   );
 
   skylarkObjects.seasons = await createObjectsInSkylark(
     legacyObjects.seasons,
-    skylarkObjects
+    skylarkObjects,
+    alwaysAvailability
   );
 
   skylarkObjects.brands = await createObjectsInSkylark(
     legacyObjects.brands,
-    skylarkObjects
+    skylarkObjects,
+    alwaysAvailability
   );
 
   console.log("\nObjects Created Successfully.");

--- a/packages/ingestor/src/lib/ingestLegacyObjectsToSkylark/main.ts
+++ b/packages/ingestor/src/lib/ingestLegacyObjectsToSkylark/main.ts
@@ -18,7 +18,10 @@ import {
   updateEnumTypes,
   waitForUpdatingSchema,
 } from "../skylark/saas/schema";
-import { ALWAYS_FOREVER_AVAILABILITY_EXT_ID } from "./constants";
+import {
+  ALWAYS_FOREVER_AVAILABILITY_EXT_ID,
+  USED_LANGUAGES,
+} from "./constants";
 import { createAlwaysAndForeverAvailability } from "../skylark/saas/availability";
 import { createObjectsInSkylark } from "./skylark";
 
@@ -63,7 +66,7 @@ const updateSkylarkSchema = async ({
   assetTypes: string[];
 }) => {
   const initialVersion = await waitForUpdatingSchema();
-  console.log("--- initial schema version:", initialVersion);
+  console.log("--- Initial Schema version:", initialVersion);
 
   const { version: updatedVersion } = await updateEnumTypes(
     "AssetType",
@@ -103,7 +106,7 @@ const fetchLegacyObjects = async () => {
     LegacyObjectType.Brands
   );
 
-  return {
+  const retObj = {
     tagCategories,
     tags,
     assets,
@@ -111,6 +114,16 @@ const fetchLegacyObjects = async () => {
     seasons,
     brands,
   };
+
+  const totalObjectsFound = Object.values(retObj).reduce(
+    (previous, { totalFound }) => previous + totalFound,
+    0
+  );
+  console.log(
+    `--- ${totalObjectsFound} objects found (${USED_LANGUAGES.length} languages checked)`
+  );
+
+  return retObj;
 };
 
 const main = async () => {
@@ -126,7 +139,7 @@ const main = async () => {
         .map(({ asset_type_url }) => asset_type_url?.name)
     ),
   ].filter((name): name is string => !!name);
-  console.log("--- required asset type enums:", assetTypes.join(", "));
+  console.log("--- Required Asset type enums:", assetTypes.join(", "));
 
   console.log("\nUpdating Skylark Schema...");
   await updateSkylarkSchema({ assetTypes });

--- a/packages/ingestor/src/lib/ingestLegacyObjectsToSkylark/main.ts
+++ b/packages/ingestor/src/lib/ingestLegacyObjectsToSkylark/main.ts
@@ -1,17 +1,8 @@
+/* eslint-disable no-console */
 import "../../env";
 import "./env";
 import { SAAS_API_ENDPOINT, SAAS_API_KEY } from "@skylark-reference-apps/lib";
-import {
-  ensureDir,
-  ensureFile,
-  exists,
-  outputFile,
-  readFile,
-  readJson,
-  readdir,
-  writeFile,
-} from "fs-extra";
-import { join } from "path";
+import { ensureDir } from "fs-extra";
 import { fetchObjectsFromLegacySkylark } from "./legacy";
 import {
   LegacyAsset,
@@ -19,7 +10,6 @@ import {
   LegacyCommonObject,
   LegacyEpisode,
   LegacyObjectType,
-  LegacyObjects,
   LegacySeason,
   LegacyTag,
   LegacyTagCategory,
@@ -37,21 +27,16 @@ import { setAccountConfiguration } from "../skylark/saas/account";
 import { createAlwaysAndForeverAvailability } from "../skylark/saas/availability";
 import { createObjectsInSkylark } from "./skylark";
 import { CreatedSkylarkObjects } from "./types/skylark";
-
-/* eslint-disable no-console */
-// For Macademia
-// - Miro: https://miro.com/app/board/uXjVMDOKvio=/
-
-// const objectTypes = [
-//   "Brand",
-//   "Season",
-//   "Episode",
-//   "Asset",
-//   "Availability", // Not in use / make everything always available (No dimensions)
-//   "Tags", // Game/App only
-//   "Imagery", // Ignore
-//   "Ratings", // Ignore
-// ];
+import {
+  createLegacyObjectsTimeStampedDir,
+  getMostRecentLegacyObjectsDir,
+  readObjectsFromFile,
+  writeAllLegacyObjectsToDisk,
+  writeError,
+  writeLegacyObjectsToDisk,
+  writeStatsForLegacyObjectsToDisk,
+} from "./fs";
+import { calculateTotalObjects } from "./utils";
 
 const checkEnvVars = () => {
   const legacyApiUrl = process.env.LEGACY_API_URL;
@@ -73,24 +58,6 @@ const checkEnvVars = () => {
   console.log("Skylark API URL:", SAAS_API_ENDPOINT);
 };
 
-const calculateTotalObjects = (
-  objects: Record<
-    string,
-    {
-      type: LegacyObjectType;
-      objects: Record<string, LegacyObjects>;
-      totalFound: number;
-    }
-  >
-) => {
-  const totalObjectsFound = Object.values(objects).reduce(
-    (previous, { totalFound }) => previous + totalFound,
-    0
-  );
-
-  return totalObjectsFound;
-};
-
 const updateSkylarkSchema = async ({
   assetTypes,
 }: {
@@ -109,119 +76,6 @@ const updateSkylarkSchema = async ({
     console.log("--- Activating Schema version:", updatedVersion);
     await activateConfigurationVersion(updatedVersion);
     await waitForUpdatingSchema(updatedVersion);
-  }
-};
-
-const generateEnvIdentifier = () => {
-  const onlyDataCreatedInLastMonth =
-    process.env.LEGACY_DATA_LAST_MONTH_ONLY === "true";
-
-  const env = process.env.LEGACY_API_URL
-    ? process.env.LEGACY_API_URL.replace("https://", "")
-        .replaceAll(".", "_")
-        .replaceAll("-", "_")
-    : "unknown";
-
-  if (onlyDataCreatedInLastMonth) {
-    return `${env}_last_month_only`;
-  }
-
-  return env;
-};
-
-const generateLegacyObjectsDir = () => {
-  const env = generateEnvIdentifier();
-
-  const dir = join(__dirname, "outputs", "legacy_data", env);
-  return dir;
-};
-
-const createLegacyObjectsTimeStampedDir = async () => {
-  const dateStamp = new Date().toISOString();
-
-  const dir = join(generateLegacyObjectsDir(), dateStamp);
-
-  await ensureDir(dir);
-
-  return dir;
-};
-
-const writeLegacyObjectsToDisk = async <T>(
-  dir: string,
-  obj: {
-    type: LegacyObjectType;
-    objects: Record<string, T[]>;
-    totalFound: number;
-  }
-) => {
-  try {
-    await writeFile(
-      join(dir, `${obj.type}.json`),
-      JSON.stringify(obj, null, 4)
-    );
-  } catch (err) {
-    console.error(
-      `[writeLegacyObjectsToDisk] Failed to write ${obj.type} data`
-    );
-  }
-};
-
-const writeAllLegacyObjectsToDisk = async (
-  objects: Record<
-    string,
-    {
-      type: LegacyObjectType;
-      objects: Record<string, LegacyObjects>;
-      totalFound: number;
-    }
-  >
-) => {
-  try {
-    const dir = await createLegacyObjectsTimeStampedDir();
-
-    await Promise.all(
-      Object.values(objects).map((value) =>
-        writeLegacyObjectsToDisk<LegacyObjects[0]>(dir, value)
-      )
-    );
-  } catch (err) {
-    console.error("[writeAllLegacyObjectsToDisk] Failed to write data");
-  }
-};
-
-const writeStatsForLegacyObjectsToDisk = async (
-  legacyObjects: Record<
-    string,
-    {
-      type: LegacyObjectType;
-      objects: Record<string, LegacyObjects>;
-      totalFound: number;
-    }
-  >
-) => {
-  try {
-    const env = generateEnvIdentifier();
-    const file = join(generateLegacyObjectsDir(), "stats.md");
-
-    await ensureFile(file);
-
-    const totalObjectsFound = calculateTotalObjects(legacyObjects);
-
-    let contents = `# Stats for ${env}\n\nTotal objects across ${USED_LANGUAGES.length} languages: ${totalObjectsFound}`;
-
-    Object.values(legacyObjects).forEach(({ type, objects, totalFound }) => {
-      contents += `\n\n## ${type} (${totalFound} total)\n`;
-
-      Object.entries(objects).forEach(([language, objs]) => {
-        contents += `  - \`${language.toLowerCase()}\`: \`${objs.length}\`\n`;
-      });
-
-      contents += "\n---";
-    });
-
-    await writeFile(file, contents);
-  } catch (err) {
-    console.error("[writeAllLegacyObjectsToDisk] Failed to write data");
   }
 };
 
@@ -284,41 +138,6 @@ const fetchLegacyObjects = async () => {
   );
 
   return retObj;
-};
-
-const getMostRecentLegacyObjectsDir = async () => {
-  const parentDir = generateLegacyObjectsDir();
-  await ensureDir(parentDir);
-
-  const objectDirs = (await readdir(parentDir)).filter(
-    (dir) => dir !== "stats.md"
-  );
-
-  const [mostRecentDir] = objectDirs.sort(
-    (a, b) => +new Date(b) - +new Date(a)
-  );
-
-  return join(parentDir, mostRecentDir);
-};
-
-const readObjectsFromFile = async <T>(dir: string, type: LegacyObjectType) => {
-  const file = join(dir, `${type}.json`);
-
-  if (!(await exists(file))) {
-    return {
-      type,
-      objects: {},
-      totalFound: 0,
-    };
-  }
-
-  const data = (await readJson(file)) as {
-    type: LegacyObjectType;
-    objects: Record<string, T[]>;
-    totalFound: number;
-  };
-
-  return data;
 };
 
 const readLegacyObjectsFromFile = async () => {
@@ -464,23 +283,6 @@ const main = async () => {
   );
 
   console.log("\nObjects Created Successfully.");
-};
-
-const writeError = async (err: unknown) => {
-  const errorFile = join(__dirname, "outputs", "ingest_errors.md");
-
-  await ensureFile(errorFile);
-
-  const contents = await readFile(errorFile, "utf8");
-
-  const dateStamp = new Date().toISOString();
-  const readFromDisk = process.env.READ_LEGACY_OBJECTS_FROM_DISK === "true";
-
-  const newContents = `${contents}\n---\n\n## ${dateStamp} (${
-    readFromDisk ? "Data from disk" : "Data from Skylark"
-  })\n\n\`\`\`\n${err as string}\n\`\`\`\n`;
-
-  await outputFile(errorFile, newContents);
 };
 
 main().catch((err) => {

--- a/packages/ingestor/src/lib/ingestLegacyObjectsToSkylark/skylark.ts
+++ b/packages/ingestor/src/lib/ingestLegacyObjectsToSkylark/skylark.ts
@@ -1,5 +1,6 @@
 import { GraphQLObjectTypes } from "@skylark-reference-apps/lib";
 import {
+  LegacyAsset,
   LegacyBrand,
   LegacyEpisode,
   LegacyObjectType,
@@ -40,7 +41,7 @@ const convertLegacyObjectTypeToObjectType = (
 };
 
 const getSynopsisForMedia = (
-  legacyObject: LegacyEpisode | LegacyBrand | LegacySeason
+  legacyObject: LegacyEpisode | LegacyBrand | LegacySeason | LegacyAsset
 ) => {
   // We want to make sure that we add synopsis, then short_synopsis in the order alternate_synopsis -> synopsis -> extended_synopsis
   const synopsis =
@@ -81,13 +82,18 @@ const convertLegacyObject = (
     if (assetType && ASSET_TYPES_TO_IGNORE.includes(assetType)) {
       return null;
     }
+    const { synopsis, synopsisShort } = getSynopsisForMedia(legacyObject);
 
     return {
       ...commonFields,
       internal_title: legacyObject.name,
+      title: legacyObject.title,
+      synopsis,
+      synopsis_short: synopsisShort,
       type: assetType,
       duration: legacyObject.duration_in_seconds,
       url: legacyObject.url !== "" ? legacyObject.url : null,
+      // state: legacyObject.state, Can't add this to SkylarkAsset
     };
   }
 

--- a/packages/ingestor/src/lib/ingestLegacyObjectsToSkylark/skylark.ts
+++ b/packages/ingestor/src/lib/ingestLegacyObjectsToSkylark/skylark.ts
@@ -172,7 +172,8 @@ export const createObjectsInSkylark = async (
     type: LegacyObjectType;
     objects: Record<string, LegacyObjects>;
   },
-  relationshipObjects: CreatedSkylarkObjects
+  relationshipObjects: CreatedSkylarkObjects,
+  alwaysAvailability: GraphQLBaseObject
 ): Promise<GraphQLBaseObject[]> => {
   const objectType = convertLegacyObjectTypeToObjectType(type);
 
@@ -220,13 +221,15 @@ export const createObjectsInSkylark = async (
       language,
     }));
 
+    const availabilityUids = [alwaysAvailability.uid];
+
     const createdLanguageObjects =
       // eslint-disable-next-line no-await-in-loop
       await createOrUpdateGraphQlObjectsUsingIntrospection(
         objectType,
         existingObjects,
         objectsToCreate,
-        { language, relationships }
+        { language, relationships, availabilityUids }
       );
 
     accaArr.push(createdLanguageObjects);

--- a/packages/ingestor/src/lib/ingestLegacyObjectsToSkylark/skylark.ts
+++ b/packages/ingestor/src/lib/ingestLegacyObjectsToSkylark/skylark.ts
@@ -1,0 +1,219 @@
+import { GraphQLObjectTypes } from "@skylark-reference-apps/lib";
+import {
+  LegacyBrand,
+  LegacyEpisode,
+  LegacyObjectType,
+  LegacyObjects,
+  LegacySeason,
+} from "./types/legacySkylark";
+import { createOrUpdateGraphQlObjectsUsingIntrospection } from "../skylark/saas/create";
+import { GraphQLBaseObject } from "../interfaces";
+import { getExistingObjects } from "../skylark/saas/get";
+import { CreatedSkylarkObjects } from "./types/skylark";
+import { createRelationships } from "./skylarkRelationships";
+import { ASSET_TYPES_TO_IGNORE } from "./constants";
+
+type ConvertedLegacyObject = { external_id: string } & Record<
+  string,
+  string | null | string[] | boolean | number | object
+>;
+
+const convertLegacyObjectTypeToObjectType = (
+  legacyType: LegacyObjectType
+): GraphQLObjectTypes => {
+  switch (legacyType) {
+    case LegacyObjectType.TagCategories:
+      return "TagCategory";
+    case LegacyObjectType.Tags:
+      return "SkylarkTag";
+    case LegacyObjectType.Assets:
+      return "SkylarkAsset";
+    case LegacyObjectType.Episodes:
+      return "Episode";
+    case LegacyObjectType.Seasons:
+      return "Season";
+    case LegacyObjectType.Brands:
+      return "Brand";
+    default:
+      throw new Error("[convertLegacyObjectTypeToObjectType] Unknown type");
+  }
+};
+
+const getSynopsisForMedia = (
+  legacyObject: LegacyEpisode | LegacyBrand | LegacySeason
+) => {
+  // We want to make sure that we add synopsis, then short_synopsis in the order alternate_synopsis -> synopsis -> extended_synopsis
+  const synopsis =
+    legacyObject.alternate_synopsis ||
+    legacyObject.synopsis ||
+    legacyObject.extended_synopsis;
+  const synopsisShort =
+    (synopsis && synopsis !== legacyObject.synopsis && legacyObject.synopsis) ||
+    (synopsis !== legacyObject.extended_synopsis &&
+      legacyObject.extended_synopsis) ||
+    "";
+
+  return {
+    synopsis,
+    synopsisShort,
+  };
+};
+
+const convertLegacyObject = (
+  legacyObject: LegacyObjects[0]
+): ConvertedLegacyObject | null => {
+  // eslint-disable-next-line no-underscore-dangle
+  const legacyObjectType = legacyObject._type;
+  const legacyUid = legacyObject.uid;
+  if (!legacyObjectType) {
+    throw new Error(
+      `[convertLegacyObject] Unknown legacy object type: ${legacyUid}`
+    );
+  }
+
+  const commonFields = {
+    ...legacyObject, // By adding the whole legacy object to each object, the introspection create will add any missing fields that are
+    external_id: legacyObject.uid,
+  };
+
+  if (legacyObjectType === LegacyObjectType.Assets) {
+    const assetType = legacyObject.asset_type_url?.name || null;
+    if (assetType && ASSET_TYPES_TO_IGNORE.includes(assetType)) {
+      return null;
+    }
+
+    return {
+      ...commonFields,
+      internal_title: legacyObject.name,
+      type: assetType,
+      duration: legacyObject.duration_in_seconds,
+      url: legacyObject.url !== "" ? legacyObject.url : null,
+    };
+  }
+
+  if (legacyObjectType === LegacyObjectType.Episodes) {
+    const { synopsis, synopsisShort } = getSynopsisForMedia(legacyObject);
+    return {
+      ...commonFields,
+      internal_title: legacyObject.name,
+      title: legacyObject.title,
+      synopsis,
+      synopsis_short: synopsisShort,
+      episode_number: legacyObject.episode_number,
+    };
+  }
+
+  if (legacyObjectType === LegacyObjectType.Seasons) {
+    const { synopsis, synopsisShort } = getSynopsisForMedia(legacyObject);
+
+    return {
+      ...commonFields,
+      internal_title: legacyObject.name,
+      title: legacyObject.title,
+      synopsis,
+      synopsis_short: synopsisShort,
+      season_number: legacyObject.season_number,
+      number_of_episodes: legacyObject.number_of_episodes,
+    };
+  }
+
+  return commonFields;
+};
+
+export const createObjectsInSkylark = async (
+  {
+    type,
+    objects: legacyObjectsAndLanguage,
+  }: {
+    type: LegacyObjectType;
+    objects: Record<string, LegacyObjects>;
+  },
+  relationshipObjects: CreatedSkylarkObjects
+): Promise<GraphQLBaseObject[]> => {
+  const objectType = convertLegacyObjectTypeToObjectType(type);
+
+  const languages = Object.keys(legacyObjectsAndLanguage);
+
+  if (languages.length === 0) {
+    return [];
+  }
+
+  const existingObjectsAcca: string[][] = [];
+
+  // eslint-disable-next-line no-restricted-syntax
+  for (const language of languages) {
+    const externalIds = legacyObjectsAndLanguage[language].map(({ uid }) => ({
+      externalId: uid,
+    }));
+
+    // eslint-disable-next-line no-await-in-loop
+    const existingObjects = await getExistingObjects(
+      objectType,
+      externalIds,
+      language
+    );
+
+    existingObjectsAcca.push(existingObjects);
+  }
+
+  const flattenedExistingObjects: string[] = existingObjectsAcca.flatMap(
+    (arr) => arr
+  );
+  const existingObjects = [...new Set(flattenedExistingObjects)] as string[];
+
+  const accaArr: GraphQLBaseObject[][] = [];
+
+  // eslint-disable-next-line no-restricted-syntax
+  for (const language of languages) {
+    const legacyObjects = legacyObjectsAndLanguage[language];
+    const parsedLegacyObjects = legacyObjects
+      .map(convertLegacyObject)
+      .filter((obj): obj is ConvertedLegacyObject => !!obj);
+
+    const relationships: Record<string, Record<string, { link: string[] }>> = (
+      legacyObjects as LegacyObjects[0][]
+    ).reduce((previous, obj) => {
+      const objRelationships = createRelationships(obj, relationshipObjects);
+
+      if (!objRelationships) {
+        return previous;
+      }
+
+      return {
+        ...previous,
+        [obj.uid]: objRelationships,
+      };
+    }, {});
+
+    console.log(relationships);
+
+    const objectsToCreate = parsedLegacyObjects.map((obj) => ({
+      ...obj,
+      _id: obj.external_id,
+      language,
+    }));
+
+    const createdLanguageObjects =
+      // eslint-disable-next-line no-await-in-loop
+      await createOrUpdateGraphQlObjectsUsingIntrospection(
+        objectType,
+        existingObjects,
+        objectsToCreate,
+        { language, relationships }
+      );
+
+    accaArr.push(createdLanguageObjects);
+  }
+
+  const createdObjects = accaArr.flatMap((a) => a);
+
+  const uniqueBaseObjects = createdObjects.filter(
+    (a, index, self) =>
+      index ===
+      self.findIndex((b) => a.uid === b.uid && a.external_id === b.external_id)
+  );
+
+  console.log(createdObjects, uniqueBaseObjects);
+
+  return uniqueBaseObjects;
+};

--- a/packages/ingestor/src/lib/ingestLegacyObjectsToSkylark/skylarkRelationships.ts
+++ b/packages/ingestor/src/lib/ingestLegacyObjectsToSkylark/skylarkRelationships.ts
@@ -1,0 +1,103 @@
+import { GraphQLBaseObject } from "../interfaces";
+import {
+  LegacyAsset,
+  LegacyBrand,
+  LegacyEpisode,
+  LegacyObjects,
+  LegacyObjectType,
+  LegacySeason,
+} from "./types/legacySkylark";
+import { CreatedSkylarkObjects } from "./types/skylark";
+
+const getLegacyUidFromUrl = (url: string) => {
+  // e.g. /api/tag-categories/cate_44ef19d0f44a4775af16bf7cf35f25b9/
+  const uid = url.split("/")?.[3];
+  if (!uid) {
+    throw new Error(`Unable to parse legacy UID from "${url}"`);
+  }
+  return uid;
+};
+
+const getTags = (
+  legacyObject: LegacyAsset | LegacyEpisode | LegacySeason | LegacyBrand,
+  skylarkTags: GraphQLBaseObject[]
+) => {
+  const legacyTagExtIds = legacyObject.tags.map(({ tag_url }) => tag_url);
+  const tags = legacyTagExtIds
+    .map((extId) => skylarkTags.find((tag) => tag.external_id === extId))
+    .filter((tag): tag is GraphQLBaseObject => !!tag);
+  const tagUids = tags.map(({ uid }) => uid);
+
+  return tagUids;
+};
+
+export const createRelationships = (
+  legacyObject: LegacyObjects[0],
+  relationshipObjects: CreatedSkylarkObjects
+): Record<string, { link: string[] }> | undefined => {
+  // eslint-disable-next-line no-underscore-dangle
+  const legacyObjectType = legacyObject._type;
+  const legacyUid = legacyObject.uid;
+  if (!legacyObjectType) {
+    throw new Error(
+      // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
+      `[convertLegacyObject] Unknown legacy object type: ${legacyUid}`
+    );
+  }
+
+  // {relationships: {tag_categories: {link: ""}}}
+
+  if (legacyObjectType === LegacyObjectType.TagCategories) {
+    return undefined;
+  }
+
+  if (legacyObjectType === LegacyObjectType.Tags) {
+    const categoryExtId = getLegacyUidFromUrl(legacyObject.category_url);
+    const createdCategory = relationshipObjects.tagCategories.find(
+      ({ external_id }) => external_id === categoryExtId
+    );
+    return {
+      tag_categories: {
+        link: createdCategory ? [createdCategory.uid] : [],
+      },
+    };
+  }
+
+  if (legacyObjectType === LegacyObjectType.Assets) {
+    const tagUids = getTags(legacyObject, relationshipObjects.tags);
+    return {
+      tags: {
+        link: tagUids,
+      },
+    };
+  }
+
+  if (legacyObjectType === LegacyObjectType.Episodes) {
+    const tagUids = getTags(legacyObject, relationshipObjects.tags);
+    return {
+      tags: {
+        link: tagUids,
+      },
+    };
+  }
+
+  if (legacyObjectType === LegacyObjectType.Seasons) {
+    const tagUids = getTags(legacyObject, relationshipObjects.tags);
+    return {
+      tags: {
+        link: tagUids,
+      },
+    };
+  }
+
+  if (legacyObjectType === LegacyObjectType.Brands) {
+    const tagUids = getTags(legacyObject, relationshipObjects.tags);
+    return {
+      tags: {
+        link: tagUids,
+      },
+    };
+  }
+
+  return undefined;
+};

--- a/packages/ingestor/src/lib/ingestLegacyObjectsToSkylark/skylarkRelationships.ts
+++ b/packages/ingestor/src/lib/ingestLegacyObjectsToSkylark/skylarkRelationships.ts
@@ -5,28 +5,58 @@ import {
   LegacyEpisode,
   LegacyObjects,
   LegacyObjectType,
+  LegacyObjectUidPrefix,
   LegacySeason,
 } from "./types/legacySkylark";
 import { CreatedSkylarkObjects } from "./types/skylark";
 
 const getLegacyUidFromUrl = (url: string) => {
+  if (!url.includes("/")) {
+    throw new Error(
+      `[getLegacyUidFromUrl] URL does not contain array separator" ${url}`
+    );
+  }
+
   // e.g. /api/tag-categories/cate_44ef19d0f44a4775af16bf7cf35f25b9/
   const uid = url.split("/")?.[3];
   if (!uid) {
-    throw new Error(`Unable to parse legacy UID from "${url}"`);
+    throw new Error(
+      `[getLegacyUidFromUrl] Unable to parse legacy UID from "${url}"`
+    );
   }
   return uid;
+};
+
+const getUidsFromExtIds = (extIds: string[], objects: GraphQLBaseObject[]) => {
+  const uids = extIds
+    .map((extId) => objects.find(({ external_id }) => extId === external_id))
+    .filter((obj): obj is GraphQLBaseObject => !!obj)
+    .map(({ uid }) => uid);
+
+  return uids;
+};
+
+const getUidsFromUrls = (
+  urls: string[],
+  objects: GraphQLBaseObject[],
+  prefix: string
+) => {
+  const extIds = urls
+    .map(getLegacyUidFromUrl)
+    .filter((extId) => extId.startsWith(prefix));
+  const uids = getUidsFromExtIds(extIds, objects);
+
+  return uids;
 };
 
 const getTags = (
   legacyObject: LegacyAsset | LegacyEpisode | LegacySeason | LegacyBrand,
   skylarkTags: GraphQLBaseObject[]
 ) => {
-  const legacyTagExtIds = legacyObject.tags.map(({ tag_url }) => tag_url);
-  const tags = legacyTagExtIds
-    .map((extId) => skylarkTags.find((tag) => tag.external_id === extId))
-    .filter((tag): tag is GraphQLBaseObject => !!tag);
-  const tagUids = tags.map(({ uid }) => uid);
+  const legacyTagExtIds = legacyObject.tags.map(({ tag_url }) =>
+    getLegacyUidFromUrl(tag_url)
+  );
+  const tagUids = getUidsFromExtIds(legacyTagExtIds, skylarkTags);
 
   return tagUids;
 };
@@ -74,19 +104,87 @@ export const createRelationships = (
 
   if (legacyObjectType === LegacyObjectType.Episodes) {
     const tagUids = getTags(legacyObject, relationshipObjects.tags);
+
+    const assetUids = getUidsFromUrls(
+      legacyObject.items,
+      relationshipObjects.assets,
+      LegacyObjectUidPrefix.Asset
+    );
     return {
       tags: {
         link: tagUids,
+      },
+      assets: {
+        link: assetUids,
       },
     };
   }
 
   if (legacyObjectType === LegacyObjectType.Seasons) {
     const tagUids = getTags(legacyObject, relationshipObjects.tags);
+
+    const assetUids = getUidsFromUrls(
+      legacyObject.items,
+      relationshipObjects.assets,
+      LegacyObjectUidPrefix.Asset
+    );
+
+    const episodeUids = getUidsFromUrls(
+      legacyObject.items,
+      relationshipObjects.episodes,
+      LegacyObjectUidPrefix.Episode
+    );
     return {
       tags: {
         link: tagUids,
       },
+      assets: {
+        link: assetUids,
+      },
+      episodes: {
+        link: episodeUids,
+      },
+    };
+  }
+
+  if (legacyObjectType === LegacyObjectType.Brands) {
+    const tagUids = getTags(legacyObject, relationshipObjects.tags);
+
+    const assetUids = getUidsFromUrls(
+      legacyObject.items,
+      relationshipObjects.assets,
+      LegacyObjectUidPrefix.Asset
+    );
+
+    const episodeUids = getUidsFromUrls(
+      legacyObject.items,
+      relationshipObjects.episodes,
+      LegacyObjectUidPrefix.Episode
+    );
+
+    const seasonUids = getUidsFromUrls(
+      legacyObject.items,
+      relationshipObjects.seasons,
+      LegacyObjectUidPrefix.Season
+    );
+
+    return {
+      tags: {
+        link: tagUids,
+      },
+      assets: {
+        link: assetUids,
+      },
+      episodes: {
+        link: episodeUids,
+      },
+      seasons: {
+        link: seasonUids,
+      },
+      // TODO confirm this is needed. Implementation is a bit tricky
+      // brands: {
+      //   link: brandUids,
+      // },
     };
   }
 

--- a/packages/ingestor/src/lib/ingestLegacyObjectsToSkylark/skylarkRelationships.ts
+++ b/packages/ingestor/src/lib/ingestLegacyObjectsToSkylark/skylarkRelationships.ts
@@ -27,13 +27,18 @@ const getLegacyUidFromUrl = (url: string) => {
   return uid;
 };
 
-const getUidsFromExtIds = (extIds: string[], objects: GraphQLBaseObject[]) => {
+const getUidsFromExtIds = (
+  extIds: string[],
+  objects: GraphQLBaseObject[]
+): string[] => {
   const uids = extIds
     .map((extId) => objects.find(({ external_id }) => extId === external_id))
     .filter((obj): obj is GraphQLBaseObject => !!obj)
     .map(({ uid }) => uid);
 
-  return uids;
+  const uniqueUids = [...new Set(uids)] as string[];
+
+  return uniqueUids;
 };
 
 const getUidsFromUrls = (

--- a/packages/ingestor/src/lib/ingestLegacyObjectsToSkylark/types/legacySkylark.ts
+++ b/packages/ingestor/src/lib/ingestLegacyObjectsToSkylark/types/legacySkylark.ts
@@ -7,6 +7,13 @@ export enum LegacyObjectType {
   TagCategories = "tag-categories",
 }
 
+export enum LegacyObjectUidPrefix {
+  Tag = "tag__",
+  Asset = "asse_",
+  Episode = "epis_",
+  Season = "seas_",
+}
+
 interface LegacyTagRel {
   tag_url: string;
   schedule_urls: string[];

--- a/packages/ingestor/src/lib/ingestLegacyObjectsToSkylark/types/legacySkylark.ts
+++ b/packages/ingestor/src/lib/ingestLegacyObjectsToSkylark/types/legacySkylark.ts
@@ -1,0 +1,217 @@
+export enum LegacyObjectType {
+  Brands = "brands",
+  Seasons = "seasons",
+  Episodes = "episodes",
+  Assets = "assets",
+  Tags = "tags",
+  TagCategories = "tag-categories",
+}
+
+interface LegacyTagRel {
+  tag_url: string;
+  schedule_urls: string[];
+}
+
+export interface LegacyCommonObject {
+  _type: LegacyObjectType;
+  all_languages: string[];
+  data_source_fields: string[] | null;
+  items: string[];
+  modified_by: string;
+  parent_url: string;
+  self: string;
+  uid: string;
+  editability: string;
+  created: string;
+  data_source_id: string | null;
+  last_data_ingest: string | null;
+  modified: string;
+  ends_on: string | null;
+  is_data_source: boolean;
+  publish_on: string;
+  version_number: number;
+  version_url: string;
+  metadata_modified_by: string;
+  metadata_modified: string;
+  language_ends_on: null;
+  language_is_data_source: boolean;
+  language_modified_by: string;
+  language_publish_on: string;
+  language_version_number: number;
+  language_version_url: string;
+  language_modified: string;
+  expired: boolean;
+  future: boolean;
+  schedule_urls: string[];
+  hierarchy_url: string;
+  metadata: object;
+  schedule_statuses: {
+    self: string;
+    status: string;
+  }[];
+}
+
+export interface LegacyResponseListObjectsData<T extends LegacyCommonObject> {
+  objects: T[];
+}
+
+export interface LegacyBrand extends LegacyCommonObject {
+  _type: LegacyObjectType.Brands;
+  brand_type_url: null;
+  image_urls: string[];
+  plan_urls: string[];
+  rating_urls: string[];
+  recommended_content_urls: string[];
+  eid: string;
+  gender_skew: null;
+  language: string;
+  title: string;
+  slug: string;
+  name: string;
+  synopsis: string;
+  alternate_synopsis: string;
+  extended_synopsis: string;
+  recommendations: string;
+  technique: string;
+  why_choose_this: string;
+
+  plans: [];
+
+  sponsor_urls: string[];
+  stats: null;
+  tags: LegacyTagRel[];
+  talent: [];
+}
+
+export interface LegacySeason extends LegacyCommonObject {
+  _type: LegacyObjectType.Seasons;
+  image_urls: string[];
+  plan_urls: string[];
+  rating_urls: string[];
+  recommended_content_urls: string[];
+  publish_on: string;
+  season_number: number | null;
+  number_of_episodes: number | null;
+  year: null;
+  eid: string;
+  gender_skew: null;
+  language: string;
+  title: string;
+  slug: string;
+  name: string;
+  synopsis: string;
+  alternate_synopsis: string;
+  extended_synopsis: string;
+  recommendations: string;
+  technique: string;
+  why_choose_this: string;
+  plans: string[];
+  sponsor_urls: string[];
+  stats: null;
+  tags: LegacyTagRel[];
+  talent: string[];
+}
+
+export interface LegacyEpisode extends LegacyCommonObject {
+  _type: LegacyObjectType.Episodes;
+  episode_type_url: null | string;
+  image_urls: string[];
+  plan_urls: string[];
+  rating_urls: string[];
+  recommended_content_urls: string[];
+  episode_number: null;
+  eid: string;
+  credit_time: string;
+  new_flag: string;
+  gender_skew: null;
+  title: string;
+  slug: string;
+  synopsis: string;
+  subtitle: string;
+  name: string;
+  alternate_synopsis: string;
+  extended_synopsis: string;
+  recommendations: string;
+  technique: string;
+  why_choose_this: string;
+  plans: string[];
+  sponsor_urls: string[];
+  stats: null;
+  tags: LegacyTagRel[];
+  talent: string[];
+}
+
+export interface LegacyAsset extends LegacyCommonObject {
+  _type: LegacyObjectType.Assets;
+  asset_type_url: {
+    name: string;
+  } | null;
+  cc_urls: string[];
+  image_urls: string[];
+  ovps: string[];
+  plan_urls: string[];
+  product_urls: string[];
+  rating_urls: string[];
+  recommended_content_urls: string[];
+  text_track_urls: string[];
+  editability: string;
+  stats_last_updated: null;
+  duration: string;
+  duration_in_seconds: number;
+  max_devices: null;
+  subtitles: false;
+  sound: false;
+  release_date: null;
+  licensor: string;
+  guidance: false;
+  eid: string;
+  entitlement: string;
+  gender_skew: null;
+  state: null;
+  title: string;
+  slug: string;
+  guidance_text: string;
+  url: string;
+  name: string;
+  state_reason: string;
+  synopsis: string;
+  alternate_synopsis: string;
+  extended_synopsis: string;
+  recommendations: string;
+  technique: string;
+  why_choose_this: string;
+  expired: false;
+  future: false;
+  plans: string[];
+  sponsor_urls: string[];
+  stats: null;
+  tags: LegacyTagRel[];
+  talent: string[];
+}
+
+export interface LegacyTag extends LegacyCommonObject {
+  _type: LegacyObjectType.Tags;
+  category_url: "/api/tag-categories/cate_44ef19d0f44a4775af16bf7cf35f25b9/"; // this will be a relationship
+  self: string;
+  uid: string;
+  uuid: null;
+  slug: string;
+  name: string;
+}
+
+export interface LegacyTagCategory extends LegacyCommonObject {
+  _type: LegacyObjectType.TagCategories;
+  self: string;
+  uid: string;
+  uuid: null;
+  slug: string;
+  name: string;
+}
+
+export type LegacyObjects =
+  | LegacyTagCategory[]
+  | LegacyTag[]
+  | LegacyAsset[]
+  | LegacyEpisode[]
+  | LegacySeason[]
+  | LegacyBrand[];

--- a/packages/ingestor/src/lib/ingestLegacyObjectsToSkylark/types/skylark.ts
+++ b/packages/ingestor/src/lib/ingestLegacyObjectsToSkylark/types/skylark.ts
@@ -1,0 +1,14 @@
+import { GraphQLBaseObject } from "../../interfaces";
+
+export type CreatedSkylarkObjectKeys =
+  | "tagCategories"
+  | "tags"
+  | "assets"
+  | "episodes"
+  | "seasons"
+  | "brands";
+
+export type CreatedSkylarkObjects = Record<
+  CreatedSkylarkObjectKeys,
+  GraphQLBaseObject[]
+>;

--- a/packages/ingestor/src/lib/ingestLegacyObjectsToSkylark/utils.ts
+++ b/packages/ingestor/src/lib/ingestLegacyObjectsToSkylark/utils.ts
@@ -1,0 +1,19 @@
+import { LegacyObjectType, LegacyObjects } from "./types/legacySkylark";
+
+export const calculateTotalObjects = (
+  objects: Record<
+    string,
+    {
+      type: LegacyObjectType;
+      objects: Record<string, LegacyObjects>;
+      totalFound: number;
+    }
+  >
+) => {
+  const totalObjectsFound = Object.values(objects).reduce(
+    (previous, { totalFound }) => previous + totalFound,
+    0
+  );
+
+  return totalObjectsFound;
+};

--- a/packages/ingestor/src/lib/interfaces/saas.ts
+++ b/packages/ingestor/src/lib/interfaces/saas.ts
@@ -83,3 +83,9 @@ export type CreateOrUpdateRelationships = Record<
   string,
   Record<string, { link: string[] }>
 >;
+
+export type SkylarkGraphQLError = {
+  response: {
+    errors: { path: string[]; errorType: string; message: string }[];
+  };
+};

--- a/packages/ingestor/src/lib/interfaces/saas.ts
+++ b/packages/ingestor/src/lib/interfaces/saas.ts
@@ -66,3 +66,20 @@ export interface GraphQLDimension {
   slug: string;
   description?: string;
 }
+
+export interface GraphQLObjectRelationshipsType {
+  GET_OBJECT_RELATIONSHIPS: {
+    name: string;
+    inputFields: {
+      name: string;
+      type: {
+        name: string;
+      };
+    }[];
+  } | null;
+}
+
+export type CreateOrUpdateRelationships = Record<
+  string,
+  Record<string, { link: string[] }>
+>;

--- a/packages/ingestor/src/lib/skylark/saas/account.ts
+++ b/packages/ingestor/src/lib/skylark/saas/account.ts
@@ -2,8 +2,10 @@ import { graphQLClient } from "@skylark-reference-apps/lib";
 import { gql } from "graphql-request";
 
 const SET_ACCOUNT_CONFIGURATION = gql`
-  mutation SET_ACCOUNT_CONFIGURATION {
-    setAccountConfiguration(account_config: { default_language: "" }) {
+  mutation SET_ACCOUNT_CONFIGURATION($defaultLanguage: String!) {
+    setAccountConfiguration(
+      account_config: { default_language: $defaultLanguage }
+    ) {
       account_id
       config {
         default_language

--- a/packages/ingestor/src/lib/skylark/saas/account.ts
+++ b/packages/ingestor/src/lib/skylark/saas/account.ts
@@ -1,0 +1,19 @@
+import { graphQLClient } from "@skylark-reference-apps/lib";
+import { gql } from "graphql-request";
+
+const SET_ACCOUNT_CONFIGURATION = gql`
+  mutation SET_ACCOUNT_CONFIGURATION {
+    setAccountConfiguration(account_config: { default_language: "" }) {
+      account_id
+      config {
+        default_language
+      }
+    }
+  }
+`;
+
+export const setAccountConfiguration = async (variables: {
+  defaultLanguage: string;
+}) => {
+  await graphQLClient.request(SET_ACCOUNT_CONFIGURATION, variables);
+};

--- a/packages/ingestor/src/lib/skylark/saas/availability.ts
+++ b/packages/ingestor/src/lib/skylark/saas/availability.ts
@@ -258,10 +258,13 @@ export const createOrUpdateAvailability = async (
   dimensions: GraphQLMetadata["dimensions"]
 ) => {
   const externalIds = schedules.map(({ id }) => ({ externalId: id }));
-  const existingObjects = await getExistingObjects("Availability", externalIds);
+  const { existingObjects } = await getExistingObjects(
+    "Availability",
+    externalIds
+  );
 
   const schedulesToCreate = schedules.filter(
-    ({ id }) => !existingObjects.includes(id)
+    ({ id }) => !existingObjects.has(id)
   );
   if (schedulesToCreate.length === 0) {
     return;
@@ -271,7 +274,7 @@ export const createOrUpdateAvailability = async (
     (previousOperations, { id, ...record }) => {
       const fields = record.fields as AvailabilityTableFields;
 
-      const objectExists = existingObjects.includes(id);
+      const objectExists = existingObjects.has(id);
 
       const availabilityInput: {
         title: string;

--- a/packages/ingestor/src/lib/skylark/saas/create.test.ts
+++ b/packages/ingestor/src/lib/skylark/saas/create.test.ts
@@ -49,7 +49,7 @@ describe("saas/create.ts", () => {
           ],
         },
       };
-      graphQlRequest.mockResolvedValueOnce(mockedGraphQLResponse);
+      graphQlRequest.mockResolvedValue(mockedGraphQLResponse);
     });
 
     it("makes a request to check whether the brand exists", async () => {
@@ -61,8 +61,10 @@ describe("saas/create.ts", () => {
         }
       );
       expect(graphQLClient.request).toHaveBeenNthCalledWith(
-        2,
-        'query getBrands { brand_1: getBrand (external_id: "brand_1", ignore_availability: true) { __typename uid slug external_id } }'
+        1,
+        'query getBrands { brand_1: getBrand (external_id: "brand_1", ignore_availability: true) { __typename uid slug external_id } }',
+        {},
+        expect.any(Object)
       );
     });
 
@@ -85,7 +87,7 @@ describe("saas/create.ts", () => {
       );
       expect(graphQLClient.request).toHaveBeenNthCalledWith(
         3,
-        'mutation createOrUpdateBrands { createBrandbrand_1: createBrand (brand: {title: "Brand 1", availability: {link: []}, external_id: "brand_1"}) { __typename uid slug external_id } }',
+        'mutation createOrUpdateBrands { createBrand_brand_1: createBrand (brand: {title: "Brand 1", availability: {link: []}, external_id: "brand_1"}) { __typename uid slug external_id } }',
         {},
         expect.any(Object)
       );
@@ -101,7 +103,7 @@ describe("saas/create.ts", () => {
       );
       expect(graphQLClient.request).toHaveBeenNthCalledWith(
         3,
-        'mutation createOrUpdateBrands { updateBrandbrand_1: updateBrand (external_id: "brand_1", brand: {title: "Brand 1", availability: {link: []}}) { __typename uid slug external_id } }',
+        'mutation createOrUpdateBrands { updateBrand_brand_1: updateBrand (external_id: "brand_1", brand: {title: "Brand 1", availability: {link: []}}) { __typename uid slug external_id } }',
         {},
         expect.any(Object)
       );
@@ -164,7 +166,7 @@ describe("saas/create.ts", () => {
       );
       expect(graphQLClient.request).toHaveBeenNthCalledWith(
         3,
-        'mutation createOrUpdateBrands { updateBrandbrand_1: updateBrand (external_id: "brand_1", brand: {title: "Brand 1", availability: {link: ["default-external-id-1"]}}) { __typename uid slug external_id } }',
+        'mutation createOrUpdateBrands { updateBrand_brand_1: updateBrand (external_id: "brand_1", brand: {title: "Brand 1", availability: {link: ["default-external-id-1"]}}) { __typename uid slug external_id } }',
         {},
         expect.any(Object)
       );
@@ -229,7 +231,9 @@ describe("saas/create.ts", () => {
       );
       expect(graphQLClient.request).toHaveBeenNthCalledWith(
         2,
-        'query getCredits { credit_1: getCredit (external_id: "credit_1", ignore_availability: true) { __typename uid slug external_id } }'
+        'query getCredits { credit_1: getCredit (external_id: "credit_1", ignore_availability: true) { __typename uid slug external_id } }',
+        {},
+        expect.any(Object)
       );
     });
 

--- a/packages/ingestor/src/lib/skylark/saas/create.test.ts
+++ b/packages/ingestor/src/lib/skylark/saas/create.test.ts
@@ -7,7 +7,7 @@ import { GraphQLBaseObject, GraphQLMetadata } from "../../interfaces";
 import {
   createGraphQLMediaObjects,
   createOrUpdateGraphQLCredits,
-  createOrUpdateGraphQlObjectsUsingIntrospection,
+  createOrUpdateGraphQlObjectsFromAirtableUsingIntrospection,
   createTranslationsForGraphQLObjects,
 } from "./create";
 import { CREATE_OBJECT_CHUNK_SIZE } from "../../constants";
@@ -25,7 +25,7 @@ describe("saas/create.ts", () => {
     jest.resetAllMocks();
   });
 
-  describe("createOrUpdateGraphQlObjectsUsingIntrospection", () => {
+  describe("createOrUpdateGraphQlObjectsFromAirtableUsingIntrospection", () => {
     const records: Partial<Record<FieldSet>>[] = [
       {
         id: "brand_1",
@@ -53,7 +53,7 @@ describe("saas/create.ts", () => {
     });
 
     it("makes a request to check whether the brand exists", async () => {
-      await createOrUpdateGraphQlObjectsUsingIntrospection(
+      await createOrUpdateGraphQlObjectsFromAirtableUsingIntrospection(
         "Brand",
         records as Records<FieldSet>,
         {
@@ -76,7 +76,7 @@ describe("saas/create.ts", () => {
       };
       graphQlRequest.mockRejectedValueOnce(mockedGraphQLResponse);
 
-      await createOrUpdateGraphQlObjectsUsingIntrospection(
+      await createOrUpdateGraphQlObjectsFromAirtableUsingIntrospection(
         "Brand",
         records as Records<FieldSet>,
         {
@@ -92,7 +92,7 @@ describe("saas/create.ts", () => {
     });
 
     it("makes a request to update the brand when it exists", async () => {
-      await createOrUpdateGraphQlObjectsUsingIntrospection(
+      await createOrUpdateGraphQlObjectsFromAirtableUsingIntrospection(
         "Brand",
         records as Records<FieldSet>,
         {
@@ -119,7 +119,7 @@ describe("saas/create.ts", () => {
         })
       );
 
-      await createOrUpdateGraphQlObjectsUsingIntrospection(
+      await createOrUpdateGraphQlObjectsFromAirtableUsingIntrospection(
         "Brand",
         manyRecords as Records<FieldSet>,
         {
@@ -154,7 +154,7 @@ describe("saas/create.ts", () => {
     });
 
     it("adds the default availability to the request", async () => {
-      await createOrUpdateGraphQlObjectsUsingIntrospection(
+      await createOrUpdateGraphQlObjectsFromAirtableUsingIntrospection(
         "Brand",
         records as Records<FieldSet>,
         {

--- a/packages/ingestor/src/lib/skylark/saas/create.ts
+++ b/packages/ingestor/src/lib/skylark/saas/create.ts
@@ -124,11 +124,13 @@ export const createOrUpdateGraphQlObjectsUsingIntrospection = async (
     isImage,
     language,
     relationships,
+    availabilityUids,
   }: {
     metadataAvailability?: GraphQLMetadata["availability"];
     isImage?: boolean;
     language?: string;
     relationships?: CreateOrUpdateRelationships;
+    availabilityUids?: string[];
   }
 ): Promise<GraphQLBaseObject[]> => {
   if (objects.length === 0) {
@@ -155,6 +157,10 @@ export const createOrUpdateGraphQlObjectsUsingIntrospection = async (
             fields.availability as string[]
           )
         : { link: [] };
+
+      if (availabilityUids) {
+        availability.link.push(...availabilityUids);
+      }
 
       const argName = objectType
         .match(/[A-Z][a-z]+/g)

--- a/packages/ingestor/src/lib/skylark/saas/delete.ts
+++ b/packages/ingestor/src/lib/skylark/saas/delete.ts
@@ -1,0 +1,33 @@
+import { GraphQLObjectTypes, graphQLClient } from "@skylark-reference-apps/lib";
+import { jsonToGraphQLQuery, VariableType } from "json-to-graphql-query";
+import { GraphQLBaseObject } from "../../interfaces";
+
+export const deleteObject = async (
+  objectType: GraphQLObjectTypes,
+  variables: { uid: string }
+) => {
+  const mutation = {
+    mutation: {
+      __variables: {
+        uid: "String!",
+        // externalId: "String",
+      },
+      deleteObject: {
+        __aliasFor: `delete${objectType}`,
+        __args: {
+          uid: new VariableType("uid"),
+          // external_id: new VariableType("externalId"),
+        },
+        uid: true,
+      },
+    },
+  };
+
+  const graphQLGetQuery = jsonToGraphQLQuery(mutation);
+
+  await graphQLClient.request<{ getObject: GraphQLBaseObject }>(
+    graphQLGetQuery,
+    variables,
+    { "x-bypass-cache": "1" }
+  );
+};

--- a/packages/ingestor/src/lib/skylark/saas/get.test.ts
+++ b/packages/ingestor/src/lib/skylark/saas/get.test.ts
@@ -146,7 +146,9 @@ describe("saas/get.ts", () => {
       await getExistingObjects("Brand", [{ externalId: "brand-1" }]);
 
       expect(graphQlRequest).toBeCalledWith(
-        'query getBrands { brand-1: getBrand (external_id: "brand-1", ignore_availability: true) { __typename uid slug external_id } }'
+        'query getBrands { brand-1: getBrand (external_id: "brand-1", ignore_availability: true) { __typename uid slug external_id } }',
+        {},
+        expect.any(Object)
       );
     });
 
@@ -156,7 +158,10 @@ describe("saas/get.ts", () => {
         { externalId: "brand-2" },
         { externalId: "brand-3" },
       ]);
-      expect(got).toEqual(["brand-1", "brand-2", "brand-3"]);
+      expect(got.existingObjects).toEqual(
+        new Set(["brand-1", "brand-2", "brand-3"])
+      );
+      expect(got.missingObjects).toEqual(new Set([]));
     });
 
     it("returns the uids that exist when some queries return a null value", async () => {
@@ -174,7 +179,8 @@ describe("saas/get.ts", () => {
         { externalId: "brand-2" },
         { externalId: "brand-3" },
       ]);
-      expect(got).toEqual(["brand-2", "brand-3"]);
+      expect(got.existingObjects).toEqual(new Set(["brand-2", "brand-3"]));
+      expect(got.missingObjects).toEqual(new Set(["brand-1"]));
     });
 
     it("rejects when an unexpected error occurs", async () => {

--- a/packages/ingestor/src/lib/skylark/saas/schema.ts
+++ b/packages/ingestor/src/lib/skylark/saas/schema.ts
@@ -27,6 +27,16 @@ const ACTIVATE_CONFIGURATION_VERSION = gql`
   }
 `;
 
+const GET_ENUM_VALUES = gql`
+  query GET_ENUM_VALUES($name: String!) {
+    __type(name: $name) {
+      enumValues {
+        name
+      }
+    }
+  }
+`;
+
 const getActivationStatus = async () => {
   const res = await graphQLClient.request<{
     getActivationStatus: {
@@ -39,7 +49,7 @@ const getActivationStatus = async () => {
   return res.getActivationStatus;
 };
 
-const activateConfigurationVersion = async (version: number) => {
+export const activateConfigurationVersion = async (version: number) => {
   const res = await graphQLClient.request<{
     activateConfigurationVersion: { version: number; messages: string };
   }>(ACTIVATE_CONFIGURATION_VERSION, { version });
@@ -47,11 +57,26 @@ const activateConfigurationVersion = async (version: number) => {
   return res.activateConfigurationVersion;
 };
 
-const updateEnumTypes = async (
+const getEnumValues = async (name: string) => {
+  const data = await graphQLClient.request<{
+    __type: { enumValues: { name: string }[] };
+  }>(GET_ENUM_VALUES, { name });
+
+  // eslint-disable-next-line no-underscore-dangle
+  const values = data.__type.enumValues.map((e) => e.name.toUpperCase());
+  return values;
+};
+
+export const updateEnumTypes = async (
   enumName: string,
   values: string[],
-  version?: number
-) => {
+  version: number
+): Promise<{ version: number }> => {
+  const existingValues = await getEnumValues(enumName);
+  if (values.every((value) => existingValues.includes(value.toUpperCase()))) {
+    return { version };
+  }
+
   const mutation = {
     mutation: {
       __name: `UPDATE_${enumName}`,
@@ -128,23 +153,30 @@ const addPreferredImageTypeToSeason = async (version?: number) => {
   }
 };
 
-export const updateSkylarkSchema = async () => {
+export const waitForUpdatingSchema = async (expectedVersion?: number) => {
   const {
-    active_version: initialVersion,
-    update_in_progress: initialUpdateInProgress,
+    active_version: activeVersion,
+    update_in_progress: updateInProgress,
   } = await getActivationStatus();
 
-  if (initialUpdateInProgress) {
-    let initialUpdating = true;
-    while (initialUpdating) {
-      const { update_in_progress: initialUpdateStillRunning } =
+  if (updateInProgress) {
+    let currentlyUpdating = true;
+    while (currentlyUpdating) {
+      const { update_in_progress: updateStillRunning } =
         // eslint-disable-next-line no-await-in-loop
         await getActivationStatus();
-      initialUpdating = initialUpdateStillRunning;
+      currentlyUpdating =
+        updateStillRunning || activeVersion !== expectedVersion;
       // eslint-disable-next-line no-await-in-loop
       await pause(2500);
     }
   }
+
+  return activeVersion;
+};
+
+export const updateSkylarkSchema = async () => {
+  const initialVersion = await waitForUpdatingSchema();
 
   const { version: updatedVersion } = await updateEnumTypes(
     "SetType",
@@ -157,14 +189,7 @@ export const updateSkylarkSchema = async () => {
 
   await activateConfigurationVersion(updatedVersion);
 
-  let activeVersion = initialVersion;
-  while (`${activeVersion}` !== `${updatedVersion}`) {
-    // eslint-disable-next-line no-await-in-loop
-    const { active_version: currentVersion } = await getActivationStatus();
-    activeVersion = currentVersion;
-    // eslint-disable-next-line no-await-in-loop
-    await pause(5000);
-  }
+  const activeVersion = await waitForUpdatingSchema(updatedVersion);
 
   return { version: activeVersion };
 };

--- a/packages/ingestor/src/lib/skylark/saas/sets.ts
+++ b/packages/ingestor/src/lib/skylark/saas/sets.ts
@@ -222,7 +222,9 @@ export const createOrUpdateGraphQLSet = async (
     )
     .filter((lang) => lang) as string[];
 
-  const existingSets = await Promise.all([
+  const existingSets = new Set<string>();
+
+  const existingSetsArr = await Promise.all([
     getExistingObjects("SkylarkSet", [{ externalId: set.externalId }]),
     ...airtableTranslationLanguages.map((language) =>
       getExistingObjects("SkylarkSet", [
@@ -231,7 +233,11 @@ export const createOrUpdateGraphQLSet = async (
     ),
   ]);
 
-  const setExists = existingSets.findIndex((sets) => sets.length > 0) > -1;
+  existingSetsArr.forEach(({ existingObjects }) =>
+    existingObjects.forEach((obj) => existingSets.add(obj))
+  );
+
+  const setExists = existingSets.has(set.externalId);
 
   const operationName = setExists ? `updateSkylarkSet` : `createSkylarkSet`;
 

--- a/packages/ingestor/src/lib/skylark/saas/sets.ts
+++ b/packages/ingestor/src/lib/skylark/saas/sets.ts
@@ -147,7 +147,7 @@ const createSetArgsWithTranslations = (
     external_id?: string;
     language: string;
     skylark_set: {
-      [key: string]: string | object | number | EnumType | boolean;
+      [key: string]: string | object | number | EnumType | boolean | null;
     };
   } = update
     ? {

--- a/packages/ingestor/src/lib/skylark/saas/utils.test.ts
+++ b/packages/ingestor/src/lib/skylark/saas/utils.test.ts
@@ -94,7 +94,7 @@ describe("saas/utils.ts", () => {
       slug: "a-title",
       phone_number: "07777777",
       theme: ["theme-1"],
-      enum: "enum",
+      enum: "ENUM",
     };
 
     it("returns fields object containing only properties that exist in the validProperties array", () => {

--- a/packages/ingestor/src/lib/skylark/saas/utils.ts
+++ b/packages/ingestor/src/lib/skylark/saas/utils.ts
@@ -103,6 +103,8 @@ export const getValidFields = (
     [key: string]:
       | EnumType
       | undefined
+      | null
+      | object
       | string
       | number
       | boolean
@@ -112,7 +114,7 @@ export const getValidFields = (
       | ReadonlyArray<Attachment>;
   },
   validProperties: GraphQLIntrospectionProperties[]
-): { [key: string]: string | number | boolean | EnumType } => {
+): { [key: string]: string | number | boolean | EnumType | null } => {
   const validObjectFields = validProperties.filter(({ property }) =>
     has(fields, property)
   );
@@ -123,8 +125,8 @@ export const getValidFields = (
     return {
       ...obj,
       [property]:
-        kind === "ENUM"
-          ? new EnumType(val as string)
+        kind === "ENUM" && typeof val === "string"
+          ? new EnumType(val.toUpperCase())
           : (val as string | number | boolean | EnumType),
     };
   }, {} as { [key: string]: string | number | boolean | EnumType });

--- a/packages/ingestor/src/main.ts
+++ b/packages/ingestor/src/main.ts
@@ -11,7 +11,7 @@ import { UNLICENSED_BY_DEFAULT } from "./lib/constants";
 import {
   createGraphQLMediaObjects,
   createOrUpdateGraphQLCredits,
-  createOrUpdateGraphQlObjectsUsingIntrospection,
+  createOrUpdateGraphQlObjectsFromAirtableUsingIntrospection,
   createTranslationsForGraphQLObjects,
 } from "./lib/skylark/saas/create";
 import { createOrUpdateGraphQLSet } from "./lib/skylark/saas/sets";
@@ -102,47 +102,54 @@ const main = async () => {
   };
 
   metadata.call_to_actions =
-    await createOrUpdateGraphQlObjectsUsingIntrospection(
+    await createOrUpdateGraphQlObjectsFromAirtableUsingIntrospection(
       "CallToAction",
       airtable.callToActions,
       metadataAvailability
     );
-  metadata.images = await createOrUpdateGraphQlObjectsUsingIntrospection(
-    "SkylarkImage",
-    airtable.images,
-    metadataAvailability,
-    true
-  );
-  metadata.themes = await createOrUpdateGraphQlObjectsUsingIntrospection(
-    "Theme",
-    airtable.themes,
-    metadataAvailability
-  );
-  metadata.genres = await createOrUpdateGraphQlObjectsUsingIntrospection(
-    "Genre",
-    airtable.genres,
-    metadataAvailability
-  );
-  metadata.ratings = await createOrUpdateGraphQlObjectsUsingIntrospection(
-    "Rating",
-    airtable.ratings,
-    metadataAvailability
-  );
-  metadata.tags = await createOrUpdateGraphQlObjectsUsingIntrospection(
-    "SkylarkTag",
-    airtable.tags,
-    metadataAvailability
-  );
-  metadata.people = await createOrUpdateGraphQlObjectsUsingIntrospection(
-    "Person",
-    airtable.people,
-    metadataAvailability
-  );
-  metadata.roles = await createOrUpdateGraphQlObjectsUsingIntrospection(
-    "Role",
-    airtable.roles,
-    metadataAvailability
-  );
+  metadata.images =
+    await createOrUpdateGraphQlObjectsFromAirtableUsingIntrospection(
+      "SkylarkImage",
+      airtable.images,
+      metadataAvailability,
+      true
+    );
+  metadata.themes =
+    await createOrUpdateGraphQlObjectsFromAirtableUsingIntrospection(
+      "Theme",
+      airtable.themes,
+      metadataAvailability
+    );
+  metadata.genres =
+    await createOrUpdateGraphQlObjectsFromAirtableUsingIntrospection(
+      "Genre",
+      airtable.genres,
+      metadataAvailability
+    );
+  metadata.ratings =
+    await createOrUpdateGraphQlObjectsFromAirtableUsingIntrospection(
+      "Rating",
+      airtable.ratings,
+      metadataAvailability
+    );
+  metadata.tags =
+    await createOrUpdateGraphQlObjectsFromAirtableUsingIntrospection(
+      "SkylarkTag",
+      airtable.tags,
+      metadataAvailability
+    );
+  metadata.people =
+    await createOrUpdateGraphQlObjectsFromAirtableUsingIntrospection(
+      "Person",
+      airtable.people,
+      metadataAvailability
+    );
+  metadata.roles =
+    await createOrUpdateGraphQlObjectsFromAirtableUsingIntrospection(
+      "Role",
+      airtable.roles,
+      metadataAvailability
+    );
   metadata.credits = await createOrUpdateGraphQLCredits(
     airtable.credits,
     metadata

--- a/packages/lib/src/interfaces/skylark/types.ts
+++ b/packages/lib/src/interfaces/skylark/types.ts
@@ -32,8 +32,12 @@ export type GraphQLMediaObjectTypes =
   | "Movie"
   | "SkylarkAsset";
 
+// Usually customer instances
+export type OptionalCustomGraphQLObjectTypes = "TagCategory";
+
 export type GraphQLObjectTypes =
   | GraphQLMediaObjectTypes
+  | OptionalCustomGraphQLObjectTypes
   | "Theme"
   | "Genre"
   | "Rating"

--- a/packages/lib/src/skylark/skylark.constants.ts
+++ b/packages/lib/src/skylark/skylark.constants.ts
@@ -9,3 +9,5 @@ export const LOCAL_STORAGE = {
   uri: "streamtv:uri",
   apikey: "streamtv:apikey",
 };
+export const CLOUDINARY_ENVIRONMENT = process.env
+  .NEXT_PUBLIC_CLOUDINARY_ENVIRONMENT as string;

--- a/packages/lib/src/utils/utils.ts
+++ b/packages/lib/src/utils/utils.ts
@@ -3,6 +3,7 @@ import customParseFormat from "dayjs/plugin/customParseFormat";
 import { TitleTypes, SynopsisTypes } from "../interfaces";
 
 import "dayjs/locale/pt";
+import { CLOUDINARY_ENVIRONMENT } from "../skylark";
 
 dayjs.extend(customParseFormat);
 
@@ -100,3 +101,30 @@ export const hasProperty = <T, K extends PropertyKey>(
   property: K
 ): object is T & Record<K, unknown> =>
   Object.prototype.hasOwnProperty.call(object, property);
+
+export const addCloudinaryOnTheFlyImageTransformation = (
+  imageUrl: string,
+  opts: { height?: number; width?: number }
+) => {
+  // If the Cloudinary Environment is falsy, return the original image URL
+  if (!imageUrl || !CLOUDINARY_ENVIRONMENT) {
+    return imageUrl;
+  }
+
+  const urlOpts = [];
+  if (opts.height) {
+    urlOpts.push(`h_${opts.height}`);
+  }
+  if (opts.width) {
+    urlOpts.push(`w_${opts.width}`);
+  }
+
+  if (opts.height && opts.width) {
+    urlOpts.push("c_fill");
+  }
+
+  const urlOptsStr = urlOpts.length > 0 ? `${urlOpts.join(",")}/` : "";
+
+  const cloudinaryUrl = `https://res.cloudinary.com/${CLOUDINARY_ENVIRONMENT}/image/fetch/${urlOptsStr}${imageUrl}`;
+  return cloudinaryUrl;
+};

--- a/packages/react/src/components/carousel/carousel.component.tsx
+++ b/packages/react/src/components/carousel/carousel.component.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from "react";
+import React, { useEffect, useMemo, useState } from "react";
 import { motion, AnimatePresence } from "framer-motion";
 import { wrap } from "popmotion";
 import useTranslation from "next-translate/useTranslation";
@@ -59,12 +59,16 @@ export const Carousel: React.FC<CarouselProps> = ({
   const [areImagesLoaded, setImagesLoaded] = useState(false);
   const itemIndex = wrap(0, unparsedItems.length, page);
 
-  const items = unparsedItems.map((item) => ({
-    ...item,
-    image: addCloudinaryOnTheFlyImageTransformation(item.image, {
-      width: 2000,
-    }),
-  }));
+  const items = useMemo(
+    () =>
+      unparsedItems.map((item) => ({
+        ...item,
+        image: addCloudinaryOnTheFlyImageTransformation(item.image, {
+          width: 2000,
+        }),
+      })),
+    [unparsedItems]
+  );
 
   const paginate = (newDirection: number) => {
     setPage([page + newDirection, newDirection]);

--- a/packages/react/src/components/carousel/carousel.component.tsx
+++ b/packages/react/src/components/carousel/carousel.component.tsx
@@ -2,7 +2,11 @@ import React, { useEffect, useState } from "react";
 import { motion, AnimatePresence } from "framer-motion";
 import { wrap } from "popmotion";
 import useTranslation from "next-translate/useTranslation";
-import { formatYear, ObjectTypes } from "@skylark-reference-apps/lib";
+import {
+  addCloudinaryOnTheFlyImageTransformation,
+  formatYear,
+  ObjectTypes,
+} from "@skylark-reference-apps/lib";
 import { MdPlayCircleFilled, MdArrowForward } from "react-icons/md";
 import { CarouselButton } from "./carousel-button.component";
 import { List } from "../list";
@@ -47,13 +51,20 @@ const variants = {
 };
 
 export const Carousel: React.FC<CarouselProps> = ({
-  items,
+  items: unparsedItems,
   changeInterval,
 }) => {
   const [loadedImages, setLoadedImages] = useState<string[]>([]);
   const [[page, direction], setPage] = useState([0, 0]);
   const [areImagesLoaded, setImagesLoaded] = useState(false);
-  const itemIndex = wrap(0, items.length, page);
+  const itemIndex = wrap(0, unparsedItems.length, page);
+
+  const items = unparsedItems.map((item) => ({
+    ...item,
+    image: addCloudinaryOnTheFlyImageTransformation(item.image, {
+      width: 2000,
+    }),
+  }));
 
   const paginate = (newDirection: number) => {
     setPage([page + newDirection, newDirection]);

--- a/packages/react/src/components/player/player.component.tsx
+++ b/packages/react/src/components/player/player.component.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import MuxVideo from "@mux-elements/mux-video-react";
+import { addCloudinaryOnTheFlyImageTransformation } from "@skylark-reference-apps/lib";
 
 interface PlayerProps {
   src: string;
@@ -39,7 +40,13 @@ export const Player: React.FC<PlayerProps> = ({
               video_id: videoId,
               video_title: videoTitle,
             }}
-            poster={poster}
+            poster={
+              poster
+                ? addCloudinaryOnTheFlyImageTransformation(poster, {
+                    width: 1000,
+                  })
+                : undefined
+            }
             ref={undefined}
             // Convert relative URL into absolute
             src={absoluteSrc}

--- a/packages/react/src/components/thumbnail/base/base-thumbnail.component.tsx
+++ b/packages/react/src/components/thumbnail/base/base-thumbnail.component.tsx
@@ -1,6 +1,7 @@
 import Link from "next/link";
 import React, { useEffect, useState } from "react";
 import { MdPlayArrow } from "react-icons/md";
+import { addCloudinaryOnTheFlyImageTransformation } from "@skylark-reference-apps/lib";
 import { List } from "../../list";
 
 export type ThumbnailContentLocation = "inside" | "below";
@@ -28,12 +29,17 @@ export interface ThumbnailProps extends BaseThumbnailWithLinkProps {
 }
 
 const BaseThumbnail: React.FC<BaseThumbnailProps> = ({
-  backgroundImage,
+  backgroundImage: uncachedImage,
   contentLocation = "inside",
   children,
   large,
 }) => {
   const [imageLoaded, setImageLoaded] = useState(false);
+
+  const backgroundImage = addCloudinaryOnTheFlyImageTransformation(
+    uncachedImage,
+    { width: 400 }
+  );
 
   useEffect(() => {
     const image = new Image();

--- a/packages/react/src/components/thumbnail/base/base-thumbnail.component.tsx
+++ b/packages/react/src/components/thumbnail/base/base-thumbnail.component.tsx
@@ -1,5 +1,5 @@
 import Link from "next/link";
-import React, { useEffect, useState } from "react";
+import React, { useEffect, useMemo, useState } from "react";
 import { MdPlayArrow } from "react-icons/md";
 import { addCloudinaryOnTheFlyImageTransformation } from "@skylark-reference-apps/lib";
 import { List } from "../../list";
@@ -36,9 +36,10 @@ const BaseThumbnail: React.FC<BaseThumbnailProps> = ({
 }) => {
   const [imageLoaded, setImageLoaded] = useState(false);
 
-  const backgroundImage = addCloudinaryOnTheFlyImageTransformation(
-    uncachedImage,
-    { width: 400 }
+  const backgroundImage = useMemo(
+    () =>
+      addCloudinaryOnTheFlyImageTransformation(uncachedImage, { width: 400 }),
+    [uncachedImage]
   );
 
   useEffect(() => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -5772,6 +5772,14 @@
   resolved "https://registry.yarnpkg.com/@types/estree/-/estree-0.0.51.tgz#cfd70924a25a3fd32b218e5e420e6897e1ac4f40"
   integrity sha512-CuPgU6f3eT/XgKKPqKd/gLZV1Xmvf1a2R5POBOGQa6uv82xpls89HU5zKeVoyR8XzHd1RGNOlQlvUe3CFkjWNQ==
 
+"@types/fs-extra@^11.0.1":
+  version "11.0.1"
+  resolved "https://registry.yarnpkg.com/@types/fs-extra/-/fs-extra-11.0.1.tgz#f542ec47810532a8a252127e6e105f487e0a6ea5"
+  integrity sha512-MxObHvNl4A69ofaTRU8DFqvgzzv8s9yRtaPPm5gud9HDNvpB3GPQFvNuTWAI59B9huVGV5jXYJwbCsmBsOGYWA==
+  dependencies:
+    "@types/jsonfile" "*"
+    "@types/node" "*"
+
 "@types/glob@*", "@types/glob@^7.1.1":
   version "7.2.0"
   resolved "https://registry.yarnpkg.com/@types/glob/-/glob-7.2.0.tgz#bc1b5bf3aa92f25bd5dd39f35c57361bdce5b2eb"
@@ -5880,6 +5888,13 @@
   version "0.0.29"
   resolved "https://registry.yarnpkg.com/@types/json5/-/json5-0.0.29.tgz#ee28707ae94e11d2b827bcbe5270bcea7f3e71ee"
   integrity sha1-7ihweulOEdK4J7y+UnC86n8+ce4=
+
+"@types/jsonfile@*":
+  version "6.1.1"
+  resolved "https://registry.yarnpkg.com/@types/jsonfile/-/jsonfile-6.1.1.tgz#ac84e9aefa74a2425a0fb3012bdea44f58970f1b"
+  integrity sha512-GSgiRCVeapDN+3pqA35IkQwasaCh/0YFH5dEF6S88iDvEn901DjOeH3/QPY+XYP1DFzDZPvIvfeEgk+7br5png==
+  dependencies:
+    "@types/node" "*"
 
 "@types/jsonwebtoken@^8.5.0":
   version "8.5.9"
@@ -10199,6 +10214,15 @@ fs-extra@^0.30.0:
     klaw "^1.0.0"
     path-is-absolute "^1.0.0"
     rimraf "^2.2.8"
+
+fs-extra@^11.1.1:
+  version "11.1.1"
+  resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-11.1.1.tgz#da69f7c39f3b002378b0954bb6ae7efdc0876e2d"
+  integrity sha512-MGIE4HOvQCeUCzmlHs0vXpih4ysz4wg9qiSAu6cd42lVwPbTM1TjV7RusoyQqMmk/95gdQZX72u+YW+c3eEpFQ==
+  dependencies:
+    graceful-fs "^4.2.0"
+    jsonfile "^6.0.1"
+    universalify "^2.0.0"
 
 fs-extra@^9.0.0, fs-extra@^9.0.1, fs-extra@^9.1.0:
   version "9.1.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3100,6 +3100,13 @@
   dependencies:
     regenerator-runtime "^0.13.4"
 
+"@babel/runtime@^7.15.4":
+  version "7.22.6"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.22.6.tgz#57d64b9ae3cff1d67eb067ae117dac087f5bd438"
+  integrity sha512-wDb5pWm4WDdF6LFUde3Jl8WzPA+3ZbxYqkC6xAXuD3irdEHN1k0NfTRrJD8ZD378SJ61miMLCqIOXYhd8x+AJQ==
+  dependencies:
+    regenerator-runtime "^0.13.11"
+
 "@babel/template@^7.12.7", "@babel/template@^7.16.7", "@babel/template@^7.3.3":
   version "7.16.7"
   resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.16.7.tgz#8d126c8701fde4d66b264b3eba3d96f07666d155"
@@ -7107,6 +7114,14 @@ axe-core@^4.3.5:
   resolved "https://registry.yarnpkg.com/axe-core/-/axe-core-4.4.1.tgz#7dbdc25989298f9ad006645cd396782443757413"
   integrity sha512-gd1kmb21kwNuWr6BQz8fv6GNECPBnUasepcoLbekws23NVBLODdsClRZ+bQ8+9Uomf3Sm3+Vwn0oYG9NvwnJCw==
 
+axios-retry@^3.5.1:
+  version "3.5.1"
+  resolved "https://registry.yarnpkg.com/axios-retry/-/axios-retry-3.5.1.tgz#d902f69fe1b2a71902e29605318f887bef0981c6"
+  integrity sha512-mQRJ4IyAUnYig14BQ4MnnNHHuH1cNH7NW4JxEUD6mNJwK6pwOY66wKLCwZ6Y0o3POpfStalqRC+J4+Hnn6Om7w==
+  dependencies:
+    "@babel/runtime" "^7.15.4"
+    is-retry-allowed "^2.2.0"
+
 axios@^0.21.1:
   version "0.21.4"
   resolved "https://registry.yarnpkg.com/axios/-/axios-0.21.4.tgz#c67b90dc0568e5c1cf2b0b858c43ba28e2eda575"
@@ -7114,13 +7129,14 @@ axios@^0.21.1:
   dependencies:
     follow-redirects "^1.14.0"
 
-axios@^0.27.2:
-  version "0.27.2"
-  resolved "https://registry.yarnpkg.com/axios/-/axios-0.27.2.tgz#207658cc8621606e586c85db4b41a750e756d972"
-  integrity sha512-t+yRIyySRTp/wua5xEr+z1q60QmLq8ABsS5O9Me1AsE5dfKqgnCFzwiCZZ/cGNd1lq4/7akDWMxdhVlucjmnOQ==
+axios@^1.4.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/axios/-/axios-1.4.0.tgz#38a7bf1224cd308de271146038b551d725f0be1f"
+  integrity sha512-S4XCWMEmzvo64T9GfvQDOXgYRDJ/wsSZc7Jvdgx5u1sd0JwsuPLqb3SYmusag+edF6ziyMensPVqLTSc1PiSEA==
   dependencies:
-    follow-redirects "^1.14.9"
+    follow-redirects "^1.15.0"
     form-data "^4.0.0"
+    proxy-from-env "^1.1.0"
 
 axobject-query@^2.2.0:
   version "2.2.0"
@@ -10063,10 +10079,10 @@ follow-redirects@^1.14.0:
   resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.15.0.tgz#06441868281c86d0dda4ad8bdaead2d02dca89d4"
   integrity sha512-aExlJShTV4qOUOL7yF1U5tvLCB0xQuudbf6toyYA0E/acBNw71mvjFTnLaRp50aQaYocMR0a/RMMBIHeZnGyjQ==
 
-follow-redirects@^1.14.9:
-  version "1.15.1"
-  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.15.1.tgz#0ca6a452306c9b276e4d3127483e29575e207ad5"
-  integrity sha512-yLAMQs+k0b2m7cVxpS1VKJVvoz7SS9Td1zss3XRwXj+ZDH00RJgnuLx7E44wx02kQLrdM3aOOy+FpzS7+8OizA==
+follow-redirects@^1.15.0:
+  version "1.15.2"
+  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.15.2.tgz#b460864144ba63f2681096f274c4e57026da2c13"
+  integrity sha512-VQLG33o04KaQ8uYi2tVNbdrWp1QWxNNea+nmIB4EVM28v0hmP17z7aG1+wAkNzVq4KeXTq3221ye5qTJP91JwA==
 
 for-in@^1.0.2:
   version "1.0.2"
@@ -11442,6 +11458,11 @@ is-relative@^1.0.0:
   integrity sha512-Kw/ReK0iqwKeu0MITLFuj0jbPAmEiOsIwyIXvvbfa6QfmN9pkD1M+8pdk7Rl/dTKbH34/XBFMbgD4iMJhLQbGA==
   dependencies:
     is-unc-path "^1.0.0"
+
+is-retry-allowed@^2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/is-retry-allowed/-/is-retry-allowed-2.2.0.tgz#88f34cbd236e043e71b6932d09b0c65fb7b4d71d"
+  integrity sha512-XVm7LOeLpTW4jV19QSH38vkswxoLud8sQ57YwJVTPWdiaI9I8keEhGFpBlslyVsgdQy4Opg8QOLb8YRgsyZiQg==
 
 is-set@^2.0.2:
   version "2.0.2"
@@ -14287,6 +14308,11 @@ proxy-addr@~2.0.7:
     forwarded "0.2.0"
     ipaddr.js "1.9.1"
 
+proxy-from-env@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/proxy-from-env/-/proxy-from-env-1.1.0.tgz#e102f16ca355424865755d2c9e8ea4f24d58c3e2"
+  integrity sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==
+
 prr@~1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/prr/-/prr-1.0.1.tgz#d3fc114ba06995a45ec6893f484ceb1d78f5f476"
@@ -14733,6 +14759,11 @@ regenerate@^1.4.2:
   version "1.4.2"
   resolved "https://registry.yarnpkg.com/regenerate/-/regenerate-1.4.2.tgz#b9346d8827e8f5a32f7ba29637d398b69014848a"
   integrity sha512-zrceR/XhGYU/d/opr2EKO7aRHUeiBI8qjtfHqADTwZd6Szfy16la6kqD0MIUs5z5hx6AaKa+PixpPrR289+I0A==
+
+regenerator-runtime@^0.13.11:
+  version "0.13.11"
+  resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz#f6dca3e7ceec20590d07ada785636a90cdca17f9"
+  integrity sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg==
 
 regenerator-runtime@^0.13.4, regenerator-runtime@^0.13.7, regenerator-runtime@^0.13.9:
   version "0.13.9"


### PR DESCRIPTION
<!-- Enter a very brief description of change -->
<!-- Add any optional commentary which may help the code reviewer. -->

Adds a Skylark Legacy -> Skylark GraphQL ingestor
- Creates/Updates objects + translations
- Adds Relationships
- Adds an Always Availability to all objects
- Updates AssetTypes in Skylark GraphQL with old values
- Sets the default language
- Writes Skylark Legacy objects to disk + outputs stats about the environment (number of objects per type, per language)

Also:
- Improves `getExistingObjects` to:
  - Use a `Set` for faster lookup
  - Return `missingObjects`
  - Limit requests when requesting loads of objects
- Improves Schema updating 
- Adds a GraphQL Retry for when creating with introspection
- Error handling to attempt to fix the ingest when:
  - Object already exists error - adds the external ID to the existingObjects
  - Can't find language version none error - delete the objects and retries the request

<!-- Please tick all relevant change types this PR commits -->
<!-- Delete non-relevant lines -->
* [x] Feature

#### Jira
<!-- Line separated list of relevant Jira ticket links -->
https://skylarkplatform.atlassian.net/browse/SL-2724

