### PR TITLE
feat: StreamTV Config Object

### DIFF
--- a/.github/actions/run-ingestor/action.yml
+++ b/.github/actions/run-ingestor/action.yml
@@ -46,6 +46,10 @@ inputs:
     deprecationMessage: SLX Demos have been moved to a standalone Airtable base. All content in a base is now ingested
     required: false
     default: "all"
+  streamtv-setup-only:
+    description: Only make set up changes (Add object types, enum values, dimensions)
+    required: false
+    default: "false"
 runs:
   using: composite
   steps:
@@ -74,6 +78,7 @@ runs:
         CREATE_SETS: ${{ inputs.create-additional-objects }}
         SAAS_API_ENDPOINT: ${{ inputs.skylark-api-url }}
         SAAS_API_KEY: ${{ inputs.saas-api-token }}
+        STREAMTV_SETUP_ONLY: ${{ inputs.streamtv-setup-only }}
       with:
         timeout_minutes: 30
         retry_wait_seconds: 10

--- a/.github/workflows/ingest-streamtv-content-to-remote-skylark.yml
+++ b/.github/workflows/ingest-streamtv-content-to-remote-skylark.yml
@@ -11,6 +11,11 @@ on:
         type: string
         required: true
         description: Your Skylark API Key.
+      streamtv_setup_only:
+        type: boolean
+        required: false
+        default: false
+        description: Only setup StreamTV - Add object types, enum values, dimensions etc
 concurrency:
   group: ingest-streamtv-content-${{ github.event.inputs.skylark_url }}
   cancel-in-progress: true
@@ -35,3 +40,4 @@ jobs:
           saas-ingest: "true"
           saas-api-token: ${{ env.SKYLARK_API_KEY }}
           content-type: "streamtv"
