### PR TITLE
feat: Add UID to all Queries so they can be reevaluated in the Skylark cache

### DIFF
--- a/apps/marketing-site/src/queries/fragments.ts
+++ b/apps/marketing-site/src/queries/fragments.ts
@@ -13,12 +13,12 @@ export const ImageListingFragment = gql`
 
 export const CallToActionFragment = gql`
   fragment callToActionFragment on CallToAction {
+    uid
     external_id
     slug
     appearance
     copy
     type
-    uid
     url
     url_path
     button_text

--- a/apps/marketing-site/src/queries/getPage.ts
+++ b/apps/marketing-site/src/queries/getPage.ts
@@ -7,6 +7,7 @@ export const GET_PAGE = gql`
 
   query GET_PAGE {
     getPage(external_id: "marketing-site-homepage") {
+      uid
       seo_description
       seo_title
       slug
@@ -14,6 +15,7 @@ export const GET_PAGE = gql`
         objects {
           object {
             __typename
+            uid
             ... on Block {
               external_id
               slug
@@ -21,7 +23,6 @@ export const GET_PAGE = gql`
               type
               copy
               appearance
-              uid
               images {
                 ...imageListingFragment
               }
@@ -37,17 +38,16 @@ export const GET_PAGE = gql`
               type
               internal_title
               embed_id
-              uid
             }
             ... on Section {
               slug
               internal_title
               title
               type
-              uid
               content(limit: 100) {
                 objects {
                   object {
+                    uid
                     ... on Block {
                       external_id
                       slug
@@ -55,15 +55,14 @@ export const GET_PAGE = gql`
                       internal_title
                       title
                       type
-                      uid
                       images {
                         ...imageListingFragment
                       }
                       content {
                         objects {
                           object {
+                            uid
                             ... on FrequentlyAskedQuestion {
-                              uid
                               external_id
                               slug
                               answer
@@ -75,7 +74,6 @@ export const GET_PAGE = gql`
                       }
                     }
                     ... on Testimonial {
-                      uid
                       external_id
                       slug
                       copy

--- a/apps/streamtv/graphql/queries/fragments.ts
+++ b/apps/streamtv/graphql/queries/fragments.ts
@@ -3,6 +3,7 @@ import { gql } from "graphql-request";
 export const ImageListingFragment = gql`
   fragment imageListingFragment on SkylarkImageListing {
     objects {
+      uid
       title
       type
       url
@@ -13,6 +14,7 @@ export const ImageListingFragment = gql`
 export const CallToActionListingFragment = gql`
   fragment callToActionListingFragment on CallToActionListing {
     objects {
+      uid
       type
       text
       text_short
@@ -26,6 +28,7 @@ export const CallToActionListingFragment = gql`
 
 export const ObjectLanguageFragment = gql`
   fragment objectLanguageFragment on Metadata {
+    uid
     ... on Episode {
       _meta {
         language_data {

--- a/apps/streamtv/graphql/queries/getBrand.ts
+++ b/apps/streamtv/graphql/queries/getBrand.ts
@@ -19,12 +19,14 @@ export const GET_BRAND_THUMBNAIL = gql`
       ]
     ) {
       __typename
+      uid
       title
       title_short
       synopsis
       synopsis_short
       images {
         objects {
+          uid
           title
           type
           url
@@ -32,6 +34,7 @@ export const GET_BRAND_THUMBNAIL = gql`
       }
       tags {
         objects {
+          uid
           name
           type
         }
@@ -59,12 +62,14 @@ export const GET_BRAND = (streamTVIngestorSchemaLoaded: boolean) => gql`
         { dimension: "regions", value: $region }
       ]
     ) {
+      uid
       title
       title_short
       synopsis
       synopsis_short
       images {
         objects {
+          uid
           title
           type
           url
@@ -91,11 +96,13 @@ export const GET_BRAND = (streamTVIngestorSchemaLoaded: boolean) => gql`
       }
       tags {
         objects {
+          uid
           name
         }
       }
       ratings {
         objects {
+          uid
           value
         }
       }

--- a/apps/streamtv/graphql/queries/getEpisode.ts
+++ b/apps/streamtv/graphql/queries/getEpisode.ts
@@ -18,6 +18,7 @@ export const GET_EPISODE_THUMBNAIL = gql`
       ]
     ) {
       __typename
+      uid
       title
       title_short
       synopsis
@@ -26,6 +27,7 @@ export const GET_EPISODE_THUMBNAIL = gql`
       release_date
       images {
         objects {
+          uid
           title
           type
           url
@@ -33,6 +35,7 @@ export const GET_EPISODE_THUMBNAIL = gql`
       }
       tags {
         objects {
+          uid
           name
           type
         }
@@ -60,6 +63,7 @@ export const GET_EPISODE = gql`
         { dimension: "regions", value: $region }
       ]
     ) {
+      uid
       title
       title_short
       synopsis
@@ -68,6 +72,7 @@ export const GET_EPISODE = gql`
       release_date
       images {
         objects {
+          uid
           title
           type
           url
@@ -97,14 +102,17 @@ export const GET_EPISODE = gql`
       }
       credits {
         objects {
+          uid
           character
           people {
             objects {
+              uid
               name
             }
           }
           roles {
             objects {
+              uid
               internal_title
               title
               title_sort
@@ -114,27 +122,32 @@ export const GET_EPISODE = gql`
       }
       genres {
         objects {
+          uid
           name
         }
       }
       themes {
         objects {
+          uid
           name
         }
       }
       ratings {
         objects {
+          uid
           value
         }
       }
       tags {
         objects {
+          uid
           name
           type
         }
       }
       availability(limit: 20) {
         objects {
+          uid
           end
         }
       }

--- a/apps/streamtv/graphql/queries/getLiveStream.ts
+++ b/apps/streamtv/graphql/queries/getLiveStream.ts
@@ -18,12 +18,14 @@ export const GET_LIVE_STREAM_THUMBNAIL = gql`
       ]
     ) {
       __typename
+      uid
       title
       title_short
       synopsis
       synopsis_short
       images {
         objects {
+          uid
           title
           type
           url
@@ -31,6 +33,7 @@ export const GET_LIVE_STREAM_THUMBNAIL = gql`
       }
       tags {
         objects {
+          uid
           name
           type
         }
@@ -58,12 +61,14 @@ export const GET_LIVE_STREAM = gql`
         { dimension: "regions", value: $region }
       ]
     ) {
+      uid
       title
       title_short
       synopsis
       synopsis_short
       images {
         objects {
+          uid
           title
           type
           url
@@ -85,14 +90,17 @@ export const GET_LIVE_STREAM = gql`
       }
       credits {
         objects {
+          uid
           character
           people {
             objects {
+              uid
               name
             }
           }
           roles {
             objects {
+              uid
               internal_title
               title
               title_sort
@@ -102,27 +110,32 @@ export const GET_LIVE_STREAM = gql`
       }
       genres {
         objects {
+          uid
           name
         }
       }
       themes {
         objects {
           name
+          uid
         }
       }
       ratings {
         objects {
           value
+          uid
         }
       }
       tags {
         objects {
+          uid
           name
           type
         }
       }
       availability(limit: 20) {
         objects {
+          uid
           end
         }
       }

--- a/apps/streamtv/graphql/queries/getMovie.ts
+++ b/apps/streamtv/graphql/queries/getMovie.ts
@@ -17,6 +17,7 @@ export const GET_MOVIE_THUMBNAIL = gql`
         { dimension: "regions", value: $region }
       ]
     ) {
+      uid
       __typename
       title
       title_short
@@ -25,6 +26,7 @@ export const GET_MOVIE_THUMBNAIL = gql`
       release_date
       images {
         objects {
+          uid
           title
           type
           url
@@ -32,6 +34,7 @@ export const GET_MOVIE_THUMBNAIL = gql`
       }
       tags {
         objects {
+          uid
           name
           type
         }
@@ -59,6 +62,7 @@ export const GET_MOVIE = gql`
         { dimension: "regions", value: $region }
       ]
     ) {
+      uid
       title
       title_short
       synopsis
@@ -66,6 +70,7 @@ export const GET_MOVIE = gql`
       release_date
       images {
         objects {
+          uid
           title
           type
           url
@@ -87,14 +92,17 @@ export const GET_MOVIE = gql`
       }
       credits {
         objects {
+          uid
           character
           people {
             objects {
+              uid
               name
             }
           }
           roles {
             objects {
+              uid
               internal_title
               title
               title_sort
@@ -104,27 +112,32 @@ export const GET_MOVIE = gql`
       }
       genres {
         objects {
+          uid
           name
         }
       }
       themes {
         objects {
+          uid
           name
         }
       }
       ratings {
         objects {
+          uid
           value
         }
       }
       tags {
         objects {
+          uid
           name
           type
         }
       }
       availability(limit: 20) {
         objects {
+          uid
           end
         }
       }

--- a/apps/streamtv/graphql/queries/getSeason.ts
+++ b/apps/streamtv/graphql/queries/getSeason.ts
@@ -20,6 +20,7 @@ export const GET_SEASON_THUMBNAIL = gql`
       ]
     ) {
       __typename
+      uid
       title
       title_short
       synopsis
@@ -28,6 +29,7 @@ export const GET_SEASON_THUMBNAIL = gql`
       season_number
       images {
         objects {
+          uid
           title
           type
           url

--- a/apps/streamtv/graphql/queries/getSet.ts
+++ b/apps/streamtv/graphql/queries/getSet.ts
@@ -22,6 +22,7 @@ export const GET_SET_THUMBNAIL = gql`
       ]
     ) {
       __typename
+      uid
       type
       title
       title_short
@@ -176,6 +177,7 @@ export const GET_COLLECTION_SET = gql`
       }
       ratings {
         objects {
+          uid
           value
         }
       }
@@ -218,8 +220,8 @@ export const GET_PAGE_SET = (streamTVIngestorSchemaLoaded: boolean) => gql`
         objects {
           object {
             __typename
+            uid
             ... on Season {
-              uid
               title
               title_short
               ${
@@ -236,7 +238,6 @@ export const GET_PAGE_SET = (streamTVIngestorSchemaLoaded: boolean) => gql`
               }
             }
             ... on SkylarkSet {
-              uid
               type
               title
               title_short
@@ -250,10 +251,9 @@ export const GET_PAGE_SET = (streamTVIngestorSchemaLoaded: boolean) => gql`
               }
             }
             ... on CallToAction {
-              uid
+              __typename
             }
             ... on SkylarkTag {
-              uid
               brands(limit: 50) {
                 objects {
                   __typename
@@ -263,7 +263,6 @@ export const GET_PAGE_SET = (streamTVIngestorSchemaLoaded: boolean) => gql`
               movies(limit: 50) {
                 objects {
                   __typename
-                  uid
                 }
               }
             }

--- a/apps/streamtv/graphql/queries/streamtvConfig.ts
+++ b/apps/streamtv/graphql/queries/streamtvConfig.ts
@@ -22,6 +22,7 @@ export const GET_STREAMTV_CONFIG = gql`
       ]
     ) {
       objects {
+        uid
         app_name
         primary_color
         accent_color


### PR DESCRIPTION
<!-- Enter a very brief description of change -->
<!-- Add any optional commentary which may help the code reviewer. -->

As we move to the new caching features, all GraphQL queries need to request the UID as a field so it can be interpreted and hit the cache.

<!-- Please tick all relevant change types this PR commits -->
<!-- Delete non-relevant lines -->
* [x] Refactoring

#### Jira
<!-- Line separated list of relevant Jira ticket links -->
https://skylarkplatform.atlassian.net/browse/SL-2882

