### PR TITLE
feat: rename TV Shows to Featured, enable StreamtvConfig to set it

### DIFF
--- a/apps/streamtv/components/layout.tsx
+++ b/apps/streamtv/components/layout.tsx
@@ -20,23 +20,39 @@ import createDefaultSeo from "../next-seo.config";
 import { GoogleTagManagerScript } from "./googleTagManager";
 
 interface Props {
-  appTitle?: string;
-  tvShowsHref: string;
   skylarkApiUrl?: string;
   timeTravelEnabled?: boolean;
   children?: React.ReactNode;
 }
 
+const convertUrlWithSameOriginToPath = (url: string): string => {
+  if (url.startsWith("/")) {
+    return url;
+  }
+
+  try {
+    const parsedUrl = new URL(url);
+    if (
+      typeof window !== "undefined" &&
+      window.location.origin === parsedUrl.origin
+    ) {
+      return parsedUrl.pathname;
+    }
+    return url;
+  } catch {
+    return url;
+  }
+};
+
 export const StreamTVLayout: React.FC<Props> = ({
-  appTitle: propAppTitle,
-  tvShowsHref,
   skylarkApiUrl,
   timeTravelEnabled,
   children,
 }) => {
   const { config } = useStreamTVConfig();
 
-  const appTitle = config?.appName || propAppTitle || "StreamTV";
+  const appTitle =
+    config?.appName || process.env.NEXT_PUBLIC_APP_TITLE || "StreamTV";
 
   const { asPath, query } = useRouter();
   const { t } = useTranslation("common");
@@ -45,7 +61,14 @@ export const StreamTVLayout: React.FC<Props> = ({
   const links = [
     { text: t("discover"), href: "/" },
     { text: t("movies"), href: "/movies" },
-    { text: t("tv-shows"), href: tvShowsHref },
+    {
+      text: t("featured"),
+      href: convertUrlWithSameOriginToPath(
+        config?.featuredPageUrl ||
+          process.env.NEXT_PUBLIC_TV_SHOWS_HREF ||
+          "/brand/reculg97iNzbkEZCK" // StreamTV Ingest External ID
+      ),
+    },
   ];
 
   const [modalOpen, setModalOpen] = useState(false);

--- a/apps/streamtv/graphql/queries/streamtvConfig.ts
+++ b/apps/streamtv/graphql/queries/streamtvConfig.ts
@@ -22,8 +22,10 @@ export const GET_STREAMTV_CONFIG = gql`
       ]
     ) {
       objects {
-        accent_color
         app_name
+        primary_color
+        accent_color
+        featured_page_url
         google_tag_manager_id
         logo(limit: 1) {
           objects {
@@ -33,7 +35,6 @@ export const GET_STREAMTV_CONFIG = gql`
             slug
           }
         }
-        primary_color
       }
     }
   }

--- a/apps/streamtv/hooks/useStreamTVConfig.tsx
+++ b/apps/streamtv/hooks/useStreamTVConfig.tsx
@@ -19,6 +19,7 @@ interface StreamTVConfigResponse {
       primary_color: string;
       accent_color: string;
       google_tag_manager_id: string;
+      featured_page_url: string;
       logo: SkylarkImageListing;
     }[];
   };