+          streamtv-setup-only: ${{ github.event.inputs.streamtv_setup_only }}

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -17,7 +17,7 @@
       }
     },
     {
-      "name": "Debug ingestor (with SLX Demo sets)",
+      "name": "Debug ingestor (only Schema changes)",
       "request": "launch",
       "cwd": "${workspaceFolder}/packages/ingestor",
       "runtimeArgs": ["ingest"],
@@ -25,7 +25,7 @@
       "skipFiles": ["<node_internals>/**"],
       "type": "node",
       "env": {
-        "CREATE_SLX_DEMO_SETS": "true"
+        "STREAMTV_SETUP_ONLY": "true"
       }
     },
     {

--- a/apps/storybook/styles/globals.css
+++ b/apps/storybook/styles/globals.css
@@ -1,3 +1,8 @@
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
+
+:root {
+  --streamtv-primary-color: #5b45ce;
+  --streamtv-accent-color: #ff385c;
+}

--- a/apps/streamtv/components/cta.tsx
+++ b/apps/streamtv/components/cta.tsx
@@ -20,7 +20,7 @@ export const CTA = ({ uid }: CallToActionProps) => {
           rel="noreferrer"
           target="_blank"
         >
-          <p className="rounded border-2 bg-purple-500 p-2 px-4 text-center text-white">
+          <p className="rounded border-2 bg-streamtv-primary p-2 px-4 text-center text-white">
             {cta?.text?.split(" ").map((word) => (
               <span className="block" key={word}>
                 {word}

--- a/apps/streamtv/components/googleTagManager.tsx
+++ b/apps/streamtv/components/googleTagManager.tsx
@@ -1,0 +1,53 @@
+import Script from "next/script";
+
+interface GoogleTagManagerProps {
+  id: string;
+}
+
+export const GoogleTagManagerScript = ({ id }: GoogleTagManagerProps) => (
+  <Script id="google-tag-manager" strategy="afterInteractive">
+    {`
+        (function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+        new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+        j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+        'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+        })(window,document,'script','dataLayer','${id}');
+      `}
+  </Script>
+);
+
+export const GoogleTagManagerBodyNoScript = ({ id }: GoogleTagManagerProps) => {
+  <noscript
+    dangerouslySetInnerHTML={{
+      __html: `<noscript><iframe src="https://www.googletagmanager.com/ns.html?id=${id}" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>`,
+    }}
+  />;
+};
+
+const noScriptId = "google-tag-manager-no-script";
+
+export const addGoogleTagManagerNoScriptToBody = (
+  id: GoogleTagManagerProps["id"]
+) => {
+  if (!document.getElementById(noScriptId)) {
+    const noscript = document.createElement("noscript");
+    noscript.id = noScriptId;
+
+    const iframe = document.createElement("iframe");
+    iframe.src = `https://www.googletagmanager.com/ns.html?id=${id}`;
+    iframe.height = "0";
+    iframe.width = "0";
+    iframe.setAttribute("style", "display:none;visibility:hidden");
+
+    noscript.appendChild(iframe);
+
+    document.body.appendChild(noscript);
+  }
+};
+
+export const removeGoogleTagManagerNoScriptFromBody = () => {
+  const el = document.getElementById(noScriptId);
+  if (el) {
+    el.remove();
+  }
+};

--- a/apps/streamtv/components/layout.tsx
+++ b/apps/streamtv/components/layout.tsx
@@ -17,6 +17,7 @@ import { DefaultSeo } from "next-seo";
 import { Search } from "./search";
 import { useStreamTVConfig } from "../hooks/useStreamTVConfig";
 import createDefaultSeo from "../next-seo.config";
+import { GoogleTagManagerScript } from "./googleTagManager";
 
 interface Props {
   appTitle?: string;
@@ -62,6 +63,9 @@ export const StreamTVLayout: React.FC<Props> = ({
   return (
     <>
       <DefaultSeo {...createDefaultSeo(appTitle, t("seo.description"))} />
+      {config?.googleTagManagerId && (
+        <GoogleTagManagerScript id={config.googleTagManagerId} />
+      )}
       <div className="relative w-full">
         {isMobileSearchOpen && (
           <div className="fixed inset-0 z-20 bg-gray-900/40 md:hidden">

--- a/apps/streamtv/components/layout.tsx
+++ b/apps/streamtv/components/layout.tsx
@@ -72,9 +72,18 @@ export const StreamTVLayout: React.FC<Props> = ({
           <TitleScreen
             exitBackgroundColor="#5B45CE"
             logo={
-              <MdStream className="h-12 w-12 rounded-md bg-streamtv-primary sm:h-14 sm:w-14 lg:h-16 lg:w-16" />
+              config?.logo ? (
+                // eslint-disable-next-line @next/next/no-img-element
+                <img
+                  alt={config.logo.alt}
+                  className="block max-h-20"
+                  src={config.logo.src}
+                />
+              ) : (
+                <MdStream className="h-12 w-12 rounded-md bg-streamtv-primary sm:h-14 sm:w-14 lg:h-16 lg:w-16" />
+              )
             }
-            title={"A StreamTV App"}
+            title={appTitle}
           >
             <p className="text-xs text-gray-500 sm:text-sm lg:text-lg">
               {t("by-skylark")}
@@ -83,9 +92,18 @@ export const StreamTVLayout: React.FC<Props> = ({
         )}
         <AppBackgroundGradient />
         <AppHeader activeHref={asPath} links={links}>
-          <div className="flex items-center justify-center text-3xl text-gray-100">
-            <div className="ltr:md:ml-8 rtl:md:mr-8 ltr:lg:ml-16 rtl:lg:mr-16 ltr:xl:ml-20 rtl:xl:mr-20">
-              <MdStream className="h-9 w-9 md:h-10 md:w-10 lg:h-12 lg:w-12" />
+          <div className="flex h-full items-center justify-center text-3xl text-gray-100">
+            <div className="flex h-full items-center ltr:md:ml-8 rtl:md:mr-8 ltr:lg:ml-16 rtl:lg:mr-16 ltr:xl:ml-20 rtl:xl:mr-20">
+              {config?.logo ? (
+                // eslint-disable-next-line @next/next/no-img-element
+                <img
+                  alt={config.logo.alt}
+                  className="block h-full py-2 md:py-4 lg:py-8"
+                  src={config.logo.src}
+                />
+              ) : (
+                <MdStream className="h-9 w-9 md:h-10 md:w-10 lg:h-12 lg:w-12" />
+              )}
             </div>
             <h2 className="mx-1 text-base md:mx-2 md:text-xl lg:text-2xl">
               <Link href="/">{appTitle}</Link>

--- a/apps/streamtv/components/layout.tsx
+++ b/apps/streamtv/components/layout.tsx
@@ -13,10 +13,13 @@ import {
   useDimensions,
 } from "@skylark-reference-apps/react";
 import { hasProperty } from "@skylark-reference-apps/lib";
+import { DefaultSeo } from "next-seo";
 import { Search } from "./search";
+import { useStreamTVConfig } from "../hooks/useStreamTVConfig";
+import createDefaultSeo from "../next-seo.config";
 
 interface Props {
-  appTitle: string;
+  appTitle?: string;
   tvShowsHref: string;
   skylarkApiUrl?: string;
   timeTravelEnabled?: boolean;
@@ -24,12 +27,16 @@ interface Props {
 }
 
 export const StreamTVLayout: React.FC<Props> = ({
-  appTitle,
+  appTitle: propAppTitle,
   tvShowsHref,
   skylarkApiUrl,
   timeTravelEnabled,
   children,
 }) => {
+  const { config } = useStreamTVConfig();
+
+  const appTitle = config?.appName || propAppTitle || "StreamTV";
+
   const { asPath, query } = useRouter();
   const { t } = useTranslation("common");
   const [isMobileSearchOpen, setMobileSearchOpen] = useState(false);
@@ -54,6 +61,7 @@ export const StreamTVLayout: React.FC<Props> = ({
 
   return (
     <>
+      <DefaultSeo {...createDefaultSeo(appTitle, t("seo.description"))} />
       <div className="relative w-full">
         {isMobileSearchOpen && (
           <div className="fixed inset-0 z-20 bg-gray-900/40 md:hidden">
@@ -64,9 +72,9 @@ export const StreamTVLayout: React.FC<Props> = ({
           <TitleScreen
             exitBackgroundColor="#5B45CE"
             logo={
-              <MdStream className="h-12 w-12 rounded-md bg-purple-500 sm:h-14 sm:w-14 lg:h-16 lg:w-16" />
+              <MdStream className="h-12 w-12 rounded-md bg-streamtv-primary sm:h-14 sm:w-14 lg:h-16 lg:w-16" />
             }
-            title={appTitle}
+            title={"A StreamTV App"}
           >
             <p className="text-xs text-gray-500 sm:text-sm lg:text-lg">
               {t("by-skylark")}
@@ -76,7 +84,9 @@ export const StreamTVLayout: React.FC<Props> = ({
         <AppBackgroundGradient />
         <AppHeader activeHref={asPath} links={links}>
           <div className="flex items-center justify-center text-3xl text-gray-100">
-            <MdStream className="h-9 w-9 md:h-10 md:w-10 ltr:md:ml-8 rtl:md:mr-8 lg:h-12 lg:w-12 ltr:lg:ml-16 rtl:lg:mr-16 ltr:xl:ml-20 rtl:xl:mr-20" />
+            <div className="ltr:md:ml-8 rtl:md:mr-8 ltr:lg:ml-16 rtl:lg:mr-16 ltr:xl:ml-20 rtl:xl:mr-20">
+              <MdStream className="h-9 w-9 md:h-10 md:w-10 lg:h-12 lg:w-12" />
+            </div>
             <h2 className="mx-1 text-base md:mx-2 md:text-xl lg:text-2xl">
               <Link href="/">{appTitle}</Link>
             </h2>

--- a/apps/streamtv/components/search.tsx
+++ b/apps/streamtv/components/search.tsx
@@ -181,7 +181,7 @@ export const Search = ({ onSearch }: { onSearch?: () => void }) => {
     >
       <div
         className={clsx(
-          "flex items-center justify-center rounded-full border-0 border-gray-300 bg-streamtv-primary/90 p-3 px-4 transition-colors  focus-within:border-white focus-within:text-white  md:bg-button-tertiary",
+          "bg-streamtv-primary/90 flex items-center justify-center rounded-full border-0 border-gray-300 p-3 px-4 transition-colors  focus-within:border-white focus-within:text-white  md:bg-button-tertiary",
           searchQuery ? "text-white" : "text-gray-300"
         )}
       >

--- a/apps/streamtv/components/search.tsx
+++ b/apps/streamtv/components/search.tsx
@@ -72,7 +72,7 @@ const HighlightedSearchResultText = ({
       className={clsx(
         className,
         matchClassName,
-        "[&>span]:text-pink-500 [&>span]:transition-colors group-hover:[&>span]:text-purple-400"
+        "[&>span]:text-streamtv-accent [&>span]:transition-colors group-hover:[&>span]:text-streamtv-accent"
       )}
       dangerouslySetInnerHTML={{ __html: cleanHTML }}
     />
@@ -104,19 +104,19 @@ const SearchResultItem = ({
     <div className="flex h-full flex-col">
       <div className="flex flex-col">
         <HighlightedSearchResultText
-          className="text-lg font-medium text-gray-100 transition-colors group-hover:text-purple-400"
+          className="text-lg font-medium text-gray-100 transition-colors group-hover:text-white"
           matchClassName="[&>span]:font-bold"
           text={title}
         />
         {description && (
           <HighlightedSearchResultText
-            className="line-clamp-3 text-sm text-gray-400 transition-colors group-hover:text-purple-400"
+            className="line-clamp-3 text-sm text-gray-400 transition-colors group-hover:text-gray-300"
             matchClassName="[&>span]:font-semibold"
             text={description}
           />
         )}
       </div>
-      <div className="flex flex-row justify-between gap-2 text-sm text-gray-600 transition-colors group-hover:text-purple-400">
+      <div className="flex flex-row justify-between gap-2 text-sm text-gray-600 transition-colors group-hover:text-gray-500">
         <HighlightedSearchResultText
           matchClassName="[&>span]:font-semibold"
           text={typename}
@@ -181,7 +181,7 @@ export const Search = ({ onSearch }: { onSearch?: () => void }) => {
     >
       <div
         className={clsx(
-          "flex items-center justify-center rounded-full border-0 border-gray-300 bg-purple-500/90 p-3 px-4 transition-colors  focus-within:border-white focus-within:text-white  md:bg-button-tertiary",
+          "flex items-center justify-center rounded-full border-0 border-gray-300 bg-streamtv-primary/90 p-3 px-4 transition-colors  focus-within:border-white focus-within:text-white  md:bg-button-tertiary",
           searchQuery ? "text-white" : "text-gray-300"
         )}
       >

--- a/apps/streamtv/graphql/queries/skylarkEnvironment.ts
+++ b/apps/streamtv/graphql/queries/skylarkEnvironment.ts
@@ -5,7 +5,7 @@ import { gql } from "graphql-request";
  * Mostly this checks to see whether the StreamTV ingestor has been run against this account and changes to the data model have been made.
  */
 export const GET_SKYLARK_ENVIRONMENT = gql`
-  query {
+  query GET_SKYLARK_ENVIRONMENT {
     seasonFields: __type(name: "Season") {
       possibleTypes {
         kind
@@ -14,6 +14,11 @@ export const GET_SKYLARK_ENVIRONMENT = gql`
       name
       kind
       fields {
+        name
+      }
+    }
+    objectTypes: __type(name: "Metadata") {
+      possibleTypes {
         name
       }
     }

--- a/apps/streamtv/graphql/queries/streamtvConfig.ts
+++ b/apps/streamtv/graphql/queries/streamtvConfig.ts
@@ -24,7 +24,7 @@ export const GET_STREAMTV_CONFIG = gql`
       objects {
         accent_color
         app_name
-        google_analytics_id
+        google_tag_manager_id
         logo(limit: 1) {
           objects {
             uid

--- a/apps/streamtv/graphql/queries/streamtvConfig.ts
+++ b/apps/streamtv/graphql/queries/streamtvConfig.ts
@@ -30,6 +30,7 @@ export const GET_STREAMTV_CONFIG = gql`
             uid
             url
             title
+            slug
           }
         }
         primary_color

--- a/apps/streamtv/graphql/queries/streamtvConfig.ts
+++ b/apps/streamtv/graphql/queries/streamtvConfig.ts
@@ -1,0 +1,39 @@
+import { gql } from "graphql-request";
+
+/**
+ * This Query is used to get an active StreamTVConfig
+ * It uses a list endpoint so it will use the first available StreamTV Config
+ * Also fetches only a single logo
+ */
+export const GET_STREAMTV_CONFIG = gql`
+  query GET_STREAMTV_CONFIG(
+    $language: String!
+    $deviceType: String!
+    $customerType: String!
+    $region: String!
+  ) {
+    listStreamtvConfig(
+      limit: 1
+      language: $language
+      dimensions: [
+        { dimension: "device-types", value: $deviceType }
+        { dimension: "customer-types", value: $customerType }
+        { dimension: "regions", value: $region }
+      ]
+    ) {
+      objects {
+        accent_color
+        app_name
+        google_analytics_id
+        logo(limit: 1) {
+          objects {
+            uid
+            url
+            title
+          }
+        }
+        primary_color
+      }
+    }
+  }
+`;

--- a/apps/streamtv/hooks/useSkylarkEnvironment.tsx
+++ b/apps/streamtv/hooks/useSkylarkEnvironment.tsx
@@ -14,14 +14,21 @@ interface SkylarkEnvironmentResponse {
       };
     }[];
   };
+  objectTypes?: {
+    possibleTypes: {
+      name: string;
+    }[];
+  };
 }
 
 interface SkylarkEnvironment {
   hasUpdatedSeason: boolean;
+  hasStreamTVConfig: boolean;
+  objectTypes: string[];
 }
 
 export const useSkylarkEnvironment = () => {
-  const { data, error, ...rest } = useQuery({
+  const { data, error } = useQuery({
     queryKey: ["SkylarkEnvironment"],
     queryFn: () =>
       skylarkRequestWithLocalStorage<SkylarkEnvironmentResponse>(
@@ -39,14 +46,20 @@ export const useSkylarkEnvironment = () => {
         ) > -1
     );
 
+    const objectTypes =
+      data?.objectTypes?.possibleTypes.map(({ name }) => name) || [];
+
+    const hasStreamTVConfig = objectTypes.includes("StreamtvConfig");
+
     return {
       hasUpdatedSeason,
+      hasStreamTVConfig,
+      objectTypes,
     };
   }, [data]);
 
   return {
     environment,
-    ...rest,
     error: error as GQLError,
   };
 };

--- a/apps/streamtv/hooks/useStreamTVConfig.tsx
+++ b/apps/streamtv/hooks/useStreamTVConfig.tsx
@@ -10,6 +10,7 @@ import {
   addGoogleTagManagerNoScriptToBody,
   removeGoogleTagManagerNoScriptFromBody,
 } from "../components/googleTagManager";
+import { useSkylarkEnvironment } from "./useSkylarkEnvironment";
 
 interface StreamTVConfigResponse {
   listStreamtvConfig?: {
@@ -37,6 +38,8 @@ interface StreamTVConfig {
 export const useStreamTVConfig = () => {
   const { dimensions } = useDimensions();
 
+  const { environment } = useSkylarkEnvironment();
+
   const { data, error } = useQuery({
     queryKey: ["StreamTVConfig", dimensions],
     queryFn: () =>
@@ -46,6 +49,7 @@ export const useStreamTVConfig = () => {
         {}
       ),
     cacheTime: Infinity,
+    enabled: environment.hasStreamTVConfig,
   });
 
   const config = useMemo((): StreamTVConfig | undefined => {

--- a/apps/streamtv/hooks/useStreamTVConfig.tsx
+++ b/apps/streamtv/hooks/useStreamTVConfig.tsx
@@ -6,6 +6,10 @@ import {
 import { useEffect, useMemo } from "react";
 import { GQLError, SkylarkImageListing } from "../types";
 import { GET_STREAMTV_CONFIG } from "../graphql/queries/streamtvConfig";
+import {
+  addGoogleTagManagerNoScriptToBody,
+  removeGoogleTagManagerNoScriptFromBody,
+} from "../components/googleTagManager";
 
 interface StreamTVConfigResponse {
   listStreamtvConfig?: {
@@ -13,7 +17,7 @@ interface StreamTVConfigResponse {
       app_name: string;
       primary_color: string;
       accent_color: string;
-      google_analytics_id: string;
+      google_tag_manager_id: string;
       logo: SkylarkImageListing;
     }[];
   };
@@ -23,7 +27,7 @@ interface StreamTVConfig {
   appName: string;
   primaryColor: string;
   accentColor: string;
-  gaCode: string;
+  googleTagManagerId: string;
   logo?: {
     alt: string;
     src: string;
@@ -63,7 +67,7 @@ export const useStreamTVConfig = () => {
       appName: gqlConfig.app_name,
       primaryColor: gqlConfig.primary_color,
       accentColor: gqlConfig.accent_color,
-      gaCode: gqlConfig.google_analytics_id,
+      googleTagManagerId: gqlConfig.google_tag_manager_id,
       logo:
         logo && logo.url
           ? {
@@ -83,6 +87,12 @@ export const useStreamTVConfig = () => {
       "--streamtv-accent-color",
       config?.accentColor || "#ff385c"
     );
+
+    if (config?.googleTagManagerId) {
+      addGoogleTagManagerNoScriptToBody(config?.googleTagManagerId);
+    } else {
+      removeGoogleTagManagerNoScriptFromBody();
+    }
   }, [config]);
 
   return {

--- a/apps/streamtv/hooks/useStreamTVConfig.tsx
+++ b/apps/streamtv/hooks/useStreamTVConfig.tsx
@@ -34,7 +34,7 @@ export const useStreamTVConfig = () => {
   const { dimensions } = useDimensions();
 
   const { data, error } = useQuery({
-    queryKey: ["StreamTVConfig"],
+    queryKey: ["StreamTVConfig", dimensions],
     queryFn: () =>
       skylarkRequestWithDimensions<StreamTVConfigResponse>(
         GET_STREAMTV_CONFIG,
@@ -67,7 +67,7 @@ export const useStreamTVConfig = () => {
       logo:
         logo && logo.url
           ? {
-              alt: logo.title || logo.url,
+              alt: logo.title || logo.slug || logo.url,
               src: logo.url,
             }
           : undefined,
@@ -75,16 +75,14 @@ export const useStreamTVConfig = () => {
   }, [data]);
 
   useEffect(() => {
-    if (config) {
-      document.documentElement.style.setProperty(
-        "--streamtv-primary-color",
-        config.primaryColor
-      );
-      document.documentElement.style.setProperty(
-        "--streamtv-accent-color",
-        config.accentColor
-      );
-    }
+    document.documentElement.style.setProperty(
+      "--streamtv-primary-color",
+      config?.primaryColor || "#5b45ce"
+    );
+    document.documentElement.style.setProperty(
+      "--streamtv-accent-color",
+      config?.accentColor || "#ff385c"
+    );
   }, [config]);
 
   return {

--- a/apps/streamtv/hooks/useStreamTVConfig.tsx
+++ b/apps/streamtv/hooks/useStreamTVConfig.tsx
@@ -1,0 +1,94 @@
+import { useQuery } from "@tanstack/react-query";
+import {
+  skylarkRequestWithDimensions,
+  useDimensions,
+} from "@skylark-reference-apps/react";
+import { useEffect, useMemo } from "react";
+import { GQLError, SkylarkImageListing } from "../types";
+import { GET_STREAMTV_CONFIG } from "../graphql/queries/streamtvConfig";
+
+interface StreamTVConfigResponse {
+  listStreamtvConfig?: {
+    objects?: {
+      app_name: string;
+      primary_color: string;
+      accent_color: string;
+      google_analytics_id: string;
+      logo: SkylarkImageListing;
+    }[];
+  };
+}
+
+interface StreamTVConfig {
+  appName: string;
+  primaryColor: string;
+  accentColor: string;
+  gaCode: string;
+  logo?: {
+    alt: string;
+    src: string;
+  };
+}
+
+export const useStreamTVConfig = () => {
+  const { dimensions } = useDimensions();
+
+  const { data, error } = useQuery({
+    queryKey: ["StreamTVConfig"],
+    queryFn: () =>
+      skylarkRequestWithDimensions<StreamTVConfigResponse>(
+        GET_STREAMTV_CONFIG,
+        dimensions,
+        {}
+      ),
+    cacheTime: Infinity,
+  });
+
+  const config = useMemo((): StreamTVConfig | undefined => {
+    if (
+      !data?.listStreamtvConfig?.objects ||
+      data.listStreamtvConfig.objects.length === 0
+    ) {
+      return undefined;
+    }
+
+    const gqlConfig = data.listStreamtvConfig.objects[0];
+
+    const logo =
+      gqlConfig.logo.objects &&
+      gqlConfig.logo.objects.length > 0 &&
+      gqlConfig.logo.objects[0];
+
+    return {
+      appName: gqlConfig.app_name,
+      primaryColor: gqlConfig.primary_color,
+      accentColor: gqlConfig.accent_color,
+      gaCode: gqlConfig.google_analytics_id,
+      logo:
+        logo && logo.url
+          ? {
+              alt: logo.title || logo.url,
+              src: logo.url,
+            }
+          : undefined,
+    };
+  }, [data]);
+
+  useEffect(() => {
+    if (config) {
+      document.documentElement.style.setProperty(
+        "--streamtv-primary-color",
+        config.primaryColor
+      );
+      document.documentElement.style.setProperty(
+        "--streamtv-accent-color",
+        config.accentColor
+      );
+    }
+  }, [config]);
+
+  return {
+    config,
+    error: error as GQLError,
+  };
+};

--- a/apps/streamtv/pages/_app.tsx
+++ b/apps/streamtv/pages/_app.tsx
@@ -5,23 +5,18 @@ import "@fontsource/outfit/700.css";
 import "@fontsource/inter/500.css";
 import "@fontsource/inter/600.css";
 import type { AppProps } from "next/app";
-import { DefaultSeo } from "next-seo";
-import useTranslation from "next-translate/useTranslation";
 import PlausibleProvider from "next-plausible";
 import { withPasswordProtect } from "next-password-protect";
 import { LOCAL_STORAGE } from "@skylark-reference-apps/lib";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { useEffect, useState } from "react";
 import { DimensionsContextProvider } from "@skylark-reference-apps/react";
-import createDefaultSeo from "../next-seo.config";
 import { StreamTVLayout } from "../components/layout";
 
-const appTitle = process.env.NEXT_PUBLIC_APP_TITLE || "StreamTV";
 const tvShowsHref =
   process.env.NEXT_PUBLIC_TV_SHOWS_HREF || "/brand/reculg97iNzbkEZCK";
 
 function MyApp({ Component, pageProps }: AppProps) {
-  const { t } = useTranslation("common");
   const [skylarkApiUrl, setSkylarkApiUrl] = useState(
     process.env.NEXT_PUBLIC_SAAS_API_ENDPOINT
   );
@@ -48,12 +43,11 @@ function MyApp({ Component, pageProps }: AppProps) {
       <QueryClientProvider client={queryClient}>
         <DimensionsContextProvider>
           <StreamTVLayout
-            appTitle={appTitle}
+            appTitle={process.env.NEXT_PUBLIC_APP_TITLE}
             skylarkApiUrl={skylarkApiUrl}
             timeTravelEnabled
             tvShowsHref={tvShowsHref}
           >
-            <DefaultSeo {...createDefaultSeo(appTitle, t("seo.description"))} />
             <Component {...pageProps} />
           </StreamTVLayout>
         </DimensionsContextProvider>

--- a/apps/streamtv/types/gql.ts
+++ b/apps/streamtv/types/gql.ts
@@ -1622,6 +1622,7 @@ export type Mutation = {
   createSkylarkLiveAsset?: Maybe<SkylarkLiveAsset>;
   createSkylarkSet?: Maybe<SkylarkSet>;
   createSkylarkTag?: Maybe<SkylarkTag>;
+  createStreamtvConfig?: Maybe<StreamtvConfig>;
   createTheme?: Maybe<Theme>;
   deleteAvailability?: Maybe<Scalars["String"]>;
   deleteBrand?: Maybe<Array<Maybe<ObjectDeleteResponse>>>;
@@ -1646,6 +1647,7 @@ export type Mutation = {
   deleteSkylarkLiveAsset?: Maybe<Array<Maybe<ObjectDeleteResponse>>>;
   deleteSkylarkSet?: Maybe<Array<Maybe<ObjectDeleteResponse>>>;
   deleteSkylarkTag?: Maybe<Array<Maybe<ObjectDeleteResponse>>>;
+  deleteStreamtvConfig?: Maybe<Array<Maybe<ObjectDeleteResponse>>>;
   deleteTheme?: Maybe<Array<Maybe<ObjectDeleteResponse>>>;
   editEnumConfiguration?: Maybe<ConfigurationResponse>;
   editFieldConfiguration?: Maybe<ConfigurationResponse>;
@@ -1679,6 +1681,7 @@ export type Mutation = {
   updateSkylarkLiveAsset?: Maybe<SkylarkLiveAsset>;
   updateSkylarkSet?: Maybe<SkylarkSet>;
   updateSkylarkTag?: Maybe<SkylarkTag>;
+  updateStreamtvConfig?: Maybe<StreamtvConfig>;
   updateTheme?: Maybe<Theme>;
 };
 
@@ -1803,6 +1806,11 @@ export type MutationCreateSkylarkSetArgs = {
 export type MutationCreateSkylarkTagArgs = {
   language?: InputMaybe<Scalars["String"]>;
   skylark_tag?: InputMaybe<SkylarkTagCreateInput>;
+};
+
+export type MutationCreateStreamtvConfigArgs = {
+  language?: InputMaybe<Scalars["String"]>;
+  streamtv_config?: InputMaybe<StreamtvConfigCreateInput>;
 };
 
 export type MutationCreateThemeArgs = {
@@ -1980,6 +1988,14 @@ export type MutationDeleteSkylarkSetArgs = {
 };
 
 export type MutationDeleteSkylarkTagArgs = {
+  external_id?: InputMaybe<Scalars["String"]>;
+  global_version?: InputMaybe<Scalars["Int"]>;
+  language?: InputMaybe<Scalars["String"]>;
+  language_version?: InputMaybe<Scalars["Int"]>;
+  uid: Scalars["String"];
+};
+
+export type MutationDeleteStreamtvConfigArgs = {
   external_id?: InputMaybe<Scalars["String"]>;
   global_version?: InputMaybe<Scalars["Int"]>;
   language?: InputMaybe<Scalars["String"]>;
@@ -2250,6 +2266,16 @@ export type MutationUpdateSkylarkTagArgs = {
   uid?: InputMaybe<Scalars["String"]>;
 };
 
+export type MutationUpdateStreamtvConfigArgs = {
+  draft?: InputMaybe<Scalars["Boolean"]>;
+  external_id?: InputMaybe<Scalars["String"]>;
+  global_version?: InputMaybe<Scalars["Int"]>;
+  language?: InputMaybe<Scalars["String"]>;
+  language_version?: InputMaybe<Scalars["Int"]>;
+  streamtv_config?: InputMaybe<StreamtvConfigInput>;
+  uid?: InputMaybe<Scalars["String"]>;
+};
+
 export type MutationUpdateThemeArgs = {
   draft?: InputMaybe<Scalars["Boolean"]>;
   external_id?: InputMaybe<Scalars["String"]>;
@@ -2303,6 +2329,7 @@ export enum ObjectTypes {
   SkylarkImage = "SkylarkImage",
   SkylarkSet = "SkylarkSet",
   SkylarkTag = "SkylarkTag",
+  StreamtvConfig = "StreamtvConfig",
   Theme = "Theme",
 }
 
@@ -2602,6 +2629,7 @@ export type Query = {
   getSkylarkLiveAsset?: Maybe<SkylarkLiveAsset>;
   getSkylarkSet?: Maybe<SkylarkSet>;
   getSkylarkTag?: Maybe<SkylarkTag>;
+  getStreamtvConfig?: Maybe<StreamtvConfig>;
   getTheme?: Maybe<Theme>;
   getUser?: Maybe<UserDetails>;
   listAvailability?: Maybe<AvailabilityListing>;
@@ -2626,6 +2654,7 @@ export type Query = {
   listSkylarkLiveAsset?: Maybe<SkylarkLiveAssetListing>;
   listSkylarkSet?: Maybe<SkylarkSetListing>;
   listSkylarkTag?: Maybe<SkylarkTagListing>;
+  listStreamtvConfig?: Maybe<StreamtvConfigListing>;
   listTheme?: Maybe<ThemeListing>;
   search?: Maybe<SearchResultListing>;
 };
@@ -2825,6 +2854,14 @@ export type QueryGetSkylarkTagArgs = {
   uid?: InputMaybe<Scalars["String"]>;
 };
 
+export type QueryGetStreamtvConfigArgs = {
+  dimensions?: InputMaybe<Array<InputMaybe<UserDimension>>>;
+  external_id?: InputMaybe<Scalars["String"]>;
+  ignore_availability?: InputMaybe<Scalars["Boolean"]>;
+  language?: InputMaybe<Scalars["String"]>;
+  uid?: InputMaybe<Scalars["String"]>;
+};
+
 export type QueryGetThemeArgs = {
   dimensions?: InputMaybe<Array<InputMaybe<UserDimension>>>;
   external_id?: InputMaybe<Scalars["String"]>;
@@ -2987,6 +3024,14 @@ export type QueryListSkylarkSetArgs = {
 };
 
 export type QueryListSkylarkTagArgs = {
+  dimensions?: InputMaybe<Array<InputMaybe<UserDimension>>>;
+  ignore_availability?: InputMaybe<Scalars["Boolean"]>;
+  language?: InputMaybe<Scalars["String"]>;
+  limit?: InputMaybe<Scalars["Int"]>;
+  next_token?: InputMaybe<Scalars["String"]>;
+};
+
+export type QueryListStreamtvConfigArgs = {
   dimensions?: InputMaybe<Array<InputMaybe<UserDimension>>>;
   ignore_availability?: InputMaybe<Scalars["Boolean"]>;
   language?: InputMaybe<Scalars["String"]>;
@@ -3646,6 +3691,7 @@ export type SetContentRelationships = {
   SkylarkLiveAsset?: InputMaybe<SkylarkLiveAssetSetInput>;
   SkylarkSet?: InputMaybe<SubSkylarkSetInput>;
   SkylarkTag?: InputMaybe<SkylarkTagSetInput>;
+  StreamtvConfig?: InputMaybe<StreamtvConfigSetInput>;
   Theme?: InputMaybe<ThemeSetInput>;
 };
 
@@ -4125,6 +4171,7 @@ export type SkylarkImage = MediaFile &
     seasons?: Maybe<SeasonListing>;
     sets?: Maybe<SkylarkSetListing>;
     slug?: Maybe<Scalars["String"]>;
+    streamtv_config?: Maybe<StreamtvConfigListing>;
     tags?: Maybe<SkylarkTagListing>;
     themes?: Maybe<ThemeListing>;
     title?: Maybe<Scalars["String"]>;
@@ -4242,6 +4289,13 @@ export type SkylarkImageSetsArgs = {
   order_direction?: InputMaybe<OrderDirections>;
 };
 
+export type SkylarkImageStreamtv_ConfigArgs = {
+  language?: InputMaybe<Scalars["String"]>;
+  limit?: InputMaybe<Scalars["Int"]>;
+  next_token?: InputMaybe<Scalars["String"]>;
+  order_direction?: InputMaybe<OrderDirections>;
+};
+
 export type SkylarkImageTagsArgs = {
   language?: InputMaybe<Scalars["String"]>;
   limit?: InputMaybe<Scalars["Int"]>;
@@ -4315,6 +4369,7 @@ export type SkylarkImageRelationships = {
   ratings?: InputMaybe<RatingRelationshipInput>;
   seasons?: InputMaybe<SeasonRelationshipInput>;
   sets?: InputMaybe<SkylarkSetRelationshipInput>;
+  streamtv_config?: InputMaybe<StreamtvConfigRelationshipInput>;
   tags?: InputMaybe<SkylarkTagRelationshipInput>;
   themes?: InputMaybe<ThemeRelationshipInput>;
 };
@@ -4847,6 +4902,100 @@ export type SkylarkTagSetInput = {
   unlink?: InputMaybe<Array<InputMaybe<Scalars["String"]>>>;
 };
 
+export type StreamtvConfig = Metadata &
+  VisibleObject & {
+    __typename?: "StreamtvConfig";
+    _config?: Maybe<ObjectConfig>;
+    _context?: Maybe<RequestContext>;
+    _meta?: Maybe<_StreamtvConfigMeta>;
+    accent_color?: Maybe<Scalars["String"]>;
+    app_name?: Maybe<Scalars["String"]>;
+    availability?: Maybe<AvailabilityListing>;
+    content_of?: Maybe<SetListing>;
+    external_id?: Maybe<Scalars["String"]>;
+    google_tag_manager_id?: Maybe<Scalars["String"]>;
+    logo?: Maybe<SkylarkImageListing>;
+    primary_color?: Maybe<Scalars["String"]>;
+    slug?: Maybe<Scalars["String"]>;
+    uid: Scalars["String"];
+  };
+
+export type StreamtvConfig_MetaArgs = {
+  global_version?: InputMaybe<Scalars["Int"]>;
+  language?: InputMaybe<Scalars["String"]>;
+  language_version?: InputMaybe<Scalars["Int"]>;
+};
+
+export type StreamtvConfigAvailabilityArgs = {
+  limit?: InputMaybe<Scalars["Int"]>;
+  next_token?: InputMaybe<Scalars["String"]>;
+};
+
+export type StreamtvConfigContent_OfArgs = {
+  language?: InputMaybe<Scalars["String"]>;
+  limit?: InputMaybe<Scalars["Int"]>;
+  next_token?: InputMaybe<Scalars["String"]>;
+};
+
+export type StreamtvConfigLogoArgs = {
+  language?: InputMaybe<Scalars["String"]>;
+  limit?: InputMaybe<Scalars["Int"]>;
+  next_token?: InputMaybe<Scalars["String"]>;
+  order_direction?: InputMaybe<OrderDirections>;
+};
+
+export type StreamtvConfigCreateInput = {
+  accent_color?: InputMaybe<Scalars["String"]>;
+  app_name?: InputMaybe<Scalars["String"]>;
+  availability?: InputMaybe<AssignAvailabilityInput>;
+  external_id?: InputMaybe<Scalars["String"]>;
+  google_tag_manager_id?: InputMaybe<Scalars["String"]>;
+  primary_color?: InputMaybe<Scalars["String"]>;
+  relationships?: InputMaybe<StreamtvConfigRelationships>;
+  slug?: InputMaybe<Scalars["String"]>;
+};
+
+export type StreamtvConfigInput = {
+  accent_color?: InputMaybe<Scalars["String"]>;
+  app_name?: InputMaybe<Scalars["String"]>;
+  availability?: InputMaybe<AssignAvailabilityInput>;
+  external_id?: InputMaybe<Scalars["String"]>;
+  google_tag_manager_id?: InputMaybe<Scalars["String"]>;
+  primary_color?: InputMaybe<Scalars["String"]>;
+  relationships?: InputMaybe<StreamtvConfigRelationships>;
+  slug?: InputMaybe<Scalars["String"]>;
+};
+
+export type StreamtvConfigListing = Listing & {
+  __typename?: "StreamtvConfigListing";
+  count?: Maybe<Scalars["Int"]>;
+  next_token?: Maybe<Scalars["String"]>;
+  objects?: Maybe<Array<Maybe<StreamtvConfig>>>;
+};
+
+export type StreamtvConfigRelationshipInput = {
+  config?: InputMaybe<RelationshipConfigInput>;
+  create?: InputMaybe<Array<InputMaybe<StreamtvConfigCreateInput>>>;
+  link?: InputMaybe<Array<InputMaybe<Scalars["String"]>>>;
+  unlink?: InputMaybe<Array<InputMaybe<Scalars["String"]>>>;
+};
+
+export type StreamtvConfigRelationships = {
+  logo?: InputMaybe<SkylarkImageRelationshipInput>;
+};
+
+export type StreamtvConfigSetCreate = {
+  object?: InputMaybe<StreamtvConfigInput>;
+  position: Scalars["Int"];
+};
+
+export type StreamtvConfigSetInput = {
+  create?: InputMaybe<Array<InputMaybe<StreamtvConfigSetCreate>>>;
+  link?: InputMaybe<Array<InputMaybe<SetLink>>>;
+  reposition?: InputMaybe<Array<InputMaybe<SetLink>>>;
+  unlink?: InputMaybe<Array<InputMaybe<Scalars["String"]>>>;
+};
+
 export type SubSkylarkSetCreate = {
   object?: InputMaybe<SkylarkSetInput>;
   position: Scalars["Int"];
@@ -5074,6 +5223,7 @@ export enum VisibleObjectTypes {
   SkylarkLiveAsset = "SkylarkLiveAsset",
   SkylarkSet = "SkylarkSet",
   SkylarkTag = "SkylarkTag",
+  StreamtvConfig = "StreamtvConfig",
   Theme = "Theme",
 }
 
@@ -5848,6 +5998,41 @@ export type _SkylarkTagMeta = {
   field_config?: Maybe<Array<Maybe<_FieldConfig>>>;
   global_data?: Maybe<_SkylarkTagGlobal>;
   language_data?: Maybe<_SkylarkTagLanguage>;
+  modified?: Maybe<_Audit>;
+  publish_stage?: Maybe<PublishStage>;
+};
+
+export type _StreamtvConfigGlobal = _Global & {
+  __typename?: "_StreamtvConfigGlobal";
+  accent_color?: Maybe<Scalars["String"]>;
+  app_name?: Maybe<Scalars["String"]>;
+  created?: Maybe<_Audit>;
+  google_tag_manager_id?: Maybe<Scalars["String"]>;
+  history?: Maybe<Array<Maybe<_StreamtvConfigGlobal>>>;
+  modified?: Maybe<_Audit>;
+  primary_color?: Maybe<Scalars["String"]>;
+  publish_stage?: Maybe<PublishStage>;
+  version?: Maybe<Scalars["Int"]>;
+};
+
+export type _StreamtvConfigLanguage = _Language & {
+  __typename?: "_StreamtvConfigLanguage";
+  created?: Maybe<_Audit>;
+  history?: Maybe<Array<Maybe<_StreamtvConfigLanguage>>>;
+  language?: Maybe<Scalars["String"]>;
+  modified?: Maybe<_Audit>;
+  publish_stage?: Maybe<PublishStage>;
+  slug?: Maybe<Scalars["String"]>;
+  version?: Maybe<Scalars["Int"]>;
+};
+
+export type _StreamtvConfigMeta = {
+  __typename?: "_StreamtvConfigMeta";
+  available_languages?: Maybe<Array<Maybe<Scalars["String"]>>>;
+  created?: Maybe<_Audit>;
+  field_config?: Maybe<Array<Maybe<_FieldConfig>>>;
+  global_data?: Maybe<_StreamtvConfigGlobal>;
+  language_data?: Maybe<_StreamtvConfigLanguage>;
   modified?: Maybe<_Audit>;
   publish_stage?: Maybe<PublishStage>;
 };

--- a/packages/ingestor/src/lib/skylark/saas/objectConfiguration.ts
+++ b/packages/ingestor/src/lib/skylark/saas/objectConfiguration.ts
@@ -54,7 +54,12 @@ const createMutation = (): string[] => {
             object_config: {
               colour: `#${OBJECT_CONFIG[objectType].colour.toLowerCase()}`,
               primary_field: OBJECT_CONFIG[objectType].primaryField,
-              field_config: OBJECT_CONFIG[objectType].fieldConfig,
+              field_config: OBJECT_CONFIG[objectType].fieldConfig.map(
+                (fieldConfig) => ({
+                  ...fieldConfig,
+                  ui_field_type: new EnumType(fieldConfig.ui_field_type),
+                })
+              ),
             },
           },
           colour: true,

--- a/packages/ingestor/src/lib/skylark/saas/objectConfiguration.ts
+++ b/packages/ingestor/src/lib/skylark/saas/objectConfiguration.ts
@@ -32,7 +32,7 @@ const OBJECT_CONFIG: Record<
         ui_position: 3,
       },
       {
-        name: "google_analytics_id",
+        name: "google_tag_manager_id",
         ui_field_type: "STRING",
         ui_position: 4,
       },

--- a/packages/ingestor/src/lib/skylark/saas/objectConfiguration.ts
+++ b/packages/ingestor/src/lib/skylark/saas/objectConfiguration.ts
@@ -3,42 +3,42 @@ import { EnumType, jsonToGraphQLQuery } from "json-to-graphql-query";
 import { chunk } from "lodash";
 import { CREATE_OBJECT_CHUNK_SIZE } from "../../constants";
 
-const OBJECT_CONFIG: Record<string, { colour: string; primaryField: string }> =
+const OBJECT_CONFIG: Record<
+  string,
   {
-    Episode: {
-      colour: "FF7BA8",
-      primaryField: "title",
-    },
-    Season: {
-      colour: "9C27B0",
-      primaryField: "title",
-    },
-    Brand: {
-      colour: "673AB7",
-      primaryField: "title",
-    },
-    ParentalGuidance: {
-      colour: "03A9F4",
-      primaryField: "slug",
-    },
-    Rating: {
-      colour: "00BCD4",
-      primaryField: "title",
-    },
-    Movie: {
-      colour: "009688",
-      primaryField: "title",
-    },
-    SkylarkTag: { colour: "4CAF50", primaryField: "name" },
-    Genre: { colour: "8BC34A", primaryField: "name" },
-    Theme: { colour: "CDDC39", primaryField: "name" },
-    Role: { colour: "FFC107", primaryField: "title" },
-    Person: { colour: "FF9800", primaryField: "name" },
-    Credit: { colour: "FF5722", primaryField: "slug" },
-    SkylarkAsset: { colour: "9E9E9E", primaryField: "title" },
-    SkylarkImage: { colour: "607D8B", primaryField: "title" },
-    SkylarkSet: { colour: "000000", primaryField: "title" },
-  };
+    colour: string;
+    primaryField: string;
+    fieldConfig: { name: string; ui_field_type: string; ui_position: number }[];
+  }
+> = {
+  // Object created in schema section of ingestor
+  StreamtvConfig: {
+    colour: "5B45CE",
+    primaryField: "app_name",
+    fieldConfig: [
+      {
+        name: "app_name",
+        ui_field_type: "STRING",
+        ui_position: 1,
+      },
+      {
+        name: "primary_color",
+        ui_field_type: "STRING",
+        ui_position: 2,
+      },
+      {
+        name: "accent_color",
+        ui_field_type: "STRING",
+        ui_position: 3,
+      },
+      {
+        name: "google_analytics_id",
+        ui_field_type: "STRING",
+        ui_position: 4,
+      },
+    ],
+  },
+};
 
 const createMutation = (): string[] => {
   const chunks = chunk(Object.keys(OBJECT_CONFIG), CREATE_OBJECT_CHUNK_SIZE);
@@ -54,6 +54,7 @@ const createMutation = (): string[] => {
             object_config: {
               colour: `#${OBJECT_CONFIG[objectType].colour.toLowerCase()}`,
               primary_field: OBJECT_CONFIG[objectType].primaryField,
+              field_config: OBJECT_CONFIG[objectType].fieldConfig,
             },
           },
           colour: true,

--- a/packages/ingestor/src/lib/skylark/saas/schema.ts
+++ b/packages/ingestor/src/lib/skylark/saas/schema.ts
@@ -161,6 +161,36 @@ const addPreferredImageTypeToSeason = async (version?: number) => {
   }
 };
 
+const addStreamTVConfigObjectType = () => {
+  const CREATE_STREAMTV_CONFIG_OBJECT_TYPE = gql`
+    mutation CREATE_STREAMTV_CONFIG_OBJECT_TYPE($version: Int!) {
+      createObjectType(
+        version: $version
+        object_types: {
+          name: "streamtv_config"
+          relationships: [
+            {
+              operation: CREATE
+              to_class: SkylarkImage
+              relationship_name: "logo"
+              reverse_relationship_name: "streamtv_config"
+            }
+          ]
+          fields: [
+            { name: "app_name", operation: CREATE, type: STRING }
+            { name: "primary_color", operation: CREATE, type: STRING }
+            { name: "accent_color", operation: CREATE, type: STRING }
+            { name: "google_analytics_id", operation: CREATE, type: STRING }
+          ]
+        }
+      ) {
+        messages
+        version
+      }
+    }
+  `;
+};
+
 export const waitForUpdatingSchema = async () => {
   const {
     active_version: activeVersion,

--- a/packages/ingestor/src/lib/skylark/saas/schema.ts
+++ b/packages/ingestor/src/lib/skylark/saas/schema.ts
@@ -212,7 +212,7 @@ const addStreamTVConfigObjectType = async (version?: number) => {
             { name: "app_name", operation: CREATE, type: STRING }
             { name: "primary_color", operation: CREATE, type: STRING }
             { name: "accent_color", operation: CREATE, type: STRING }
-            { name: "google_analytics_id", operation: CREATE, type: STRING }
+            { name: "google_tag_manager_id", operation: CREATE, type: STRING }
           ]
         }
       ) {

--- a/packages/ingestor/src/main.ts
+++ b/packages/ingestor/src/main.ts
@@ -26,6 +26,7 @@ import {
   clearUnableToFindVersionNoneObjectsFile,
   writeAirtableOutputFile,
 } from "./lib/skylark/saas/fs";
+import { updateObjectConfigurations } from "./lib/skylark/saas/objectConfiguration";
 
 const main = async () => {
   await clearUnableToFindVersionNoneObjectsFile();
@@ -74,10 +75,9 @@ const main = async () => {
   // eslint-disable-next-line no-console
   console.log("Schema updated to version:", version);
 
-  // Comment updateObjectConfigurations as we can use the defaults
-  // await updateObjectConfigurations();
-  // // eslint-disable-next-line no-console
-  // console.log("Object configuration updated");
+  await updateObjectConfigurations();
+  // eslint-disable-next-line no-console
+  console.log("Object configuration updated");
 
   await createDimensions(showcaseDimensionsConfig);
 

--- a/packages/react/src/components/app-background-gradient/app-background-gradient.component.tsx
+++ b/packages/react/src/components/app-background-gradient/app-background-gradient.component.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 
 export const AppBackgroundGradient: React.FC = () => (
-  <div className="absolute h-screen w-screen from-purple-500 to-gray-900 bg-page-gradient" />
+  <div className="absolute h-screen w-screen from-streamtv-primary to-gray-900 bg-page-gradient" />
 );
 
 export default AppBackgroundGradient;

--- a/packages/react/src/components/app-header/app-header.component.tsx
+++ b/packages/react/src/components/app-header/app-header.component.tsx
@@ -18,7 +18,7 @@ export const AppHeader: React.FC<NavigationProps & { forceRtl?: boolean }> = ({
       <div
         className={`
     fixed z-90 flex h-mobile-header w-full items-center justify-center
-    bg-purple-500 md:relative md:h-full md:w-3/5 md:justify-between ltr:md:pr-md-gutter
+    bg-streamtv-primary md:relative md:h-full md:w-3/5 md:justify-between ltr:md:pr-md-gutter
     rtl:md:pl-md-gutter lg:w-2/3 ltr:lg:pr-lg-gutter rtl:lg:pl-lg-gutter
     ltr:xl:pr-xl-gutter rtl:xl:pl-xl-gutter
   `}

--- a/packages/react/src/components/button/button.component.tsx
+++ b/packages/react/src/components/button/button.component.tsx
@@ -13,17 +13,17 @@ interface ButtonProps {
   disabled?: boolean;
 }
 
-const primaryStyles = "bg-button-primary";
-const secondaryStyles = "bg-button-secondary";
-const tertiaryStyles = "bg-button-tertiary";
-const outlineStyles = "text-gray-600 hover:text-gray-100 font-medium";
-const xlStyles = "px-8 md:px-10 lg:px-12 py-4 text-base md:text-lg";
-const lgStyles =
+const primaryClassName = "bg-streamtv-primary";
+const secondaryClassName = "bg-button-secondary";
+const tertiaryClassName = "bg-button-tertiary";
+const outlineClassName = "text-gray-600 hover:text-gray-100 font-medium";
+const xlClassName = "px-8 md:px-10 lg:px-12 py-4 text-base md:text-lg";
+const lgClassName =
   "px-4 md:px-6 lg:px-8 xl:px-10 py-2 lg:py-3 text-sm lg:text-base";
-const smStyles = "px-2 md:px-4 lg:px-6 py-2 text-xs md:text-sm";
-const onlyIconXlStyles = "p-4 md:p-5";
-const onlyIconLgStyles = "p-3";
-const onlyIconSmStyles = "p-2";
+const smClassName = "px-2 md:px-4 lg:px-6 py-2 text-xs md:text-sm";
+const onlyIconXlClassName = "p-4 md:p-5";
+const onlyIconLgClassName = "p-3";
+const onlyIconSmClassName = "p-2";
 
 export const Button: React.FC<ButtonProps> = ({
   size = "lg",
@@ -37,26 +37,30 @@ export const Button: React.FC<ButtonProps> = ({
   onClick,
 }) => {
   let className = `
-  ${variant === "primary" ? primaryStyles : ""}
-  ${variant === "secondary" ? secondaryStyles : ""}
-  ${variant === "tertiary" ? tertiaryStyles : ""}
-  ${variant === "outline" ? outlineStyles : "text-white disabled:text-gray-300"}
+  ${variant === "primary" ? primaryClassName : ""}
+  ${variant === "secondary" ? secondaryClassName : ""}
+  ${variant === "tertiary" ? tertiaryClassName : ""}
+  ${
+    variant === "outline"
+      ? outlineClassName
+      : "text-white disabled:text-gray-300"
+  }
 flex justify-center items-center h-full
-hover:bg-button-hover disabled:bg-button-disabled transition-colors
+hover:bg-streamtv-accent disabled:bg-gray-100 transition-colors
 font-body cursor-pointer
 `;
 
   if (text) {
     className += ` rounded-sm w-full md:w-fit px-2
-      ${size === "sm" ? smStyles : ""}
-      ${size === "lg" ? lgStyles : ""}
-      ${size === "xl" ? xlStyles : ""}
+      ${size === "sm" ? smClassName : ""}
+      ${size === "lg" ? lgClassName : ""}
+      ${size === "xl" ? xlClassName : ""}
     `;
   } else {
     className += ` rounded-full
-      ${size === "sm" ? onlyIconSmStyles : ""}
-      ${size === "lg" ? onlyIconLgStyles : ""}
-      ${size === "xl" ? onlyIconXlStyles : ""}
+      ${size === "sm" ? onlyIconSmClassName : ""}
+      ${size === "lg" ? onlyIconLgClassName : ""}
+      ${size === "xl" ? onlyIconXlClassName : ""}
     `;
   }
 

--- a/packages/react/src/components/carousel/carousel-button.component.tsx
+++ b/packages/react/src/components/carousel/carousel-button.component.tsx
@@ -45,7 +45,7 @@ export const CarouselButton: React.FC<CarouselButtonProps> = ({
         {duration && active && (
           <motion.circle
             animate="visible"
-            className="fill-transparent stroke-pink-500 stroke-[6]"
+            className="fill-transparent stroke-streamtv-accent stroke-[6]"
             custom={1}
             cx="50"
             cy="50"

--- a/packages/react/src/components/dropdown/dropdown.component.tsx
+++ b/packages/react/src/components/dropdown/dropdown.component.tsx
@@ -73,7 +73,7 @@ export const Dropdown: React.FC<DropdownProps> = ({
                   text-xs
                   font-semibold
                   hover:bg-gray-100
-                  hover:text-purple-500
+                  hover:text-streamtv-primary
                   md:text-sm
                   "
                 type="button"

--- a/packages/react/src/components/loading-screen/loading-screen.component.tsx
+++ b/packages/react/src/components/loading-screen/loading-screen.component.tsx
@@ -98,7 +98,7 @@ export const LoadingScreen: React.FC<LoadingScreenProps> = ({
               className="mr-2 inline-block md:mr-4"
               variants={character}
             >
-              <MdStream className="h-12 w-12 rounded-md bg-purple-500 sm:h-14 sm:w-14 lg:h-16 lg:w-16" />
+              <MdStream className="h-12 w-12 rounded-md bg-streamtv-primary sm:h-14 sm:w-14 lg:h-16 lg:w-16" />
             </motion.span>
             {title.split("").map((item, i) => (
               <motion.span

--- a/packages/react/src/components/thumbnail/base/base-thumbnail.component.tsx
+++ b/packages/react/src/components/thumbnail/base/base-thumbnail.component.tsx
@@ -74,9 +74,9 @@ const BaseThumbnail: React.FC<BaseThumbnailProps> = ({
         <div
           className={`
               ${contentLocation === "below" ? "justify-end" : "justify-between"}
-              relative flex h-full w-full flex-col rounded-sm
-              bg-gradient-to-t from-gray-900 to-transparent bg-clip-border bg-no-repeat p-2 font-display text-white shadow
-              shadow-gray-900 transition-all sm:p-3 md:hover:scale-[1.005] md:group-hover:bg-streamtv-primary/[.85] lg:p-4
+              md:group-hover:bg-streamtv-primary/[.85] relative flex h-full w-full flex-col
+              rounded-sm bg-gradient-to-t from-gray-900 to-transparent bg-clip-border bg-no-repeat p-2 font-display text-white
+              shadow shadow-gray-900 transition-all sm:p-3 md:hover:scale-[1.005] lg:p-4
             `}
         >
           {statusTag && (

--- a/packages/react/src/components/thumbnail/base/base-thumbnail.component.tsx
+++ b/packages/react/src/components/thumbnail/base/base-thumbnail.component.tsx
@@ -64,7 +64,7 @@ const BaseThumbnail: React.FC<BaseThumbnailProps> = ({
           }
           relative z-30 block w-full scale-[1.0001] rounded-sm bg-cover bg-clip-border
           bg-center bg-no-repeat transition-all md:hover:z-40
-          ${!imageLoaded ? "animate-pulse bg-purple-500" : ""}
+          ${!imageLoaded ? "animate-pulse bg-streamtv-primary" : ""}
         `}
       style={{
         backgroundImage: imageLoaded ? `url('${backgroundImage}')` : "",
@@ -76,11 +76,11 @@ const BaseThumbnail: React.FC<BaseThumbnailProps> = ({
               ${contentLocation === "below" ? "justify-end" : "justify-between"}
               relative flex h-full w-full flex-col rounded-sm
               bg-gradient-to-t from-gray-900 to-transparent bg-clip-border bg-no-repeat p-2 font-display text-white shadow
-              shadow-gray-900 transition-all sm:p-3 md:hover:scale-[1.005] md:group-hover:bg-purple-500/[.85] lg:p-4
+              shadow-gray-900 transition-all sm:p-3 md:hover:scale-[1.005] md:group-hover:bg-streamtv-primary/[.85] lg:p-4
             `}
         >
           {statusTag && (
-            <div className="absolute right-0 top-2 rounded-l-sm bg-purple-500 px-2 py-0.5 text-xs">
+            <div className="absolute right-0 top-2 rounded-l-sm bg-streamtv-primary px-2 py-0.5 text-xs">
               {statusTag}
             </div>
           )}

--- a/packages/react/src/components/title-screen/title-screen.component.tsx
+++ b/packages/react/src/components/title-screen/title-screen.component.tsx
@@ -78,10 +78,14 @@ export const TitleScreen: React.FC<TitleScreenProps> = ({
   };
 
   const [show, setShow] = useState(true);
+  const [animationComplete, setShown] = useState(false);
 
   return (
-    <AnimatePresence>
-      {show && (
+    <AnimatePresence
+      key={title} // Makes this reset when the title changes so the name is always right on load
+      onExitComplete={() => setShown(true)}
+    >
+      {show && !animationComplete && (
         <motion.div
           className="fixed inset-0 z-[999] flex flex-col items-center justify-center gap-y-1 bg-gray-900 font-display text-white sm:gap-y-2 lg:gap-y-4"
           exit="exit"

--- a/packages/react/src/components/title-screen/title-screen.stories.tsx
+++ b/packages/react/src/components/title-screen/title-screen.stories.tsx
@@ -24,7 +24,7 @@ export const WithLogo = Template.bind({});
 WithLogo.args = {
   ...Default.args,
   logo: (
-    <MdStream className="h-12 w-12 rounded-md bg-purple-500 sm:h-14 sm:w-14 lg:h-16 lg:w-16" />
+    <MdStream className="h-12 w-12 rounded-md bg-streamtv-primary sm:h-14 sm:w-14 lg:h-16 lg:w-16" />
   ),
 };
 WithLogo.parameters = {

--- a/packages/react/styles/globals.css
+++ b/packages/react/styles/globals.css
@@ -1,3 +1,8 @@
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
+
+:root {
+  --streamtv-primary-color: #5b45ce;
+  --streamtv-accent-color: #ff385c;
+}

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -22,7 +22,26 @@ module.exports = {
         ol2: ["10px", "10px"],
       },
       colors: {
-        "skylark-blue": "#226DFF",
+        skylark: {
+          blue: "#226DFF",
+        },
+        streamtv: {
+          primary: "var(--streamtv-primary-color)",
+          accent: "var(--streamtv-accent-color)",
+          purple: {
+            50: "#EDE8F9",
+            100: "#D0C7F0",
+            300: "#917CDE",
+            400: "#7760D6",
+            500: "#5B45CE",
+            700: "#4138BE",
+          },
+          pink: {
+            400: "#FF7E96",
+            500: "#FF385C",
+            600: "#D82646",
+          },
+        },
         gray: {
           50: "#F7F7FC",
           100: "#F3F3FB",
@@ -34,24 +53,8 @@ module.exports = {
           800: "#3C3A41",
           900: "#1B1A20",
         },
-        purple: {
-          50: "#EDE8F9",
-          100: "#D0C7F0",
-          300: "#917CDE",
-          400: "#7760D6",
-          500: "#5B45CE",
-          700: "#4138BE",
-        },
-        pink: {
-          400: "#FF7E96",
-          500: "#FF385C",
-          600: "#D82646",
-        },
         button: {
-          primary: "#5B45CE",
           secondary: "rgba(104, 108, 119, 0.65)",
-          hover: "#FF385C",
-          disabled: "#F3F3FB",
           tertiary: "rgba(27, 26, 32, 0.25)",
         },
       },


### PR DESCRIPTION
<!-- Enter a very brief description of change -->
<!-- Add any optional commentary which may help the code reviewer. -->

Ingestor:
- Adds StreamtvConfig object type to Skylark
- Adds UI Config for the object type
- Adds mode to only add Schema changes, Object config changes, Dimensions and Availabilities to Skylark (so no actual objects but Availability) - this sets up a Skylark env for StreamTV

StreamTV:
- Adds support for the StreamtvConfig object to change:
  - App name
  - Logo
  - Primary colour
  - Accent colour
  - Add a GA Tag Manager Script
- Object is fetched using the list endpoint and will use the first returned config - this means it can be availability driven
- Refactors the TailwindCSS to use a primary color and accent color tailwind classname which is driven by a CSS variable. This means it can be overridden in JS.

<!-- Please tick all relevant change types this PR commits -->
<!-- Delete non-relevant lines -->
* [x] Feature

#### Jira
<!-- Line separated list of relevant Jira ticket links -->
https://skylarkplatform.atlassian.net/browse/SL-2832