@@ -29,6 +30,7 @@ interface StreamTVConfig {
   primaryColor: string;
   accentColor: string;
   googleTagManagerId: string;
+  featuredPageUrl: string;
   logo?: {
     alt: string;
     src: string;
@@ -72,6 +74,7 @@ export const useStreamTVConfig = () => {
       primaryColor: gqlConfig.primary_color,
       accentColor: gqlConfig.accent_color,
       googleTagManagerId: gqlConfig.google_tag_manager_id,
+      featuredPageUrl: gqlConfig.featured_page_url,
       logo:
         logo && logo.url
           ? {

--- a/apps/streamtv/locales/ar/common.json
+++ b/apps/streamtv/locales/ar/common.json
@@ -29,7 +29,7 @@
   },
   "discover": "يكتشف",
   "movies": "أفلام",
-  "tv-shows": "عرض تلفزيوني",
+  "featured": "بارز",
   "movies-page-description": "ابحث في المئات من أحدث وأروع العناوين المتوفرة للمشاهدة على StreamTV",
   "by-skylark": "بواسطة سكايلارك",
   "available-for": {

--- a/apps/streamtv/locales/en-gb/common.json
+++ b/apps/streamtv/locales/en-gb/common.json
@@ -29,7 +29,7 @@
   },
   "discover": "Discover",
   "movies": "Movies",
-  "tv-shows": "TV Shows",
+  "featured": "Featured",
   "movies-page-description": "Search 100's of the latest and greatest titles, available to watch on StreamTV",
   "by-skylark": "By Skylark",
   "available-for": {

--- a/apps/streamtv/locales/pt-pt/common.json
+++ b/apps/streamtv/locales/pt-pt/common.json
@@ -29,7 +29,7 @@
   },
   "discover": "Descobrir",
   "movies": "Filmes",
-  "tv-shows": "Televisão",
+  "featured": "Apresentou",
   "movies-page-description": "Pesquise 100 dos melhores e mais recentes títulos, disponíveis para assistir em StreamTV",
   "by-skylark": "Por Skylark",
   "available-for": {

--- a/apps/streamtv/pages/_app.tsx
+++ b/apps/streamtv/pages/_app.tsx
@@ -13,9 +13,6 @@ import { useEffect, useState } from "react";
 import { DimensionsContextProvider } from "@skylark-reference-apps/react";
 import { StreamTVLayout } from "../components/layout";
 
-const tvShowsHref =
-  process.env.NEXT_PUBLIC_TV_SHOWS_HREF || "/brand/reculg97iNzbkEZCK";
-
 function MyApp({ Component, pageProps }: AppProps) {
   const [skylarkApiUrl, setSkylarkApiUrl] = useState(
     process.env.NEXT_PUBLIC_SAAS_API_ENDPOINT
@@ -42,12 +39,7 @@ function MyApp({ Component, pageProps }: AppProps) {
     <PlausibleProvider domain={process.env.NEXT_PUBLIC_APP_DOMAIN as string}>
       <QueryClientProvider client={queryClient}>
         <DimensionsContextProvider>
-          <StreamTVLayout
-            appTitle={process.env.NEXT_PUBLIC_APP_TITLE}
-            skylarkApiUrl={skylarkApiUrl}
-            timeTravelEnabled
-            tvShowsHref={tvShowsHref}
-          >
+          <StreamTVLayout skylarkApiUrl={skylarkApiUrl} timeTravelEnabled>
             <Component {...pageProps} />
           </StreamTVLayout>
         </DimensionsContextProvider>

--- a/packages/ingestor/src/additional-objects/sets.ts
+++ b/packages/ingestor/src/additional-objects/sets.ts
@@ -216,9 +216,9 @@ const gameOfThronesUniversePage: SetConfig = {
   ],
 };
 
-const streamingNowRail: SetConfig = {
-  externalId: createStreamTVExternalId("streaming_now"),
-  slug: "streaming-now",
+const liveNowRail: SetConfig = {
+  externalId: createStreamTVExternalId("live_now"),
+  slug: "live-now",
   graphQlSetType: "RAIL",
   contents: [
     { type: "live-stream", slug: "tears-of-steel" },
@@ -325,7 +325,7 @@ const mediaReferenceHomepage: SetConfig = {
     { type: "seasons", slug: "miraculous-s05" },
     { type: "set", slug: setInEuropeRail.slug },
     { type: "set", slug: setInAmericaRail.slug },
-    { type: "set", slug: streamingNowRail.slug },
+    { type: "set", slug: liveNowRail.slug },
     { type: "set", slug: discoverCollectionRail.slug },
   ],
 };
@@ -342,7 +342,7 @@ export const orderedSetsToCreate = [
   starWarsMoviesCollection,
   bestPictureMovies2020,
   bestPictureMovies2021,
-  streamingNowRail,
+  liveNowRail,
   setInEuropeRail,
   setInAmericaRail,
   topArabicMovies,

--- a/packages/ingestor/src/lib/skylark/saas/objectConfiguration.ts
+++ b/packages/ingestor/src/lib/skylark/saas/objectConfiguration.ts
@@ -8,7 +8,11 @@ const OBJECT_CONFIG: Record<
   {
     colour: string;
     primaryField: string;
-    fieldConfig: { name: string; ui_field_type: string; ui_position: number }[];
+    fieldConfig: {
+      name: string;
+      ui_field_type: string | null;
+      ui_position: number;
+    }[];
   }
 > = {
   // Object created in schema section of ingestor
@@ -32,9 +36,14 @@ const OBJECT_CONFIG: Record<
         ui_position: 3,
       },
       {
+        name: "featured_page_url",
+        ui_field_type: null,
+        ui_position: 4,
+      },
+      {
         name: "google_tag_manager_id",
         ui_field_type: "STRING",
-        ui_position: 4,
+        ui_position: 5,
       },
     ],
   },
@@ -57,7 +66,9 @@ const createMutation = (): string[] => {
               field_config: OBJECT_CONFIG[objectType].fieldConfig.map(
                 (fieldConfig) => ({
                   ...fieldConfig,
-                  ui_field_type: new EnumType(fieldConfig.ui_field_type),
+                  ui_field_type: fieldConfig.ui_field_type
+                    ? new EnumType(fieldConfig.ui_field_type)
+                    : null,
                 })
               ),
             },

--- a/packages/ingestor/src/lib/skylark/saas/schema.ts
+++ b/packages/ingestor/src/lib/skylark/saas/schema.ts
@@ -210,6 +210,7 @@ const addStreamTVConfigObjectType = async (version?: number) => {
           ]
           fields: [
             { name: "app_name", operation: CREATE, type: STRING }
+            { name: "featured_page_url", operation: CREATE, type: URL }
             { name: "primary_color", operation: CREATE, type: STRING }
             { name: "accent_color", operation: CREATE, type: STRING }
             { name: "google_tag_manager_id", operation: CREATE, type: STRING }


### PR DESCRIPTION
Changes `TV Shows` to `Featured` in StreamTV navigation bar

Enables the `Featured` link's destination to be set in the StreamtvConfig object

<!-- Enter a very brief description of change -->
<!-- Add any optional commentary which may help the code reviewer. -->

<!-- Please tick all relevant change types this PR commits -->
<!-- Delete non-relevant lines -->
* [x] Feature



